### PR TITLE
correct '(E)HP restored over duration' calculation to reflect removal…

### DIFF
--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -477,6 +477,8 @@ class Miscellanea(ViewColumn):
                 tooltip = "E{0}".format(tooltip)
             else:
                 hpRatio = 1
+            if itemGroup == "Ancillary Armor Repairer":
+                hpRatio *= 3
             ehp = hp * hpRatio
             duration = cycles * cycleTime / 1000
             text = "{0} / {1}s".format(formatAmount(ehp, 3, 0, 9), formatAmount(duration, 3, 0, 3))


### PR DESCRIPTION
…al of AAR multiplier from armorDamageAmount

commit 7406210c4a31e05a009df9ac7b73d7744b1cfb2a, "Fix remote AAR" resulted in the '(E)HP over duration' calculation no longer including the 3x multiplier.  This patch adds a 3x multiplication to the calculation.

fixes #630 