### PR TITLE
Applied size reduction effect to neut/nos

### DIFF
--- a/eos/effects/energydestabilizationnew.py
+++ b/eos/effects/energydestabilizationnew.py
@@ -1,10 +1,9 @@
 # Not used by any item
 from eos.types import State
 type = "active", "projected"
-def handler(fit, container, context):
-    if "projected" in context and ((hasattr(container, "state") \
-    and container.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        multiplier = container.amountActive if hasattr(container, "amountActive") else 1
-        amount = container.getModifiedItemAttr("energyNeutralizerAmount")
-        time = container.getModifiedItemAttr("duration")
-        fit.addDrain(time, amount * multiplier, 0)
+def handler(fit, src, context):
+    if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
+        multiplier = src.amountActive if hasattr(src, "amountActive") else 1
+        amount = src.getModifiedItemAttr("energyNeutralizerAmount")
+        time = src.getModifiedItemAttr("duration")
+        fit.addDrain(src, time, amount * multiplier, 0)

--- a/eos/effects/energyneutralizerentity.py
+++ b/eos/effects/energyneutralizerentity.py
@@ -10,30 +10,5 @@ def handler(fit, src, context):
     if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
         amount = src.getModifiedItemAttr("energyNeutralizerAmount")
         time = src.getModifiedItemAttr("duration")
-        rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
-        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
-        #Signature reduction, uses the bomb formula as per CCP Larrikin
-        if energyNeutralizerSignatureResolution:
-            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
-
-            sigReductionList = [1, sigRatio]
-            amount = amount*min(sigReductionList)
-
-        #Small rigged ships
-        if (rigSize == 1) and modifierSmall:
-            amount = amount*modifierSmall
-
-        #Medium rigged ships
-        if (rigSize == 2) and modifierMedium:
-            amount = amount*modifierMedium
-
-        #Large rigged ships
-        if (rigSize == 3) and modifierLarge:
-            amount = amount*modifierLarge
-
-        fit.addDrain(time, amount, 0)
+        fit.addDrain(src, time, amount, 0)

--- a/eos/effects/energyneutralizerentity.py
+++ b/eos/effects/energyneutralizerentity.py
@@ -13,6 +13,15 @@ def handler(fit, module, context):
         modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
         modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
         modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
+
+        #Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
+
+            sigReductionList = [1, sigRatio]
+            amount = amount*min(sigReductionList)
 
         #Small rigged ships
         if (rigSize == 1) and modifierSmall:

--- a/eos/effects/energyneutralizerentity.py
+++ b/eos/effects/energyneutralizerentity.py
@@ -4,9 +4,26 @@
 # Drones from group: Energy Neutralizer Drone (3 of 3)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, container, context):
-    if "projected" in context and ((hasattr(container, "state") \
-    and container.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        amount = container.getModifiedItemAttr("energyNeutralizerAmount")
-        time = container.getModifiedItemAttr("duration")
+def handler(fit, module, context):
+    if "projected" in context and ((hasattr(module, "state") \
+    and module.state >= State.ACTIVE) or hasattr(container, "amountActive")):
+        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
+        time = module.getModifiedItemAttr("duration")
+        rigSize = fit.ship.getModifiedItemAttr("rigSize")
+        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+
+        #Small rigged ships
+        if (rigSize == 1) and modifierSmall:
+            amount = amount*modifierSmall
+
+        #Medium rigged ships
+        if (rigSize == 2) and modifierMedium:
+            amount = amount*modifierMedium
+
+        #Large rigged ships
+        if (rigSize == 3) and modifierLarge:
+            amount = amount*modifierLarge
+
         fit.addDrain(time, amount, 0)

--- a/eos/effects/energyneutralizerentity.py
+++ b/eos/effects/energyneutralizerentity.py
@@ -4,16 +4,17 @@
 # Drones from group: Energy Neutralizer Drone (3 of 3)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, module, context):
-    if "projected" in context and ((hasattr(module, "state") \
-    and module.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
-        time = module.getModifiedItemAttr("duration")
+
+
+def handler(fit, src, context):
+    if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
+        amount = src.getModifiedItemAttr("energyNeutralizerAmount")
+        time = src.getModifiedItemAttr("duration")
         rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
         signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
         #Signature reduction, uses the bomb formula as per CCP Larrikin

--- a/eos/effects/energyneutralizerfalloff.py
+++ b/eos/effects/energyneutralizerfalloff.py
@@ -10,30 +10,5 @@ def handler(fit, src, context):
     if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
         amount = src.getModifiedItemAttr("energyNeutralizerAmount")
         time = src.getModifiedItemAttr("duration")
-        rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
-        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
-        #Signature reduction, uses the bomb formula as per CCP Larrikin
-        if energyNeutralizerSignatureResolution:
-            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
-
-            sigReductionList = [1, sigRatio]
-            amount = amount*min(sigReductionList)
-
-        #Small rigged ships
-        if (rigSize == 1) and modifierSmall:
-            amount = amount*modifierSmall
-
-        #Medium rigged ships
-        if (rigSize == 2) and modifierMedium:
-            amount = amount*modifierMedium
-
-        #Large rigged ships
-        if (rigSize == 3) and modifierLarge:
-            amount = amount*modifierLarge
-
-        fit.addDrain(time, amount, 0)
+        fit.addDrain(src, time, amount, 0)

--- a/eos/effects/energyneutralizerfalloff.py
+++ b/eos/effects/energyneutralizerfalloff.py
@@ -4,16 +4,17 @@
 # Modules from group: Energy Neutralizer (51 of 51)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, module, context):
-    if "projected" in context and ((hasattr(module, "state") \
-    and module.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
-        time = module.getModifiedItemAttr("duration")
+
+
+def handler(fit, src, context):
+    if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
+        amount = src.getModifiedItemAttr("energyNeutralizerAmount")
+        time = src.getModifiedItemAttr("duration")
         rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
         signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
         #Signature reduction, uses the bomb formula as per CCP Larrikin
@@ -36,4 +37,3 @@ def handler(fit, module, context):
             amount = amount*modifierLarge
 
         fit.addDrain(time, amount, 0)
-

--- a/eos/effects/energyneutralizerfalloff.py
+++ b/eos/effects/energyneutralizerfalloff.py
@@ -13,6 +13,15 @@ def handler(fit, module, context):
         modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
         modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
         modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
+
+        #Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
+
+            sigReductionList = [1, sigRatio]
+            amount = amount*min(sigReductionList)
 
         #Small rigged ships
         if (rigSize == 1) and modifierSmall:

--- a/eos/effects/energyneutralizerfalloff.py
+++ b/eos/effects/energyneutralizerfalloff.py
@@ -4,9 +4,27 @@
 # Modules from group: Energy Neutralizer (51 of 51)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, container, context):
-    if "projected" in context and ((hasattr(container, "state") \
-    and container.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        amount = container.getModifiedItemAttr("energyNeutralizerAmount")
-        time = container.getModifiedItemAttr("duration")
+def handler(fit, module, context):
+    if "projected" in context and ((hasattr(module, "state") \
+    and module.state >= State.ACTIVE) or hasattr(container, "amountActive")):
+        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
+        time = module.getModifiedItemAttr("duration")
+        rigSize = fit.ship.getModifiedItemAttr("rigSize")
+        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+
+        #Small rigged ships
+        if (rigSize == 1) and modifierSmall:
+            amount = amount*modifierSmall
+
+        #Medium rigged ships
+        if (rigSize == 2) and modifierMedium:
+            amount = amount*modifierMedium
+
+        #Large rigged ships
+        if (rigSize == 3) and modifierLarge:
+            amount = amount*modifierLarge
+
         fit.addDrain(time, amount, 0)
+

--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -14,14 +14,14 @@ def handler(fit, module, context):
     energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
     signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
-    # Signature reduction, uses the bomb formula as per CCP Larrikin
-    if energyNeutralizerSignatureResolution:
-        sigRatio = signatureRadius / energyNeutralizerSignatureResolution
-
-        sigReductionList = [1, sigRatio]
-        amount = amount * min(sigReductionList)
-
     if "projected" in context:
+        # Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            sigRatio = signatureRadius / energyNeutralizerSignatureResolution
+
+            sigReductionList = [1, sigRatio]
+            amount = amount * min(sigReductionList)
+
         #Small rigged ships
         if (rigSize == 1) and modifierSmall:
             amount = amount*modifierSmall

--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -11,6 +11,15 @@ def handler(fit, module, context):
     modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
     modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
     modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+    energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+    signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
+
+    # Signature reduction, uses the bomb formula as per CCP Larrikin
+    if energyNeutralizerSignatureResolution:
+        sigRatio = signatureRadius / energyNeutralizerSignatureResolution
+
+        sigReductionList = [1, sigRatio]
+        amount = amount * min(sigReductionList)
 
     if "projected" in context:
         #Small rigged ships

--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -4,14 +4,16 @@
 # Modules from group: Energy Nosferatu (51 of 51)
 type = "active", "projected"
 runTime = "late"
-def handler(fit, module, context):
-    amount = module.getModifiedItemAttr("powerTransferAmount")
-    time = module.getModifiedItemAttr("duration")
+
+
+def handler(fit, src, context):
+    amount = src.getModifiedItemAttr("powerTransferAmount")
+    time = src.getModifiedItemAttr("duration")
     rigSize = fit.ship.getModifiedItemAttr("rigSize")
-    modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-    modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-    modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-    energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+    modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+    modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+    modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+    energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
     signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
     if "projected" in context:
@@ -36,4 +38,4 @@ def handler(fit, module, context):
 
         fit.addDrain(time, amount, 0)
     elif "module" in context:
-        module.itemModifiedAttributes.force("capacitorNeed", -amount)
+        src.itemModifiedAttributes.force("capacitorNeed", -amount)

--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -9,33 +9,8 @@ runTime = "late"
 def handler(fit, src, context):
     amount = src.getModifiedItemAttr("powerTransferAmount")
     time = src.getModifiedItemAttr("duration")
-    rigSize = fit.ship.getModifiedItemAttr("rigSize")
-    modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-    modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-    modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-    energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
-    signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
     if "projected" in context:
-        # Signature reduction, uses the bomb formula as per CCP Larrikin
-        if energyNeutralizerSignatureResolution:
-            sigRatio = signatureRadius / energyNeutralizerSignatureResolution
-
-            sigReductionList = [1, sigRatio]
-            amount = amount * min(sigReductionList)
-
-        #Small rigged ships
-        if (rigSize == 1) and modifierSmall:
-            amount = amount*modifierSmall
-
-        #Medium rigged ships
-        if (rigSize == 2) and modifierMedium:
-            amount = amount*modifierMedium
-
-        #Large rigged ships
-        if (rigSize == 3) and modifierLarge:
-            amount = amount*modifierLarge
-
-        fit.addDrain(time, amount, 0)
+        fit.addDrain(src, time, amount, 0)
     elif "module" in context:
         src.itemModifiedAttributes.force("capacitorNeed", -amount)

--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -7,7 +7,24 @@ runTime = "late"
 def handler(fit, module, context):
     amount = module.getModifiedItemAttr("powerTransferAmount")
     time = module.getModifiedItemAttr("duration")
+    rigSize = fit.ship.getModifiedItemAttr("rigSize")
+    modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+    modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+    modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+
     if "projected" in context:
+        #Small rigged ships
+        if (rigSize == 1) and modifierSmall:
+            amount = amount*modifierSmall
+
+        #Medium rigged ships
+        if (rigSize == 2) and modifierMedium:
+            amount = amount*modifierMedium
+
+        #Large rigged ships
+        if (rigSize == 3) and modifierLarge:
+            amount = amount*modifierLarge
+
         fit.addDrain(time, amount, 0)
     elif "module" in context:
         module.itemModifiedAttributes.force("capacitorNeed", -amount)

--- a/eos/effects/energytransfer.py
+++ b/eos/effects/energytransfer.py
@@ -1,7 +1,7 @@
 # Not used by any item
 type = "projected", "active"
-def handler(fit, module, context):
+def handler(fit, src, context):
     if "projected" in context:
-        amount = module.getModifiedItemAttr("powerTransferAmount")
-        duration = module.getModifiedItemAttr("duration")
-        fit.addDrain(duration, -amount, 0)
+        amount = src.getModifiedItemAttr("powerTransferAmount")
+        duration = src.getModifiedItemAttr("duration")
+        fit.addDrain(src, duration, -amount, 0)

--- a/eos/effects/entityenergyneutralizerfalloff.py
+++ b/eos/effects/entityenergyneutralizerfalloff.py
@@ -13,6 +13,15 @@ def handler(fit, module, context):
         modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
         modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
         modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
+
+        #Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
+
+            sigReductionList = [1, sigRatio]
+            amount = amount*min(sigReductionList)
 
         #Small rigged ships
         if (rigSize == 1) and modifierSmall:

--- a/eos/effects/entityenergyneutralizerfalloff.py
+++ b/eos/effects/entityenergyneutralizerfalloff.py
@@ -4,9 +4,26 @@
 # Drones from group: Energy Neutralizer Drone (3 of 3)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, container, context):
-    if "projected" in context and ((hasattr(container, "state") \
-    and container.state >= State.ACTIVE) or hasattr(container, "amountActive")):
-        amount = container.getModifiedItemAttr("energyNeutralizerAmount")
-        time = container.getModifiedItemAttr("energyNeutralizerDuration")
+def handler(fit, module, context):
+    if "projected" in context and ((hasattr(module, "state") \
+    and module.state >= State.ACTIVE) or hasattr(module, "amountActive")):
+        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
+        time = module.getModifiedItemAttr("energyNeutralizerDuration")
+        rigSize = fit.ship.getModifiedItemAttr("rigSize")
+        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+
+        #Small rigged ships
+        if (rigSize == 1) and modifierSmall:
+            amount = amount*modifierSmall
+
+        #Medium rigged ships
+        if (rigSize == 2) and modifierMedium:
+            amount = amount*modifierMedium
+
+        #Large rigged ships
+        if (rigSize == 3) and modifierLarge:
+            amount = amount*modifierLarge
+
         fit.addDrain(time, amount, 0)

--- a/eos/effects/entityenergyneutralizerfalloff.py
+++ b/eos/effects/entityenergyneutralizerfalloff.py
@@ -4,16 +4,17 @@
 # Drones from group: Energy Neutralizer Drone (3 of 3)
 from eos.types import State
 type = "active", "projected"
-def handler(fit, module, context):
-    if "projected" in context and ((hasattr(module, "state") \
-    and module.state >= State.ACTIVE) or hasattr(module, "amountActive")):
-        amount = module.getModifiedItemAttr("energyNeutralizerAmount")
-        time = module.getModifiedItemAttr("energyNeutralizerDuration")
+
+
+def handler(fit, src, context):
+    if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
+        amount = src.getModifiedItemAttr("energyNeutralizerAmount")
+        time = src.getModifiedItemAttr("energyNeutralizerDuration")
         rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
         signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
         #Signature reduction, uses the bomb formula as per CCP Larrikin

--- a/eos/effects/entityenergyneutralizerfalloff.py
+++ b/eos/effects/entityenergyneutralizerfalloff.py
@@ -10,30 +10,5 @@ def handler(fit, src, context):
     if "projected" in context and ((hasattr(src, "state") and src.state >= State.ACTIVE) or hasattr(src, "amountActive")):
         amount = src.getModifiedItemAttr("energyNeutralizerAmount")
         time = src.getModifiedItemAttr("energyNeutralizerDuration")
-        rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
-        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
-        #Signature reduction, uses the bomb formula as per CCP Larrikin
-        if energyNeutralizerSignatureResolution:
-            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
-
-            sigReductionList = [1, sigRatio]
-            amount = amount*min(sigReductionList)
-
-        #Small rigged ships
-        if (rigSize == 1) and modifierSmall:
-            amount = amount*modifierSmall
-
-        #Medium rigged ships
-        if (rigSize == 2) and modifierMedium:
-            amount = amount*modifierMedium
-
-        #Large rigged ships
-        if (rigSize == 3) and modifierLarge:
-            amount = amount*modifierLarge
-
-        fit.addDrain(time, amount, 0)
+        fit.addDrain(src, time, amount, 0)

--- a/eos/effects/fighterabilityenergyneutralizer.py
+++ b/eos/effects/fighterabilityenergyneutralizer.py
@@ -20,6 +20,15 @@ def handler(fit, module, context):
         modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
         modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
         modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
+
+        #Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
+
+            sigReductionList = [1, sigRatio]
+            amount = amount*min(sigReductionList)
 
         # Small rigged ships
         if (rigSize == 1) and modifierSmall:

--- a/eos/effects/fighterabilityenergyneutralizer.py
+++ b/eos/effects/fighterabilityenergyneutralizer.py
@@ -12,8 +12,25 @@ prefix = "fighterAbilityEnergyNeutralizer"
 
 type = "active", "projected"
 
-def handler(fit, container, context):
+def handler(fit, module, context):
     if "projected" in context:
-        amount = container.getModifiedItemAttr("{}Amount".format(prefix))
-        time = container.getModifiedItemAttr("{}Duration".format(prefix))
+        amount = module.getModifiedItemAttr("{}Amount".format(prefix))
+        time = module.getModifiedItemAttr("{}Duration".format(prefix))
+        rigSize = fit.ship.getModifiedItemAttr("rigSize")
+        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+
+        # Small rigged ships
+        if (rigSize == 1) and modifierSmall:
+            amount = amount * modifierSmall
+
+        # Medium rigged ships
+        if (rigSize == 2) and modifierMedium:
+            amount = amount * modifierMedium
+
+        # Large rigged ships
+        if (rigSize == 3) and modifierLarge:
+            amount = amount * modifierLarge
+
         fit.addDrain(time, amount, 0)

--- a/eos/effects/fighterabilityenergyneutralizer.py
+++ b/eos/effects/fighterabilityenergyneutralizer.py
@@ -13,30 +13,5 @@ def handler(fit, src, context):
     if "projected" in context:
         amount = src.getModifiedItemAttr("{}Amount".format(prefix))
         time = src.getModifiedItemAttr("{}Duration".format(prefix))
-        rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
-        signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
-        #Signature reduction, uses the bomb formula as per CCP Larrikin
-        if energyNeutralizerSignatureResolution:
-            sigRatio = signatureRadius/energyNeutralizerSignatureResolution
-
-            sigReductionList = [1, sigRatio]
-            amount = amount*min(sigReductionList)
-
-        # Small rigged ships
-        if (rigSize == 1) and modifierSmall:
-            amount = amount * modifierSmall
-
-        # Medium rigged ships
-        if (rigSize == 2) and modifierMedium:
-            amount = amount * modifierMedium
-
-        # Large rigged ships
-        if (rigSize == 3) and modifierLarge:
-            amount = amount * modifierLarge
-
-        fit.addDrain(time, amount, 0)
+        fit.addDrain(src, time, amount, 0)

--- a/eos/effects/fighterabilityenergyneutralizer.py
+++ b/eos/effects/fighterabilityenergyneutralizer.py
@@ -3,24 +3,21 @@
 Since fighter abilities do not have any sort of item entity in the EVE database, we must derive the abilities from the
 effects, and thus this effect file contains some custom information useful only to fighters.
 """
-from eos.types import State
-
 # User-friendly name for the ability
 displayName = "Energy Neutralizer"
-
 prefix = "fighterAbilityEnergyNeutralizer"
-
 type = "active", "projected"
 
-def handler(fit, module, context):
+
+def handler(fit, src, context):
     if "projected" in context:
-        amount = module.getModifiedItemAttr("{}Amount".format(prefix))
-        time = module.getModifiedItemAttr("{}Duration".format(prefix))
+        amount = src.getModifiedItemAttr("{}Amount".format(prefix))
+        time = src.getModifiedItemAttr("{}Duration".format(prefix))
         rigSize = fit.ship.getModifiedItemAttr("rigSize")
-        modifierLarge = module.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
-        modifierMedium = module.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
-        modifierSmall = module.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
-        energyNeutralizerSignatureResolution = module.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        modifierLarge = src.getModifiedItemAttr("entityCapacitorLevelModifierLarge")
+        modifierMedium = src.getModifiedItemAttr("entityCapacitorLevelModifierMedium")
+        modifierSmall = src.getModifiedItemAttr("entityCapacitorLevelModifierSmall")
+        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
         signatureRadius = fit.ship.getModifiedItemAttr("signatureRadius")
 
         #Signature reduction, uses the bomb formula as per CCP Larrikin

--- a/eos/effects/remoteenergytransferfalloff.py
+++ b/eos/effects/remoteenergytransferfalloff.py
@@ -3,8 +3,8 @@
 # Used by:
 # Modules from group: Remote Capacitor Transmitter (41 of 41)
 type = "projected", "active"
-def handler(fit, module, context):
+def handler(fit, src, context):
     if "projected" in context:
-        amount = module.getModifiedItemAttr("powerTransferAmount")
-        duration = module.getModifiedItemAttr("duration")
-        fit.addDrain(duration, -amount, 0)
+        amount = src.getModifiedItemAttr("powerTransferAmount")
+        duration = src.getModifiedItemAttr("duration")
+        fit.addDrain(src, duration, -amount, 0)

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -879,17 +879,10 @@ class Fit(object):
         rigSize = self.ship.getModifiedItemAttr("rigSize")
         energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
         signatureRadius = self.ship.getModifiedItemAttr("signatureRadius")
-        neutSizes = {1.0: 'Small', 2.0: 'Medium', 3.0: 'Large', 4.0: 'Capital'}
 
         #Signature reduction, uses the bomb formula as per CCP Larrikin
         if energyNeutralizerSignatureResolution:
             capNeed = capNeed*min(1, signatureRadius/energyNeutralizerSignatureResolution)
-
-        #Size reduction, reduces neuts based off ship rig size
-        for sizeInt, sizeName in neutSizes.iteritems():
-            capacitorLevelModifier = src.getModifiedItemAttr("entityCapacitorLevelModifier{}".format(sizeName))
-            if (rigSize == sizeInt) and capacitorLevelModifier:
-                capNeed = capNeed*capacitorLevelModifier
 
         resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
         self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -873,8 +873,24 @@ class Fit(object):
         rechargeRate = self.ship.getModifiedItemAttr("shieldRechargeRate") / 1000.0
         return 10 / rechargeRate * sqrt(percent) * (1 - sqrt(percent)) * capacity
 
-    def addDrain(self, cycleTime, capNeed, clipSize=0):
+    def addDrain(self, src, cycleTime, capNeed, clipSize=0):
         """ Used for both cap drains and cap fills (fills have negative capNeed) """
+
+        rigSize = self.ship.getModifiedItemAttr("rigSize")
+        energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
+        signatureRadius = self.ship.getModifiedItemAttr("signatureRadius")
+        neutSizes = {1.0: 'Small', 2.0: 'Medium', 3.0: 'Large', 4.0: 'Capital'}
+
+        #Signature reduction, uses the bomb formula as per CCP Larrikin
+        if energyNeutralizerSignatureResolution:
+            capNeed = capNeed*min(1, signatureRadius/energyNeutralizerSignatureResolution)
+
+        #Size reduction, reduces neuts based off ship rig size
+        for sizeInt, sizeName in neutSizes.iteritems():
+            capacitorLevelModifier = src.getModifiedItemAttr("entityCapacitorLevelModifier{}".format(sizeName))
+            if (rigSize == sizeInt) and capacitorLevelModifier:
+                capNeed = capNeed*capacitorLevelModifier
+
         resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
         self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))
 


### PR DESCRIPTION
Relevant code is in the effects file. Basically grabs the ships rig size, and applies the small/medium/large modifiers as a straight up percentage.

Example, ship on the left with the legacy code, ship on the right with the new code.

http://puu.sh/q4qsc/83975220d9.png

Todo:
*Could figure out how CCP handles unrigged ships (freighters, shuttles, pods).  This is an edge case, so we may simply choose not to cover it.
*Not sure how CCP determines the actual size, they may use a different formula than rig size.
*Need to handle the sig radius reduction for capital sized neuts. Still not sure on formula.
*Need to verify that stacking behavior works with cap batteries.  Assumption here is that the module size reduction applies without a stacking penalty and prior to the cap battery reduction.