### PR TITLE
Fix Bastion resists

### DIFF
--- a/eos/effects/maraudermodeeffect26.py
+++ b/eos/effects/maraudermodeeffect26.py
@@ -10,7 +10,7 @@ def handler(fit, module, context):
             bonus = "%s%s" % (bonus[0].lower(), bonus[1:])
             booster = "%s%sDamageResonance" % (layer, damageType)
             fit.ship.multiplyItemAttr(bonus, module.getModifiedItemAttr(booster),
-                                      stackingPenalties=True, penaltyGroup="preMul")
+                                      stackingPenalties=False, penaltyGroup="preMul")
 
     # Turrets
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Large Energy Turret") or \


### PR DESCRIPTION
Someone tipped me off that resists weren't applying correctly on Paladin with Bastion module activated. Confirmed via screenshot:

![kls86af](https://f.cloud.github.com/assets/3904767/2475366/99194422-b056-11e3-8bde-feec46e65ffb.jpg)

I turned stacking penalty off for the resists, which seems to be more accurate:

![resists](https://f.cloud.github.com/assets/3904767/2475310/db33f330-b055-11e3-8bd4-6bf94ffea990.PNG)

Hull is still 1% off, but I'm assuming this is due to rounding in the fitting screen, etc. I did not confirm actual resist values via show info source which tend to me more accurate (I cannot fly Marauders).

However, looking at the bastion module, the description only states shield boosts as being penalized - so I'm not sure if the other attributes need to be tweaked as well (everything seems to have `stackingPenalties=False`)
