### PR TITLE
Enable job for processing fit calculations

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -22,7 +22,6 @@ import copy
 import threading
 import logging
 import wx
-import gui
 import sched, time
 from codecs import open
 

--- a/service/fit.py
+++ b/service/fit.py
@@ -22,6 +22,8 @@ import copy
 import threading
 import logging
 import wx
+import gui
+import sched, time
 from codecs import open
 
 import xml.parsers.expat
@@ -40,6 +42,8 @@ from service.port import Port
 
 logger = logging.getLogger(__name__)
 
+schedule = sched.scheduler(time.time, time.sleep)
+recalcJob = []
 
 class FitBackupThread(threading.Thread):
     def __init__(self, path, callback):
@@ -1125,8 +1129,41 @@ class Fit(object):
         self.recalc(fit)
 
     def recalc(self, fit, withBoosters=True):
+        global recalcJob
+
+        if not schedule.empty():
+            if recalcJob in schedule.queue:
+                logger.debug("Job already scheduled. Cancelling existing job")
+                schedule.cancel(recalcJob)
+                pass
+            else:
+                pass
+
+        logger.debug("Scheduling fitting job")
+            #args = [fit, withBoosters]
+        args = [fit, True]
+        recalcJob = schedule.enter(1,1,self.recalcJobs,args)
+
+        threading.Timer(1, self.runRecalcJobs, ()).start()
+
+    def runRecalcJobs(self):
+        if schedule.empty():
+            pass
+        else:
+            logger.debug("Running scheduled jobs")
+            schedule.run()
+
+    def recalcJobs(self, fit, withBoosters=True):
         logger.debug("=" * 10 + "recalc" + "=" * 10)
         if fit.factorReload is not self.serviceFittingOptions["useGlobalForceReload"]:
             fit.factorReload = self.serviceFittingOptions["useGlobalForceReload"]
         fit.clear()
         fit.calculateModifiedAttributes(withBoosters=withBoosters)
+        fit.fill()
+
+        # Check that the states of all modules are valid
+        self.checkStates(fit, None)
+
+        eos.db.commit()
+        #fit.inited = True
+        logger.debug("=" * 10 + "recalc end" + "=" * 10)


### PR DESCRIPTION
This is just a proof of concept....

There are numerous scenarios where the fitting job gets recalculated multiple times.

Examples:
On first fit load (3 times)
If a user clicks too quickly (turning on/off multiple modules, adding modules, etc)

This splits the recalc function off into a scheduled job.  A timer is created for 1 second from an event to run the job.  If the user is impatient and makes further changes, the existing job is cancelled and a new job/timer is created.

Both have a short delay (1s) to prevent a race condition from creating multiple jobs that run at the same time.

This _mostly_ works.  The GUI does not get updated always properly, sometimes does not show the correct values until the next job is ran.

Perhaps @blitzmann can chime in on a way to force a full gui refresh....
