### PR TITLE
Fix for savePath config

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ def defPaths():
         if savePath is None:
             savePath = os.path.join(pyfaPath, "saveddata")
     else:
-        savePath = getattr(configforced, "savePath", None)
+        savePath = getattr(configforced, "savePath", savePath)
         if savePath is None:
             savePath = unicode(os.path.expanduser(os.path.join("~", ".pyfa")), sys.getfilesystemencoding())
 


### PR DESCRIPTION
This fixes the default value used for savePath. Config still looks for the value in configforced; however, if it doesn't find it then it uses the value present in the config file and not defaults to None. This allows users to edit the config file and choose their destination for pyfa's files (for example, their dropbox directoy)

it would be nice to eventually be allowed to do this kind of config from the GUI, and that's sometting I may be interested in looking into. However, not sure how complete the new EOS is, so I dunno if it's really worth it looking into new features for a version that will be obsolete soon.
