### PR TITLE
Fix three...I mean...four XL Rig effect files

### DIFF
--- a/eos/effects/structurerigdoomsdaydamageloss.py
+++ b/eos/effects/structurerigdoomsdaydamageloss.py
@@ -1,5 +1,6 @@
 type = "passive"
 def handler(fit, src, context):
-    fit.modules.filteredItemMultiply(lambda mod: mod.item.group.name == "Structure Doomsday Weapon",
-                                     "lightningWeaponDamageLossTarget", src.getModifiedItemAttr("structureRigDoomsdayDamageLossTargetBonus"),
-                                     stackingPenalties=True)
+    for module in fit.modules:
+        if module.getModifiedItemAttr("lightningWeaponDamageLossTarget"):
+            boostAmount = 1+src.getModifiedItemAttr("structureRigDoomsdayDamageLossTargetBonus")
+            module.multiplyItemAttr("lightningWeaponDamageLossTarget",boostAmount)

--- a/eos/effects/structurerigdoomsdaytargetamountbonus.py
+++ b/eos/effects/structurerigdoomsdaytargetamountbonus.py
@@ -1,11 +1,3 @@
-'''
-type = "passive"
-def handler(fit, src, context):
-    fit.modules.filteredItemIncrease(lambda mod: mod.item.group.name == "Structure Doomsday Weapon", "lightningWeaponTargetAmount", src.getModifiedItemAttr("structureRigDoomsdayTargetAmountBonus"), stackingPenalties=True)
-    # This is all wrong.  We need to modify the module attached to the ship (citadel) and add the bonus from the rig.
-    # So Rig -> Ship -> Module
-'''
-
 type = "passive"
 def handler(fit, src, context):
     for module in fit.modules:

--- a/eos/effects/structurerigdoomsdaytargetamountbonus.py
+++ b/eos/effects/structurerigdoomsdaytargetamountbonus.py
@@ -1,5 +1,7 @@
+'''
 type = "passive"
 def handler(fit, src, context):
-    fit.modules.filteredItemIncrease(lambda mod: mod.item.group.name == "Structure Doomsday Weapon",
-                                     "lightningWeaponTargetAmount", src.getModifiedItemAttr("structureRigDoomsdayTargetAmountBonus"),
-                                     stackingPenalties=True)
+    fit.modules.filteredItemIncrease(lambda mod: mod.item.group.name == "Structure Doomsday Weapon", "lightningWeaponTargetAmount", src.getModifiedItemAttr("structureRigDoomsdayTargetAmountBonus"), stackingPenalties=True)
+    # This is all wrong.  We need to modify the module attached to the ship (citadel) and add the bonus from the rig.
+    # So Rig -> Ship -> Module
+'''

--- a/eos/effects/structurerigdoomsdaytargetamountbonus.py
+++ b/eos/effects/structurerigdoomsdaytargetamountbonus.py
@@ -5,3 +5,9 @@ def handler(fit, src, context):
     # This is all wrong.  We need to modify the module attached to the ship (citadel) and add the bonus from the rig.
     # So Rig -> Ship -> Module
 '''
+
+type = "passive"
+def handler(fit, src, context):
+    for module in fit.modules:
+        if module.getModifiedItemAttr("lightningWeaponTargetAmount"):
+            module.increaseItemAttr("lightningWeaponTargetAmount",src.getModifiedItemAttr("structureRigDoomsdayTargetAmountBonus"))

--- a/eos/effects/structurerigmaxtargets.py
+++ b/eos/effects/structurerigmaxtargets.py
@@ -1,3 +1,3 @@
 type = "passive"
 def handler(fit, src, context):
-    fit.ship.filteredItemIncrease("maxLockedTargets", src.getModifiedItemAttr("structureRigMaxTargetBonus"))
+    fit.ship.increaseItemAttr("maxLockedTargets", src.getModifiedItemAttr("structureRigMaxTargetBonus"))

--- a/eos/effects/structurerigsensorresolution.py
+++ b/eos/effects/structurerigsensorresolution.py
@@ -1,4 +1,3 @@
 type = "passive"
 def handler(fit, src, context):
-    fit.ship.filteredItemBoost("scanResolution", src.getModifiedItemAttr("structureRigScanResBonus"),
-                            stackingPenalties=True)
+    fit.ship.boostItemAttr("scanResolution", src.getModifiedItemAttr("structureRigScanResBonus"),stackingPenalties=True)

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -65,6 +65,10 @@ from eos.db.saveddata.loadDefaultDatabaseValues import DefaultDatabaseValues
 
 from time import gmtime, strftime
 
+#Import logging
+import logging
+logger = logging.getLogger("pyfa.service.port")
+
 if not 'wxMac' in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION >= (3,0)):
     from service.crest import CrestModes
     from gui.crestFittings import CrestFittings, ExportToEve, CrestMgmt
@@ -683,7 +687,7 @@ class MainFrame(wx.Frame):
         try:
             fits = sFit.importFitFromBuffer(fromClipboard(), self.getActiveFit())
         except:
-            pass
+            logger.error("Failed to import fit.")
         else:
             self._openAfterImport(fits)
 


### PR DESCRIPTION
```
    fit.modules.filteredItemIncrease(lambda mod: mod.item.group.name == "Structure Doomsday Weapon", "lightningWeaponTargetAmount", src.getModifiedItemAttr("structureRigDoomsdayTargetAmountBonus"), stackingPenalties=True)
    # This is all wrong.  We need to modify the module attached to the ship (citadel) and add the bonus from the rig.
    # So Rig -> Ship -> Module
```

I'm not sure how to go about this, so disabled for now....

The problem is that the ship doesn't have the attribute, and passing it through this way doesn't work.  For some reason, `fit.modules` doesn't seem to have any of the normal classes/functions attached to it. 

The other two effect files are fixed, however, and this one is disabled until we can figure it out.