### PR TITLE
Hotfix for issue #48

### DIFF
--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -181,8 +181,7 @@ def getItemsByCategory(filter, where=None, eager=None):
     return gamedata_session.query(Item).options(*processEager(eager)).join(Item.group, Group.category).filter(filter).all()
 
 @cachedQuery(3, "where", "nameLike", "join")
-def searchItems(nameLike, shipSearch=False, where=None, join=None, eager=None):
-
+def searchItems(nameLike, where=None, join=None, eager=None):
     if not isinstance(nameLike, basestring):
         raise TypeError("Need string as argument")
 
@@ -196,9 +195,7 @@ def searchItems(nameLike, shipSearch=False, where=None, join=None, eager=None):
     for token in nameLike.split(' '):
         token_safe = u"%{0}%".format(sqlizeString(token))
         items = items.filter(processWhere(Item.name.like(token_safe, escape="\\"), where))
-    if not shipSearch:
-        items = items.limit(100)
-    items = items.all()
+    items = items.limit(100).all()
     return items
 
 @cachedQuery(2, "where", "itemids")

--- a/service/market.py
+++ b/service/market.py
@@ -630,10 +630,13 @@ class Market():
 
     def searchShips(self, name):
         """Find ships according to given text pattern"""
-        results = eos.db.searchItems(name, True)
+        filter = eos.types.Category.name.in_(["Ship"])
+        results = eos.db.searchItems(name, where=filter,
+                                     join=(eos.types.Item.group, eos.types.Group.category),
+                                     eager=("icon", "group.category", "metaGroup", "metaGroup.parent"))
         ships = set()
         for item in results:
-            if self.getCategoryByItem(item).name == "Ship" and self.getPublicityByItem(item):
+            if self.getPublicityByItem(item):
                 ships.add(item)
         return ships
 


### PR DESCRIPTION
This commit is a quick fix for issue #48. This problem was introduced with limiting search results to satisfy issue #30

Both ship searching and market item searching use the same `searchItems` function. The results are returned and, in the case of ship browser, are filtered with `self.getCategoryByItem(item).name == "Ship"` to produce final results. If the search term didn't make the initial limit filter then it won't show.

I've fixed this by simply doing it the same way market does, only restricting on Ship and not `sMarket.SEARCH_CATEGORIES`. This limits the results to only ships, and THEN applies a limit of 100 results. You won't ever have 100 results for ship search.
