### PR TITLE
More properly behaviour for fitting implant sets

### DIFF
--- a/gui/builtinContextMenus/implantSets.py
+++ b/gui/builtinContextMenus/implantSets.py
@@ -69,6 +69,11 @@ class ImplantSets(ContextMenu):
         else:
             sFit = service.Fit.getInstance()
             fitID = self.mainFrame.getActiveFit()
+
+            # at first remove all implants
+            sFit.removeAllImplants(fitID)
+
+            # and add new implants from set
             for implant in set.implants:
                 sFit.addImplant(fitID, implant.item.ID, recalc=implant == set.implants[-1])
 

--- a/gui/builtinContextMenus/implantSets.py
+++ b/gui/builtinContextMenus/implantSets.py
@@ -12,7 +12,7 @@ class ImplantSets(ContextMenu):
         return srcContext in ("implantView", "implantEditor")
 
     def getText(self, itmContext, selection):
-        return "Add Implant Set"
+        return "Fit Implant Set"
 
     def getSubMenu(self, context, selection, rootMenu, i, pitem):
         """
@@ -59,6 +59,7 @@ class ImplantSets(ContextMenu):
 
         if self.context == "implantEditor":
             # we are calling from character editor, the implant source is different
+            # todo this part seems to be doesn't work (not my fault!)
             sChar = service.Character.getInstance()
             charID = self.selection.getActiveCharacter()
 

--- a/service/fit.py
+++ b/service/fit.py
@@ -304,6 +304,19 @@ class Fit(object):
         self.recalc(fit)
         return True
 
+    def removeAllImplants(self, fitID):
+        if fitID is None:
+            return False
+
+        fit = eos.db.getFit(fitID)
+        implants = fit.implants if fit is not None else None
+        if not implants:
+            return False
+        for _ in xrange(len(implants)):
+            self.removeImplant(fitID, 0)
+        self.recalc(fit)
+        return True
+
     def addBooster(self, fitID, itemID):
         if fitID is None:
             return False


### PR DESCRIPTION
Hi
In my opinion it's more reasonable behaviour for this function ("add implant set")

Old behaviour:
It actually ADDS implants from set into current fit. If there were other implants in fit and also empty slots in set, the old implants have been remained in fit. But I use this feature e.g. for jump clones and I need change all previously fitted implants.

New behaviour:
All fitted implants are removed from fit before adding new from set.
