### PR TITLE
use wxversion.select(), not wxversion.ensureMinimal()

### DIFF
--- a/pyfa.py
+++ b/pyfa.py
@@ -29,15 +29,10 @@ if not hasattr(sys, 'frozen'):
 
     try:
         import wxversion
-        wxversion.ensureMinimal('2.8')
-    except ImportError:
-        print "Cannot find wxPython or the installed wxPython version doesn't meet the min. requirements.\nYou can download wxPython (2.8) from http://www.wxpython.org/"
-        sys.exit(1)
-
-    try:
         wxversion.select('2.8')
-    except wxversion.VersionError:
-        print("Unable to select wxpython 2.8, attempting to continue anyway")
+    except:
+        print "Cannot find wxPython or the installed wxPython version doesn't meet the requirements.\nYou can download wxPython (2.8) from http://www.wxpython.org/"
+        sys.exit(1)
 
     try:
         import sqlalchemy


### PR DESCRIPTION
If wxversion.ensureMininal('2.8') runs before wxversion.select('2.8') on
a system that has wxPython 2.8 and 2.9 installed, 2.9 will be selected -
and Pyfa is incompatible with 2.9.

Otherwise, attempting to run Pyfa 1.1.16 on a system with both wxPython 2.8 and 2.9 installed results in a crash:

```
Traceback (most recent call last):
File "pyfa.py", line 88, in <module>
  MainFrame()
File "/home/tetromino/scm/pyfa/gui/mainFrame.py", line 136, in __init__
  self.statsPane = StatsPane(self)
File "/home/tetromino/scm/pyfa/gui/statsPane.py", line 71, in __init__
  view.populatePanel(contentPanel, headerPanel)
File "/home/tetromino/scm/pyfa/gui/builtinStatsViews/resistancesViewFull.py", line 81, in populatePanel
  sizerResistances.AddGrowableCol(i + 1)
File "/usr/lib64/python2.7/site-packages/wx-2.9.4-gtk2/wx/_core.py", line 15376, in AddGrowableCol
  return _core_.FlexGridSizer_AddGrowableCol(*args, **kwargs)
wx._core.PyAssertionError: C++ assertion "!m_cols || idx < (size_t)m_cols" failed at /var/tmp/portage/x11-libs/wxGTK-2.9.4.1-r1/work/wxPython-src-2.9.4.0/src/common/sizer.cpp(1956) in AddGrowableCol(): invalid column index
```
