### PR TITLE
Grouped Attributes override

### DIFF
--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -136,12 +136,11 @@ class MainMenuBar(wx.MenuBar):
                 self.Enable(self.exportToEveId, False)
 
             if not gui.mainFrame.disableOverrideEditor:
+                windowMenu.AppendSeparator()
                 attrItem = wx.MenuItem(windowMenu, self.attrEditorId, "Attribute Overrides\tCTRL+B")
                 attrItem.SetBitmap(BitmapLoader.getBitmap("fit_rename_small", "gui"))
                 windowMenu.AppendItem(attrItem)
-
-                editMenu.AppendSeparator()
-                editMenu.Append(self.toggleOverridesId, "Turn Overrides On")
+                windowMenu.Append(self.toggleOverridesId, "Turn Overrides On")
 
         # Help menu
         helpMenu = wx.Menu()


### PR DESCRIPTION
Users are confused because they find the menu to edit attribute
overrides, change values, then do not see their values reflected.  There
is an option that needs to be enabled under the edit menu to show the
users overrides.

Moved this option from the edit menu to the window menu (next to the
existing attributes override editor), and grouped them together.
Functionality is not changed, merely placement of the overrides toggle.