### PR TITLE
Fix "Change charge skills" showing module skills #535

### DIFF
--- a/gui/builtinContextMenus/changeAffectingSkills.py
+++ b/gui/builtinContextMenus/changeAffectingSkills.py
@@ -28,10 +28,12 @@ class ChangeAffectingSkills(ContextMenu):
             fitID = self.mainFrame.getActiveFit()
             sFit = service.Fit.getInstance()
             self.stuff = sFit.getFit(fitID).ship
+            cont = sFit.getFit(fitID).ship.itemModifiedAttributes
+        elif srcContext == "fittingCharge":
+            cont = selection[0].chargeModifiedAttributes
         else:
-            self.stuff = selection[0]
+            cont = selection[0].itemModifiedAttributes
 
-        cont = self.stuff.itemModifiedAttributes
         skills = set()
 
         for attrName in cont.iterAfflictions():


### PR DESCRIPTION
The 'change affecting skills' context menu showed the same list of skills for both module and charge, despite modules and charges not being affected by the same skills. This change fetches the correct list of skills for charges instead.