### PR TITLE
fixed exception that froze interface

### DIFF
--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -557,7 +557,7 @@ class FittingView(d.Display):
                      5: ''}
 
     def slotColour(self, slot):
-        return self.slotColourMap[slot] or self.GetBackgroundColour()
+        return self.slotColourMap.get(slot) or self.GetBackgroundColour()
 
     def refresh(self, stuff):
         '''


### PR DESCRIPTION
```
Traceback (most recent call last):
  File ".../Pyfa/gui/builtinViews/fittingView.py", line 463, in fitChanged
    self.refresh(self.mods)
  File ".../Pyfa/gui/builtinViews/fittingView.py", line 590, in refresh
    self.SetItemBackgroundColour(i, self.slotColour(mod.slot))
  File ".../Pyfa/gui/builtinViews/fittingView.py", line 560, in slotColour
    return self.slotColourMap[slot] or self.GetBackgroundColour()
KeyError: 8
```