### PR TITLE
Global Charge Switcher

### DIFF
--- a/gui/builtinContextMenus/__init__.py
+++ b/gui/builtinContextMenus/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["openFit", "moduleAmmoPicker", "itemStats", "damagePattern", "marketJump", "droneSplit", "itemRemove",
-           "droneRemoveStack", "ammoPattern", "project", "factorReload", "whProjector", "cargo", "shipJump",
-           "targetResists"]
+__all__ = ["openFit", "moduleGlobalAmmoPicker", "moduleAmmoPicker", "itemStats", "damagePattern", "marketJump",
+		   "droneSplit", "itemRemove", "droneRemoveStack", "ammoPattern", "project", "factorReload", "whProjector",
+		   "cargo", "shipJump", "targetResists"]

--- a/gui/builtinContextMenus/moduleGlobalAmmoPicker.py
+++ b/gui/builtinContextMenus/moduleGlobalAmmoPicker.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from gui.contextMenu import ContextMenu
+import gui.mainFrame
+import service
+import wx
+from gui import bitmapLoader
+from eos.types import Hardpoint
+import gui.globalEvents as GE
+from gui.builtinContextMenus.moduleAmmoPicker import ModuleAmmoPicker
+import eos.db
+
+class ModuleGlobalAmmoPicker(ModuleAmmoPicker):
+    def __init__(self):
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+
+    def getText(self, itmContext, selection):
+        return "Charge (All)"
+
+    def handleAmmoSwitch(self, event):
+        if len(self.modules) != 1:
+            event.Skip()
+            return
+
+        charge = self.chargeIds.get(event.Id, False)
+        if charge is False:
+            event.Skip()
+            return
+
+        sFit = service.Fit.getInstance()
+        fitID = self.mainFrame.getActiveFit()
+        fit = eos.db.getFit(fitID)
+
+        selectedModule = self.modules[0]
+        allModules = []
+        for mod in fit.modules:
+            if mod.itemID == None:
+                continue
+            if mod.itemID == selectedModule.itemID:
+                allModules.append(mod)
+
+        sFit.setAmmo(fitID, charge.ID if charge is not None else None, allModules)
+        wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
+
+    def display(self, srcContext, selection):
+        if len(selection) != 1:
+            return False
+
+        return super(ModuleGlobalAmmoPicker, self).display(srcContext, selection)
+
+
+ModuleGlobalAmmoPicker.register()


### PR DESCRIPTION
Added "Charge (All)" entry to the module context menu that allows switching charges on all modules of the same type as the selected module at once, without the need to manually select the other modules.
