### PR TITLE
fix separation of moving/non-moving drones

### DIFF
--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -71,7 +71,7 @@ class FitDpsGraph(Graph):
 
         if distance <= fit.extraAttributes["droneControlRange"]:
             for drone in fit.drones:
-                multiplier = 1 if drone.getModifiedItemAttr("maxVelocity") > 0 else self.calculateTurretMultiplier(drone, data)
+                multiplier = 1 if drone.getModifiedItemAttr("maxVelocity") > 1 else self.calculateTurretMultiplier(drone, data)
                 dps, _ =  drone.damageStats(fit.targetResists)
                 total += dps * multiplier
         return total


### PR DESCRIPTION
In a January 2016 patch, the velocity of sentry drones seems to have been increased to non-zero values.
Checking if the velocity surpasses 1 m/s should correctly separate sentries from non-sentries now.

This should fix issue #511.