### PR TITLE
change REREQUEST delay to 10 seconds from 4 hours

### DIFF
--- a/eos/saveddata/price.py
+++ b/eos/saveddata/price.py
@@ -29,8 +29,8 @@ import eos.db
 class Price(object):
     # Price validity period, 24 hours
     VALIDITY = 24*60*60
-    # Re-request delay for failed fetches, 4 hours
-    REREQUEST = 4*60*60
+    # Re-request delay for failed fetches, 10 seconds
+    REREQUEST = 10
 
     def __init__(self, typeID):
         self.typeID = typeID


### PR DESCRIPTION
This fixes an issue where inaccessible internet blocks further updates.

The proper fix would be to differentiate between data failures and connection failures.
