### PR TITLE
Add a view to display the recently used items side by side with the main items view

### DIFF
--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -49,7 +49,6 @@ class MarketBrowser(wx.Panel):
         self.searchMode = False
         self.marketView = MarketTree(self.splitter, self)
         self.splitterItems = wx.SplitterWindow(self.splitter, style = wx.SP_LIVE_UPDATE)
-        # vbox.Add(self.splitterItems, 1, wx.EXPAND)
 
         self.itemViewFavs = ItemView(self.splitterItems, self)
         self.itemView = ItemView(self.splitterItems, self, self.itemViewFavs)


### PR DESCRIPTION
The goal is to make a "favorite items" view (for now, recently used items) available to users side-by-side with the items view that can be used independent of the items view. This will help the user find their modules faster.

The changes are kept to a minimum for simplicity but can be moved into a separate class eventually.

The following commits should fully implement recently used items as a separate view (still maintaining it as a market item as well).

I am mostly a ruby programmer, so please do review the code for any python #kung-fu-fail's :)
