### PR TITLE
Fix #69 - Neut on triage/siege/bastion

### DIFF
--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -164,7 +164,7 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
     def canBeApplied(self, projectedOnto):
         """Check if drone can engage specific fitting"""
         item = self.item
-        if (item.offensive and projectedOnto.ship.getModifiedItemAttr("disallowOffensiveModifiers") == 1) or \
+        if (item.offensive and projectedOnto.ship.getModifiedItemAttr("disallowOffensiveModifiers") == 1 and "energyDestabilizationNew" not in item.effects) or \
         (item.assistive and projectedOnto.ship.getModifiedItemAttr("disallowAssistance") == 1):
             return False
         else:

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -464,7 +464,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             return currActive <= maxGroupActive
         # For projected, we're checking if ship is vulnerable to given item
         else:
-            if (item.offensive and projectedOnto.ship.getModifiedItemAttr("disallowOffensiveModifiers") == 1) or \
+            if (item.offensive and projectedOnto.ship.getModifiedItemAttr("disallowOffensiveModifiers") == 1 and "energyDestabilizationNew" not in item.effects) or \
             (item.assistive and projectedOnto.ship.getModifiedItemAttr("disallowAssistance") == 1):
                 return False
             else:


### PR DESCRIPTION
Items that have `energyDestabilizationNew` effect, although technically considered "Offensive", are no longer applied to ships with a `disallowOffensiveModifiers` (triage, siege, bastion). This affects both projected neuts and EV drones.
