### PR TITLE
Fix blank lines in damage types import

### DIFF
--- a/eos/saveddata/damagePattern.py
+++ b/eos/saveddata/damagePattern.py
@@ -79,10 +79,10 @@ class DamagePattern(object):
                 key, val = entry.split(':')
                 fields["%sAmount" % cls.importMap[key.lower()]] = float(val)
 
-            pattern = DamagePattern(**fields)
-            pattern.name = name
-            patterns.append(pattern)
-
+            if len(fields) > 0: # Avoid possible blank lines
+                pattern = DamagePattern(**fields)
+                pattern.name = name
+                patterns.append(pattern)
         return patterns
 
     EXPORT_FORMAT = "%s = EM:%d, Therm:%d, Kin:%d, Exp:%d\n"


### PR DESCRIPTION
If the text variable contains blank lines like for example ending with a
newline character or having two consecutive newline characters the
fields dict is empty and DamagePattern fails with an Exception.

This closes #124
