### PR TITLE
Added an option for HTML Export, to produce a minimal html version

### DIFF
--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -18,6 +18,8 @@ class PFHTMLExportPref ( PreferenceView):
     desc2 = "Enabling automatic exporting will update the HTML file after any change "+\
             "to a fit is made. Under certain circumstance, this may cause performance issues."
     desc3 = "Preferred website to view fits while not using in-game browser can be selected below."
+    desc4 = "Export Fittings in a minmal HTML Version, just containing the Fittingslinks " +\
+            "without any visual styling or javscript features"
 
     def populatePanel( self, panel ):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
@@ -57,6 +59,17 @@ class PFHTMLExportPref ( PreferenceView):
         self.exportEnabled.SetValue(self.HTMLExportSettings.getEnabled())
         self.exportEnabled.Bind(wx.EVT_CHECKBOX, self.OnExportEnabledChange)
         mainSizer.Add( self.exportEnabled, 0, wx.ALL|wx.EXPAND, 5 )
+        
+        
+        
+        self.stDesc4 = wx.StaticText( panel, wx.ID_ANY, self.desc4, wx.DefaultPosition, wx.DefaultSize, 0 )
+        self.stDesc4.Wrap(dlgWidth - 50)
+        mainSizer.Add( self.stDesc4, 0, wx.ALL, 5 )        
+        
+        self.exportMinimal = wx.CheckBox( panel, wx.ID_ANY, u"Enable minimal export Format", wx.DefaultPosition, wx.DefaultSize, 0 )
+        self.exportMinimal.SetValue(self.HTMLExportSettings.getMinimalEnabled())
+        self.exportMinimal.Bind(wx.EVT_CHECKBOX, self.OnMinimalEnabledChange)
+        mainSizer.Add( self.exportMinimal, 0, wx.ALL|wx.EXPAND, 5 )
 
         self.stDesc3 = wx.StaticText( panel, wx.ID_ANY, self.desc3, wx.DefaultPosition, wx.DefaultSize, 0 )
         self.stDesc3.Wrap(dlgWidth - 50)
@@ -93,6 +106,9 @@ class PFHTMLExportPref ( PreferenceView):
 
     def OnExportEnabledChange(self, event):
         self.HTMLExportSettings.setEnabled(self.exportEnabled.GetValue())
+        
+    def OnMinimalEnabledChange(self, event):
+        self.HTMLExportSettings.setMinimalEnabled(self.exportMinimal.GetValue())
 
     def OnCHWebsiteTypeSelect(self, event):
         choice = self.chWebsiteType.GetStringSelection()

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -272,8 +272,8 @@ class exportHtmlThread(threading.Thread):
                         return
                     try:
                         dnaFit = sFit.exportDna(fit[0])                  
-                        HTML += '          <a class="inGameBrowserLink" target="_blank" href=javascript:CCPEVE.showFitting("'+dnaFit+'");>IGB</a>' +\
-                        ' / <a class="outOfGameBrowserLink" target="_blank" href="' + dnaUrl + dnaFit + '">OOGB</a>    '+ fit[1]+ '<br>'
+                        HTML += '<a class="inGameBrowserLink" target="_blank" href=javascript:CCPEVE.showFitting("'+dnaFit+'");>IGB</a>' +\
+								' / <a class="outOfGameBrowserLink" target="_blank" href="' + dnaUrl + dnaFit + '">OOGB</a>    '+ship.name +': '+ fit[1]+ '<br> \n'
                     except:
                         continue
                     finally:

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -46,12 +46,36 @@ class exportHtmlThread(threading.Thread):
         timestamp = time.localtime(time.time())
         localDate = "%d/%02d/%02d %02d:%02d" % (timestamp[0], timestamp[1], timestamp[2], timestamp[3], timestamp[4])
         
+        minimal = settings.getMinimalEnabled();
         website = settings.getWebsite()
         if website == "o.smium.org":
             dnaUrl = "https://o.smium.org/loadout/dna/"
         elif website == "null-sec.com":
             dnaUrl = "https://null-sec.com/hangar/?dna="
+        
+        if minimal:
+            HTML = self.generateMinimalHTML(sMkt,sFit, dnaUrl)
+        else:
+            HTML = self.generateFullHTML(sMkt,sFit, dnaUrl)
 
+        try:
+            FILE = open(settings.getPath(), "w")
+            FILE.write(HTML.encode('utf-8'))
+            FILE.close()
+        except IOError:
+            print "Failed to write to " + settings.getPath()
+            pass
+
+        if self.callback:
+            wx.CallAfter(self.callback, -1)
+
+
+
+    def generateFullHTML(self,sMkt,sFit,dnaUrl):
+        """ Generate the complete HTML with styling and javascript """
+        timestamp = time.localtime(time.time())
+        localDate = "%d/%02d/%02d %02d:%02d" % (timestamp[0], timestamp[1], timestamp[2], timestamp[3], timestamp[4])
+        
         HTML = """
 <!DOCTYPE html>
 <html>
@@ -130,7 +154,7 @@ class exportHtmlThread(threading.Thread):
       $('a[data-dna]').each(function( index ) {
         var dna = $(this).data('dna');
         if (typeof CCPEVE !== 'undefined') { // inside IGB
-          $(this).attr('href', 'javascript:CCPEVE.showFitting("'+dna+'");'); }
+          $(this).attr('href', 'javascript:CCPEVE.showFitting("'+dna+'");');} 
         else {                               // outside IGB
           $(this).attr('href', '%s'+dna); }
       });
@@ -217,16 +241,46 @@ class exportHtmlThread(threading.Thread):
  </div>
 </div>
 </body>
-</html>"""
+</html>"""        
 
-        try:
-            FILE = open(settings.getPath(), "w")
-            FILE.write(HTML.encode('utf-8'))
-            FILE.close()
-        except IOError:
-            print "Failed to write to " + settings.getPath()
-            pass
 
-        if self.callback:
-            wx.CallAfter(self.callback, -1)
+        return HTML
+        
+        
+        
+        
+    def generateMinimalHTML(self,sMkt,sFit,dnaUrl):
+        """ Generate a minimal HTML version of the fittings, without any javascript or styling"""
+        categoryList = list(sMkt.getShipRoot())
+        categoryList.sort(key=lambda ship: ship.name)
 
+        count = 0
+        HTML = ''
+        for group in categoryList:
+            # init market group string to give ships something to attach to
+            
+
+            ships = list(sMkt.getShipList(group.ID))
+            ships.sort(key=lambda ship: ship.name)
+
+            ships.sort(key=lambda ship: ship.name)
+
+            for ship in ships:
+                fits = sFit.getFitsWithShip(ship.ID)
+                for fit in fits:
+                    if self.stopRunning:
+                        return
+                    try:
+                        dnaFit = sFit.exportDna(fit[0])                  
+                        HTML += '          <a class="inGameBrowserLink" target="_blank" href=javascript:CCPEVE.showFitting("'+dnaFit+'");>IGB</a>' +\
+                        ' / <a class="outOfGameBrowserLink" target="_blank" href="' + dnaUrl + dnaFit + '">OOGB</a>    '+ fit[1]+ '<br>'
+                    except:
+                        continue
+                    finally:
+                        if self.callback:
+                            wx.CallAfter(self.callback, count)
+                        count += 1
+        return HTML;
+                 
+    
+        

--- a/service/settings.py
+++ b/service/settings.py
@@ -221,7 +221,7 @@ class HTMLExportSettings():
         return cls._instance
 
     def __init__(self):
-        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html', "website": "null-sec.com" }
+        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html', "website": "null-sec.com", "minimal": False }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings("pyfaServiceHTMLExportSettings", serviceHTMLExportDefaultSettings)
 
     def getEnabled(self):
@@ -229,6 +229,14 @@ class HTMLExportSettings():
 
     def setEnabled(self, enabled):
         self.serviceHTMLExportSettings["enabled"] = enabled
+        
+        
+    def getMinimalEnabled(self):
+        return self.serviceHTMLExportSettings["minimal"]
+
+    def setMinimalEnabled(self, minimal):
+        self.serviceHTMLExportSettings["minimal"] = minimal
+
 
     def getPath(self):
         return self.serviceHTMLExportSettings["path"]


### PR DESCRIPTION
Added an Opton in the HTMLExport menu to set the HTML export to produce
a minimal HTML version, without any styles or Javscript dependencies.
This can be useful if you are not javascript capable, or if you just
want to copy'n'pase the exported HTML into some web-editor (wordpress).

The generated HTML was tested in Eve and in a normal OOG browser, and it works. I ofcourse also tested the normal export , and that still works.