### PR TITLE
Removes "res:/UI/Texture/Icons/....png" from iconFile

### DIFF
--- a/eos/utils/scripts/jsonToSql.py
+++ b/eos/utils/scripts/jsonToSql.py
@@ -101,8 +101,7 @@ if __name__ == "__main__":
                 instance = tables[jsonName]()
                 # fix for issue 80
                 if jsonName is "icons" and "res:/UI/Texture/Icons/" in str(row['iconFile']):
-                    row['iconFile'] = row['iconFile'].replace('res:/UI/Texture/Icons/','')
-                    row['iconFile'] = row['iconFile'].replace('.png','')
+                    row['iconFile'] = row['iconFile'].replace('res:/UI/Texture/Icons/','').replace('.png','')
                 for k, v in row.iteritems():
                     setattr(instance, fieldMap.get(k, k), v)
 


### PR DESCRIPTION
Partial fix to #80.

This simply removes `res:/UI/Texture/Icons/ ... .png` from the icon file value, which allows us to store only the needed info. only problem is instead of "02_02" format, it will be stored as "02_SIZE_02" format. This is not a big deal as we can name the file whatever we want regardless of size. I could have used a bit of regex or splitting to remove the size, but there are also other icons that don't follow the `##_##_##` format and I didn't think it was needed. It only break consistency in the icon names.
