### PR TITLE
Update README.md with current brew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are two different distributives for OS X: `-mac` and `-mac-deprecated`.
 
 There is also a [Homebrew](http://brew.sh) option for installing pyfa on OS X. Please note this is maintained by a third-party and is not tested by pyfa developers. Simply fire up in terminal:
 ```
-$ brew cask install pyfa
+$ brew install Caskroom/cask/pyfa
 ```
 
 ### Linux Distro-specific Packages


### PR DESCRIPTION
```
Error: No available formula with the name "pyfa" 
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
This formula was found in a tap:
Caskroom/cask/pyfa
To install it, run:
  brew install Caskroom/cask/pyfa
```