### PR TITLE
Improve market search

### DIFF
--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -184,8 +184,6 @@ def getItemsByCategory(filter, where=None, eager=None):
 def searchItems(nameLike, where=None, join=None, eager=None):
     if not isinstance(nameLike, basestring):
         raise TypeError("Need string as argument")
-    # Prepare our string for request
-    nameLike = u"%{0}%".format(sqlizeString(nameLike))
 
     if join is None:
         join = tuple()
@@ -193,8 +191,11 @@ def searchItems(nameLike, where=None, join=None, eager=None):
     if not hasattr(join, "__iter__"):
         join = (join,)
 
-    filter = processWhere(Item.name.like(nameLike, escape="\\"), where)
-    items = gamedata_session.query(Item).options(*processEager(eager)).join(*join).filter(filter).limit(100).all()
+    items = gamedata_session.query(Item).options(*processEager(eager)).join(*join)
+    for token in nameLike.split(' '):
+        token_safe = u"%{0}%".format(sqlizeString(token))
+        items = items.filter(processWhere(Item.name.like(token_safe, escape="\\"), where))
+    items = items.limit(100).all()
     return items
 
 @cachedQuery(2, "where", "itemids")


### PR DESCRIPTION
Hi, there are two improvements here:
1. On my old Mac laptop, pyfa crashes after a while of running when performing market searches that return a lot of results. On my new PC desktop, it never crashes, so I guess this is OOM. Limiting the result set of market queries to 100 items reduces the crashes on my Mac without (IMO) reducing market search functionality.
2. Change market search from substring to tokenised substring. Now searching for "energized membrane" will return EANMs, and "large turret ii" will return large energy/hybrid/projectil t2 turrets.
