### PR TITLE
Added website selection for HTML Export

### DIFF
--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -14,9 +14,10 @@ class PFHTMLExportPref ( PreferenceView):
     desc  = "HTML Export (File > Export HTML) allows you to export your entire fitting "+\
             "database into an HTML file at the specified location. This file can be "+\
             "used in the in-game browser to easily open and import your fits, or used "+\
-            "in a regular web browser to open them at NULL-SEC.com."
+            "in a regular web browser to open them at NULL-SEC.com or Osmium."
     desc2 = "Enabling automatic exporting will update the HTML file after any change "+\
             "to a fit is made. Under certain circumstance, this may cause performance issues."
+    desc3 = "Preferred website to view fits while not using in-game browser can be selected below."
 
     def populatePanel( self, panel ):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
@@ -57,6 +58,24 @@ class PFHTMLExportPref ( PreferenceView):
         self.exportEnabled.Bind(wx.EVT_CHECKBOX, self.OnExportEnabledChange)
         mainSizer.Add( self.exportEnabled, 0, wx.ALL|wx.EXPAND, 5 )
 
+        self.stDesc3 = wx.StaticText( panel, wx.ID_ANY, self.desc3, wx.DefaultPosition, wx.DefaultSize, 0 )
+        self.stDesc3.Wrap(dlgWidth - 50)
+        mainSizer.Add( self.stDesc3, 0, wx.ALL, 5 )
+
+        websiteSizer = wx.BoxSizer( wx.HORIZONTAL )
+
+        self.stWebsite = wx.StaticText( panel, wx.ID_ANY, u"Website:", wx.DefaultPosition, wx.DefaultSize, 0 )
+        self.stWebsite.Wrap( -1 )
+        websiteSizer.Add( self.stWebsite, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
+
+        self.chWebsiteChoices = [ "o.smium.org", "null-sec.com" ]
+        self.chWebsiteType = wx.Choice( panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, self.chWebsiteChoices, 0 )
+        self.chWebsiteType.SetStringSelection( self.HTMLExportSettings.getWebsite() )
+        websiteSizer.Add( self.chWebsiteType, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
+        self.chWebsiteType.Bind(wx.EVT_CHOICE, self.OnCHWebsiteTypeSelect)
+
+        mainSizer.Add( websiteSizer, 0, wx.EXPAND, 5 )
+
         panel.SetSizer( mainSizer )
         panel.Layout()
 
@@ -74,6 +93,10 @@ class PFHTMLExportPref ( PreferenceView):
 
     def OnExportEnabledChange(self, event):
         self.HTMLExportSettings.setEnabled(self.exportEnabled.GetValue())
+
+    def OnCHWebsiteTypeSelect(self, event):
+        choice = self.chWebsiteType.GetStringSelection()
+        self.HTMLExportSettings.setWebsite(choice)
 
     def getImage(self):
         return BitmapLoader.getBitmap("prefs_html", "gui")

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -45,6 +45,12 @@ class exportHtmlThread(threading.Thread):
 
         timestamp = time.localtime(time.time())
         localDate = "%d/%02d/%02d %02d:%02d" % (timestamp[0], timestamp[1], timestamp[2], timestamp[3], timestamp[4])
+        
+        website = settings.getWebsite()
+        if website == "o.smium.org":
+            dnaUrl = "https://o.smium.org/loadout/dna/"
+        elif website == "null-sec.com":
+            dnaUrl = "https://null-sec.com/hangar/?dna="
 
         HTML = """
 <!DOCTYPE html>
@@ -126,7 +132,7 @@ class exportHtmlThread(threading.Thread):
         if (typeof CCPEVE !== 'undefined') { // inside IGB
           $(this).attr('href', 'javascript:CCPEVE.showFitting("'+dna+'");'); }
         else {                               // outside IGB
-          $(this).attr('href', 'https://null-sec.com/hangar/?dna='+dna); }
+          $(this).attr('href', '%s'+dna); }
       });
     });
   </script>
@@ -139,7 +145,7 @@ class exportHtmlThread(threading.Thread):
   <div data-role="content">
   <div style="text-align: center;"><strong>Last updated:</strong> %s <small>(<span class="timer"></span>)</small></div>
 
-""" % (time.time(), localDate)
+""" % (time.time(), dnaUrl, localDate)
         HTML += '  <ul data-role="listview" class="ui-listview-outer" data-inset="true" data-filter="true">\n'
         categoryList = list(sMkt.getShipRoot())
         categoryList.sort(key=lambda ship: ship.name)

--- a/service/settings.py
+++ b/service/settings.py
@@ -221,7 +221,7 @@ class HTMLExportSettings():
         return cls._instance
 
     def __init__(self):
-        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html' }
+        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html', "website": "null-sec.com" }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings("pyfaServiceHTMLExportSettings", serviceHTMLExportDefaultSettings)
 
     def getEnabled(self):
@@ -235,6 +235,12 @@ class HTMLExportSettings():
 
     def setPath(self, path):
         self.serviceHTMLExportSettings["path"] = path
+
+    def getWebsite(self):
+        return self.serviceHTMLExportSettings["website"]
+
+    def setWebsite(self, website):
+        self.serviceHTMLExportSettings["website"] = website
 
 """
 Settings used by update notification


### PR DESCRIPTION
Recently I have seen some work on HTML Export tool here and wanted to contribute another improvement. I noticed a sizing issue while browsing fits on my laptop. Current online fitting viewer null-sec.com is not playing well with smaller screens so I decided to use another website called [Osmium](https://o.smium.org).

This commit adds an option to select preferred website while exporting fits. null-sec.com is the default option for compatibility but I suggest to swap them until null-sec fixes their page.

![python_2016-04-17_17-46-54](https://cloud.githubusercontent.com/assets/5316261/14587914/7bb3f85e-04c4-11e6-9001-23f8db1a5312.png)