### PR TITLE
Import DNA fittings from ingame urls

### DIFF
--- a/service/port.py
+++ b/service/port.py
@@ -213,10 +213,9 @@ class Port(object):
                 Ship(sMkt.getItem(id))
                 string = string[string.index(str(id)):]
                 break
-            except Exception, e:
-                continue
-            pass
-        string = string[0: (string.index("::") + 2)]
+            except:
+                pass
+        string = string[:string.index("::") + 2]
         info = string.split(":")
 
         f = Fit()

--- a/service/port.py
+++ b/service/port.py
@@ -206,7 +206,17 @@ class Port(object):
     @staticmethod
     def importDna(string):
         sMkt = service.Market.getInstance()
-        string = string.replace("javascript:CCPEVE.showFitting('", "").replace("');", "")
+
+        ids = map(int, re.findall(r'\d+', string))
+        for id in ids:
+            try:
+                Ship(sMkt.getItem(id))
+                string = string[string.index(str(id)):]
+                break
+            except Exception, e:
+                continue
+            pass
+        string = string[0: (string.index("::") + 2)]
         info = string.split(":")
 
         f = Fit()

--- a/service/port.py
+++ b/service/port.py
@@ -206,6 +206,7 @@ class Port(object):
     @staticmethod
     def importDna(string):
         sMkt = service.Market.getInstance()
+        string = string.replace("javascript:CCPEVE.showFitting('", "").replace("');", "")
         info = string.split(":")
 
         f = Fit()


### PR DESCRIPTION
Currently only "raw" DNA fitting string can be imported, e. g.: `11978:14146;1:14136;3:14240;3:18688;1:28744;1:3608;4:31366;1:31378;1:28201;4:2488;5:28668;1:28999;3:29001;3::`

The EVE ingame-browser uses `javascript:CCPEVE.showFitting('11978:14146;1:14136;3:14240;3:18688;1:28744;1:3608;4:31366;1:31378;1:28201;4:2488;5:28668;1:28999;3:29001;3::');` to show Fittings from DNA.

This patch allows Pyfa to handle these as well.