### PR TITLE
Added commandline arguments to specify window title and path for savefiles

### DIFF
--- a/config.py
+++ b/config.py
@@ -60,7 +60,7 @@ def __createDirs(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def defPaths():
+def defPaths(savepath):
     global debug
     global pyfaPath
     global savePath
@@ -87,8 +87,11 @@ def defPaths():
     else:
         savePath = getattr(configforced, "savePath", None)
         if savePath is None:
-            savePath = unicode(os.path.expanduser(os.path.join("~", ".pyfa")),
+            if savepath is None: # savepath is not overriden
+                savePath = unicode(os.path.expanduser(os.path.join("~", ".pyfa")),
                                sys.getfilesystemencoding())
+            else:
+                savePath = savepath
 
     __createDirs(savePath)
 

--- a/config.py
+++ b/config.py
@@ -60,7 +60,7 @@ def __createDirs(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def defPaths(savepath):
+def defPaths(customSavePath):
     global debug
     global pyfaPath
     global savePath
@@ -87,11 +87,11 @@ def defPaths(savepath):
     else:
         savePath = getattr(configforced, "savePath", None)
         if savePath is None:
-            if savepath is None: # savepath is not overriden
+            if customSavePath is None: # customSavePath is not overriden
                 savePath = unicode(os.path.expanduser(os.path.join("~", ".pyfa")),
                                sys.getfilesystemencoding())
             else:
-                savePath = savepath
+                savePath = customSavePath
 
     __createDirs(savePath)
 

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -116,8 +116,8 @@ class MainFrame(wx.Frame):
     def getInstance(cls):
         return cls.__instance if cls.__instance is not None else MainFrame()
 
-    def __init__(self):
-        self.title="pyfa %s%s - Python Fitting Assistant"%(config.version, "" if config.tag.lower() != 'git' else " (git)")
+    def __init__(self, title):
+        self.title=title
         wx.Frame.__init__(self, None, wx.ID_ANY, self.title)
 
         MainFrame.__instance = self

--- a/pyfa.py
+++ b/pyfa.py
@@ -44,6 +44,7 @@ parser.add_option("-r", "--root", action="store_true", dest="rootsavedata", help
 parser.add_option("-w", "--wx28", action="store_true", dest="force28", help="Force usage of wxPython 2.8", default=False)
 parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set logger to debug level.", default=False)
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
+parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
 
 (options, args) = parser.parse_args()
 
@@ -106,7 +107,10 @@ if __name__ == "__main__":
         options.title = "pyfa %s%s - Python Fitting Assistant"%(config.version, "" if config.tag.lower() != 'git' else " (git)")
 
     config.debug = options.debug
-    config.defPaths()
+    # convert to unicode if it is set
+    if options.savepath is not None:
+        options.savepath = unicode(options.savepath)
+    config.defPaths(options.savepath)
 
     # Basic logging initialization
     import logging

--- a/pyfa.py
+++ b/pyfa.py
@@ -43,6 +43,7 @@ parser = PassThroughOptionParser(usage=usage)
 parser.add_option("-r", "--root", action="store_true", dest="rootsavedata", help="if you want pyfa to store its data in root folder, use this option", default=False)
 parser.add_option("-w", "--wx28", action="store_true", dest="force28", help="Force usage of wxPython 2.8", default=False)
 parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set logger to debug level.", default=False)
+parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 
 (options, args) = parser.parse_args()
 
@@ -99,6 +100,10 @@ if __name__ == "__main__":
     # Configure paths
     if options.rootsavedata is True:
         config.saveInRoot = True
+        
+    # set title if it wasn't supplied by argument
+    if options.title == None:
+        options.title = "pyfa %s%s - Python Fitting Assistant"%(config.version, "" if config.tag.lower() != 'git' else " (git)")
 
     config.debug = options.debug
     config.defPaths()
@@ -123,5 +128,5 @@ if __name__ == "__main__":
     eos.db.saveddata_meta.create_all()
 
     pyfa = wx.App(False)
-    MainFrame()
+    MainFrame(options.title)
     pyfa.MainLoop()


### PR DESCRIPTION
*  Settable Window Title using commandline arguments
  *  helps to distinguish between different instances
*  Settable savefile path using comandline arguments
  * allows for multiple instances to not mix the fittings/characters

I personally needed these changes because I use pyfa to check hundreds of fits a day, and having them mixed with my personal fits was a pain! (Deleting even more after that confirmation box was introduced)