### PR TITLE
RAH gets pissy if there is no damage profile

### DIFF
--- a/eos/effects/adaptivearmorhardener.py
+++ b/eos/effects/adaptivearmorhardener.py
@@ -9,10 +9,10 @@ def handler(fit, module, context):
 
         #Adjust RAH to match the current damage pattern
         damagePattern = fit.damagePattern
-        attrDamagePattern = "%sAmount" % type
-        damagePatternModifier = getattr(damagePattern,attrDamagePattern)/float(sum((damagePattern.emAmount,damagePattern.thermalAmount,damagePattern.kineticAmount,damagePattern.explosiveAmount)))
-        modifiedResistModifier = (1-(((1-module.getModifiedItemAttr(attr))*4)*(damagePatternModifier)))
-        module.forceItemAttr(attr, modifiedResistModifier)
+        if damagePattern:
+            attrDamagePattern = "%sAmount" % type
+            damagePatternModifier = getattr(damagePattern,attrDamagePattern)/float(sum((damagePattern.emAmount,damagePattern.thermalAmount,damagePattern.kineticAmount,damagePattern.explosiveAmount)))
+            modifiedResistModifier = (1-(((1-module.getModifiedItemAttr(attr))*4)*(damagePatternModifier)))
+            module.forceItemAttr(attr, modifiedResistModifier)
 
-        fit.ship.multiplyItemAttr(attr, module.getModifiedItemAttr(attr),
-                                  stackingPenalties=True, penaltyGroup="preMul")
+        fit.ship.multiplyItemAttr(attr, module.getModifiedItemAttr(attr), stackingPenalties=True, penaltyGroup="preMul")


### PR DESCRIPTION
If there is no damage profile (likely from one that's deleted, and
somehow the profile doesn't get set back to uniform), then RAH tries to
apply null values.  This skips making the RAH reactive if that scenario
happens.

Also, RAH apparently fires on boosters (probably projected fits as well).