### PR TITLE
Show amount over limit on pg/cpu/drone displays

### DIFF
--- a/gui/pygauge.py
+++ b/gui/pygauge.py
@@ -379,9 +379,15 @@ class PyGauge(wx.PyWindow):
             dc.DrawLabel(formatStr, rect, wx.ALIGN_CENTER)
         else:
             if self.GetBarGradient() and self._showRemaining:
-                formatStr = "{0:." + str(self._fractionDigits) + "f} left"
                 range = self._range if self._range > 0.01 else 0
-                value = max( range - self._value , 0)
+                value = range - self._value
+                if value < 0:
+                    label = "over"
+                    value = -value
+                else:
+                    label = "left"
+                formatStr = "{0:." + str(self._fractionDigits) + "f} " + label
+
             else:
                 formatStr = "{0:." + str(self._fractionDigits) + "f}%"
 


### PR DESCRIPTION
Hi.  My first submission to pyfa, but it's been an annoyance for me.

I screwed up the original comment, it's not remaining units, but units over so it's more obvious how much I have to trim.

It's a pretty small change.  I'm not sure if it would break anything else that might use gauges tho.

--- Commit comment -----
Update powergrid, CPU, drone bandwidth, and drone bay displays to show remaining units so I don't have to do math.   Could affect other gauge displays?
