### PR TITLE
RAH follows damage profile

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,7 @@ saveInRoot = False
 
 # Version data
 version = "1.21.1"
-tag = "git"
+tag = "Stable"
 expansionName = "Citadel"
 expansionVersion = "1.3"
 evemonMinVersion = "4081"

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -484,6 +484,25 @@ class Miscellanea(ViewColumn):
             text = "{0} / {1}s".format(formatAmount(ehp, 3, 0, 9), formatAmount(duration, 3, 0, 3))
 
             return text, tooltip
+        elif itemGroup == "Armor Resistance Shift Hardener":
+            itemArmorResistanceShiftHardenerEM = (1-stuff.getModifiedItemAttr("armorEmDamageResonance"))*100
+            itemArmorResistanceShiftHardenerTherm = (1-stuff.getModifiedItemAttr("armorThermalDamageResonance")) * 100
+            itemArmorResistanceShiftHardenerKin = (1-stuff.getModifiedItemAttr("armorKineticDamageResonance")) * 100
+            itemArmorResistanceShiftHardenerExp = (1-stuff.getModifiedItemAttr("armorExplosiveDamageResonance")) * 100
+
+            text = "{0}% | {1}% | {2}% | {3}%".format(
+                formatAmount(itemArmorResistanceShiftHardenerEM, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerTherm, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerKin, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerExp, 3, 0, 3),
+            )
+            tooltip = "Resistances Shifted to Damage Profile:\n{0}% EM | {1}% Therm | {2}% Kin | {3}% Exp".format(
+                formatAmount(itemArmorResistanceShiftHardenerEM, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerTherm, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerKin, 3, 0, 3),
+                formatAmount(itemArmorResistanceShiftHardenerExp, 3, 0, 3),
+            )
+            return text, tooltip
         elif stuff.charge is not None:
             chargeGroup = stuff.charge.group.name
             if chargeGroup in ("Rocket", "Advanced Rocket", "Light Missile", "Advanced Light Missile", "FoF Light Missile",


### PR DESCRIPTION
The RAH will use the damage profile applied to adjust the resist on the module.  You can see the adjusted resists in the module attributes.

This does **NOT** take into account the time it takes to adjust (it assumes it adjusts instantly).  It is unlikely there is a clean way to do this that is not needlessly complex, and I'm not sure it'd be that useful anyway for what we're doing.  (Run into the same problem with passive shield HP/s, for example.)