### PR TITLE
Implement GUI exception reporting, resolves #162

### DIFF
--- a/gui/errorDialog.py
+++ b/gui/errorDialog.py
@@ -1,0 +1,128 @@
+#===============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+#===============================================================================
+
+import wx
+import sys
+import gui.utils.fonts as fonts
+
+class ErrorFrame(wx.Frame):
+
+    def __init__(self, parent):
+        wx.Frame.__init__(self, parent, id=wx.ID_ANY, title="pyfa error", pos=wx.DefaultPosition, size=wx.Size(500, 400), style=wx.DEFAULT_FRAME_STYLE^ wx.RESIZE_BORDER|wx.STAY_ON_TOP)
+
+        desc =  "pyfa has experienced an unexpected error. Below is the " \
+                "Trackback that contains crucial information about how this " \
+                "error was triggered. Please contact the developers with " \
+                "the information provided through the EVE Online forums " \
+                "(Help > Forums) or file a GitHub issue."
+
+        self.SetSizeHintsSz(wx.DefaultSize, wx.DefaultSize)
+
+        if 'wxMSW' in wx.PlatformInfo:
+            self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
+
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+        headSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.headingText = wx.StaticText(self, wx.ID_ANY, "Error!", wx.DefaultPosition, wx.DefaultSize, wx.ALIGN_CENTRE)
+        self.headingText.SetFont(wx.Font(14, 74, 90, 92, False))
+
+        headSizer.Add(self.headingText, 1, wx.ALL, 5)
+        mainSizer.Add(headSizer, 0, wx.EXPAND, 5)
+
+        mainSizer.Add(wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL), 0, wx.EXPAND |wx.ALL, 5)
+
+        descSizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.descText = wx.TextCtrl( self, wx.ID_ANY, desc, wx.DefaultPosition, wx.DefaultSize, wx.TE_AUTO_URL|wx.TE_MULTILINE|wx.TE_READONLY|wx.BORDER_NONE|wx.TRANSPARENT_WINDOW )
+        self.descText.SetFont(wx.Font(fonts.BIG, wx.SWISS, wx.NORMAL, wx.NORMAL))
+        descSizer.Add(self.descText, 1, wx.EXPAND|wx.ALL, 5)
+        mainSizer.Add(descSizer, 0, wx.EXPAND, 5)
+
+        mainSizer.AddSpacer((0, 5), 0, wx.EXPAND, 5)
+
+        self.errorTextCtrl = wx.TextCtrl(self, wx.ID_ANY, "", wx.DefaultPosition, wx.DefaultSize, wx.TE_MULTILINE|wx.TE_READONLY|wx.TE_RICH2|wx.TE_DONTWRAP)
+        self.errorTextCtrl.SetFont(wx.Font(8, wx.FONTFAMILY_TELETYPE, wx.NORMAL, wx.NORMAL))
+
+        mainSizer.Add(self.errorTextCtrl, 1, wx.EXPAND|wx.LEFT|wx.RIGHT, 5)
+
+        self.SetSizer(mainSizer)
+        mainSizer.Layout()
+        self.Layout()
+
+        self.Centre(wx.BOTH)
+
+class ErrorWin(object):
+    """
+    A class that can be used for redirecting Python's stderr streams.  It will
+    do nothing until something is written to the stream at which point it will
+    create am ErrorFrame with a text area and write the text there.
+
+    This is a modified version of wx.App.PyOnDemandOutputWindow() for
+    implementation in pyfa
+    """
+    def __init__(self):
+        self.frame = None
+        self.parent = None
+        self.origErr = sys.stderr
+
+    def SetParent(self, parent):
+        """
+        Set the window to be used as the popup Frame's parent.
+        """
+        self.parent = parent
+
+    def CreateOutputWindow(self, txt):
+        self.frame = ErrorFrame(self.parent)
+        self.text = self.frame.errorTextCtrl
+
+        self.text.AppendText(txt)
+        self.frame.Show(True)
+        self.frame.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
+
+    def OnCloseWindow(self, event):
+        if self.frame is not None:
+            self.frame.Destroy()
+        self.frame = None
+        self.text = None
+        self.parent = None
+
+    def write(self, text):
+        """
+        Create the output window if needed and write the string to it.
+        If not called in the context of the gui thread then CallAfter is
+        used to do the work there.
+        """
+        self.origErr.write(text)
+        if self.frame is None:
+            if not wx.Thread_IsMain:
+                wx.CallAfter(self.CreateOutputWindow, text)
+            else:
+                self.CreateOutputWindow(text)
+        else:
+            if not wx.Thread_IsMain:
+                wx.CallAfter(self.text.AppendText, text)
+            else:
+                self.text.AppendText(text)
+
+    def close(self):
+        if self.frame is not None:
+            wx.CallAfter(self.frame.Close)
+
+    def flush(self):
+        pass

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -99,7 +99,7 @@ class MainFrame(wx.Frame):
     def getInstance(cls):
         return cls.__instance if cls.__instance is not None else MainFrame()
 
-    def __init__(self):
+    def __init__(self, pyfaApp):
         title="pyfa %s%s - Python Fitting Assistant"%(config.version, "" if config.tag.lower() != 'git' else " (git)")
         wx.Frame.__init__(self, None, wx.ID_ANY, title)
 
@@ -163,7 +163,6 @@ class MainFrame(wx.Frame):
 
         self.charSelection = CharacterSelection(self)
         cstatsSizer.Add(self.charSelection, 0, wx.EXPAND)
-
         self.statsPane = StatsPane(self)
         cstatsSizer.Add(self.statsPane, 0, wx.EXPAND)
 
@@ -661,4 +660,3 @@ class MainFrame(wx.Frame):
         if not wnd:
             wnd = self
         InspectionTool().Show(wnd, True)
-

--- a/pyfa.py
+++ b/pyfa.py
@@ -83,9 +83,19 @@ if __name__ == "__main__":
     import os
     import os.path
 
+    class PyfaApp(wx.App):
+        def __init__(self):
+            wx.App.__init__(self, redirect=False)
+
+        def RedirectStdio(self):
+            self.stdioWin = self.outputWindowClass()
+            sys.stderr = self.stdioWin
+
     import eos.db
     import service.prefetch
+
     from gui.mainFrame import MainFrame
+    from gui.errorDialog import ErrorWin
 
     #Make sure the saveddata db exists
     if not os.path.exists(config.savePath):
@@ -93,6 +103,16 @@ if __name__ == "__main__":
 
     eos.db.saveddata_meta.create_all()
 
-    pyfa = wx.App(False)
-    MainFrame()
+    pyfa = PyfaApp()
+    pyfa.outputWindowClass = ErrorWin
+
+    # Comment out (or implement flag) to disable GUI error popup
+    pyfa.RedirectStdio()
+
+    # Remove comments to debug error window / frame
+    # (if it has an error, obviously it won't pop up or log to sys.stderr)
+    #dbgErr = ErrorWin()
+    #dbgErr.write("Test Error")
+
+    MainFrame(pyfa)
     pyfa.MainLoop()


### PR DESCRIPTION
![screenshot 2014-12-18 01 10 02](https://cloud.githubusercontent.com/assets/3904767/5484238/a1f550f4-8652-11e4-8531-7da63fa94bcb.png)

This will catch all unhandled exceptions that may crop up and present the user with it. Before, pyfa would simply crash or otherwise not work properly. When the exception is caught, it is sent to both the original `sys.stderr` (which will allow IDEs and debuggers to continue to work) and to the new error window. Fairly simple. wxPython has a similar implementation that this is based on.

This is simply a pull request to track current development. The following still must be completed before this is merged:
- Thoroughly test out on all platforms
- Rebuild the Windows skeleton with new pyfa.py from pull request, or modify distributive scripts to dynamically build skeletons. I believe OS X skeleton doesn't need modification
