### PR TITLE
Make exporting charges a preference

### DIFF
--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -62,6 +62,8 @@ class PFGeneralPref ( PreferenceView):
         self.cbGaugeAnimation = wx.CheckBox( panel, wx.ID_ANY, u"Animate gauges", wx.DefaultPosition, wx.DefaultSize, 0 )
         mainSizer.Add( self.cbGaugeAnimation, 0, wx.ALL|wx.EXPAND, 5 )
 
+        self.cbExportCharges = wx.CheckBox( panel, wx.ID_ANY, u"Export loaded charges", wx.DefaultPosition, wx.DefaultSize, 0 )
+        mainSizer.Add( self.cbExportCharges, 0, wx.ALL|wx.EXPAND, 5 )
 
         defCharSizer = wx.BoxSizer( wx.HORIZONTAL )
 
@@ -78,6 +80,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbShowTooltip.SetValue(self.sFit.serviceFittingOptions["showTooltip"] or False)
         self.cbMarketShortcuts.SetValue(self.sFit.serviceFittingOptions["showMarketShortcuts"] or False)
         self.cbGaugeAnimation.SetValue(self.sFit.serviceFittingOptions["enableGaugeAnimation"])
+        self.cbExportCharges.SetValue(self.sFit.serviceFittingOptions["exportCharges"])
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalCharStateChange)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalDmgPatternStateChange)
@@ -90,6 +93,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbShowTooltip.Bind(wx.EVT_CHECKBOX, self.onCBShowTooltip)
         self.cbMarketShortcuts.Bind(wx.EVT_CHECKBOX, self.onCBShowShortcuts)
         self.cbGaugeAnimation.Bind(wx.EVT_CHECKBOX, self.onCBGaugeAnimation)
+        self.cbExportCharges.Bind(wx.EVT_CHECKBOX, self.onCBExportCharges)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 
@@ -151,6 +155,9 @@ class PFGeneralPref ( PreferenceView):
 
     def onCBGaugeAnimation(self, event):
         self.sFit.serviceFittingOptions["enableGaugeAnimation"] = self.cbGaugeAnimation.GetValue()
+
+    def onCBExportCharges(self, event):
+        self.sFit.serviceFittingOptions["exportCharges"] = self.cbExportCharges.GetValue()
 
     def getImage(self):
         return BitmapLoader.getBitmap("prefs_settings", "gui")

--- a/service/fit.py
+++ b/service/fit.py
@@ -104,7 +104,8 @@ class Fit(object):
             "compactSkills": True,
             "showTooltip": True,
             "showMarketShortcuts": False,
-            "enableGaugeAnimation": True}
+            "enableGaugeAnimation": True,
+            "exportCharges": True}
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(
             "pyfaServiceFittingOptions", serviceFittingDefaultOptions)

--- a/service/port.py
+++ b/service/port.py
@@ -551,12 +551,13 @@ class Port(object):
         offineSuffix = " /OFFLINE"
         export = "[%s, %s]\n" % (fit.ship.item.name, fit.name)
         stuff = {}
+        sFit = service.Fit.getInstance()
         for module in fit.modules:
             slot = module.slot
             if not slot in stuff:
                 stuff[slot] = []
             curr = module.item.name if module.item else ("[Empty %s slot]" % Slot.getName(slot).capitalize() if slot is not None else "")
-            if module.charge:
+            if module.charge and sFit.serviceFittingOptions["exportCharges"]:
                 curr += ", %s" % module.charge.name
             if module.state == State.OFFLINE:
                 curr += offineSuffix
@@ -664,6 +665,8 @@ class Port(object):
         doc = xml.dom.minidom.Document()
         fittings = doc.createElement("fittings")
         doc.appendChild(fittings)
+        sFit = service.Fit.getInstance()
+
         for i, fit in enumerate(fits):
             try:
                 fitting = doc.createElement("fitting")
@@ -701,7 +704,7 @@ class Port(object):
                     hardware.setAttribute("slot", "%s slot %d" % (slotName, slotId))
                     fitting.appendChild(hardware)
 
-                    if module.charge:
+                    if module.charge and sFit.serviceFittingOptions["exportCharges"]:
                         if not module.charge.name in charges:
                             charges[module.charge.name] = 0
                         # `or 1` because some charges (ie scripts) are without qty


### PR DESCRIPTION
@blitzmann this is in reference to #368 

Just starting this PR off as a discussion, by all means let me know if there's anything you don't like about it.

This defaults the preference to the current settings so it shouldn't affect anyone unless they opt out of it.

For my specific use-case: I don't want to export equipped charges because it usually conflicts with the cargo hold (e.g. I don't need 2x of the same type of script or 2x of the same crystal).

I'm usually loading different charges to see the stats on the right.

I've also gotten caught with cap boosters in the cargo hold + equipped going over the actual cargo hold limit.

Let me know what you think.