### PR TITLE
Add login/password for proxy authorization in network settings

### DIFF
--- a/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
@@ -115,10 +115,10 @@ class PFNetworkPref ( PreferenceView):
         mainSizer.Add( fgAddrSizer, 0, wx.EXPAND, 5)
 
         # proxy auth information: login and pass
-        self.stPSetLogin = wx.StaticText(panel, wx.ID_ANY, u"Proxy login:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetLogin = wx.StaticText(panel, wx.ID_ANY, u"Username:", wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetLogin.Wrap(-1)
         self.editProxySettingsLogin = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[0], wx.DefaultPosition, wx.DefaultSize, 0)
-        self.stPSetPassword = wx.StaticText(panel, wx.ID_ANY, u"pass:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetPassword = wx.StaticText(panel, wx.ID_ANY, u"Password:", wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetPassword.Wrap(-1)
         self.editProxySettingsPassword = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[1], wx.DefaultPosition,
                                                      wx.DefaultSize, wx.TE_PASSWORD)

--- a/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
@@ -70,6 +70,8 @@ class PFNetworkPref ( PreferenceView):
         self.nPort = self.settings.getPort()
         self.nType = self.settings.getType()
         self.nAuth = self.settings.getProxyAuthDetails()  # tuple of (login, password)
+        if self.nAuth is None:
+            self.nAuth = ("", "")  # we don't want None here, it should be a tuple
 
         ptypeSizer = wx.BoxSizer( wx.HORIZONTAL )
 

--- a/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
@@ -69,6 +69,7 @@ class PFNetworkPref ( PreferenceView):
         self.nAddr = self.settings.getAddress()
         self.nPort = self.settings.getPort()
         self.nType = self.settings.getType()
+        self.nAuth = self.settings.getProxyAuthDetails()  # tuple of (login, password)
 
         ptypeSizer = wx.BoxSizer( wx.HORIZONTAL )
 
@@ -111,6 +112,21 @@ class PFNetworkPref ( PreferenceView):
 
         mainSizer.Add( fgAddrSizer, 0, wx.EXPAND, 5)
 
+        # proxy auth information: login and pass
+        self.stPSetLogin = wx.StaticText(panel, wx.ID_ANY, u"Proxy login:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetLogin.Wrap(-1)
+        self.editProxySettingsLogin = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[0], wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetPassword = wx.StaticText(panel, wx.ID_ANY, u"pass:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetPassword.Wrap(-1)
+        self.editProxySettingsPassword = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[1], wx.DefaultPosition,
+                                                     wx.DefaultSize, wx.TE_PASSWORD)
+        pAuthSizer = wx.BoxSizer(wx.HORIZONTAL)
+        pAuthSizer.Add(self.stPSetLogin, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        pAuthSizer.Add(self.editProxySettingsLogin, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        pAuthSizer.Add(self.stPSetPassword, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        pAuthSizer.Add(self.editProxySettingsPassword, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        mainSizer.Add(pAuthSizer, 0, wx.EXPAND, 5)
+
         self.stPSAutoDetected = wx.StaticText( panel, wx.ID_ANY, u"Auto-detected: ", wx.DefaultPosition, wx.DefaultSize, 0 )
         self.stPSAutoDetected.Wrap( -1 )
         mainSizer.Add( self.stPSAutoDetected, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
@@ -138,13 +154,15 @@ class PFNetworkPref ( PreferenceView):
         self.chProxyType.Bind(wx.EVT_CHOICE, self.OnCHProxyTypeSelect)
         self.editProxySettingsAddr.Bind(wx.EVT_TEXT, self.OnEditPSAddrText)
         self.editProxySettingsPort.Bind(wx.EVT_TEXT, self.OnEditPSPortText)
+        self.editProxySettingsLogin.Bind(wx.EVT_TEXT, self.OnEditPSLoginText)
+        self.editProxySettingsPassword.Bind(wx.EVT_TEXT, self.OnEditPSPasswordText)
 
 
         self.btnApply.Bind(wx.EVT_BUTTON, self.OnBtnApply)
 
         self.UpdateApplyButtonState()
 
-        if self.nMode is not 2:
+        if self.nMode is not service.settings.NetworkSettings.PROXY_MODE_MANUAL:  # == 2
             self.ToggleProxySettings(False)
         else:
             self.ToggleProxySettings(True)
@@ -180,6 +198,16 @@ class PFNetworkPref ( PreferenceView):
         self.dirtySettings = True
         self.UpdateApplyButtonState()
 
+    def OnEditPSLoginText(self, event):
+        self.nAuth = (self.editProxySettingsLogin.GetValue(), self.nAuth[1])
+        self.dirtySettings = True
+        self.UpdateApplyButtonState()
+
+    def OnEditPSPasswordText(self, event):
+        self.nAuth = (self.nAuth[0], self.editProxySettingsPassword.GetValue())
+        self.dirtySettings = True
+        self.UpdateApplyButtonState()
+
     def OnBtnApply(self, event):
         self.dirtySettings = False
         self.UpdateApplyButtonState()
@@ -190,6 +218,7 @@ class PFNetworkPref ( PreferenceView):
         self.settings.setAddress(self.nAddr)
         self.settings.setPort(self.nPort)
         self.settings.setType(self.nType)
+        self.settings.setProxyAuthDetails(self.nAuth[0], self.nAuth[1])
 
     def UpdateApplyButtonState(self):
         if self.dirtySettings:
@@ -205,7 +234,7 @@ class PFNetworkPref ( PreferenceView):
 
         self.UpdateApplyButtonState()
 
-        if choice is not 2:
+        if choice is not service.settings.NetworkSettings.PROXY_MODE_MANUAL:
             self.ToggleProxySettings(False)
         else:
             self.ToggleProxySettings(True)
@@ -216,11 +245,19 @@ class PFNetworkPref ( PreferenceView):
             self.editProxySettingsAddr.Enable()
             self.stPSetPort.Enable()
             self.editProxySettingsPort.Enable()
+            self.stPSetLogin.Enable()
+            self.stPSetPassword.Enable()
+            self.editProxySettingsLogin.Enable()
+            self.editProxySettingsPassword.Enable()
         else:
             self.stPSetAddr.Disable()
             self.editProxySettingsAddr.Disable()
             self.stPSetPort.Disable()
             self.editProxySettingsPort.Disable()
+            self.stPSetLogin.Disable()
+            self.stPSetPassword.Disable()
+            self.editProxySettingsLogin.Disable()
+            self.editProxySettingsPassword.Disable()
 
     def getImage(self):
         return BitmapLoader.getBitmap("prefs_proxy", "gui")

--- a/service/network.py
+++ b/service/network.py
@@ -76,14 +76,16 @@ class Network():
 
         proxy = NetworkSettings.getInstance().getProxySettings()
         if proxy is not None:
-            # proxy is tuple of (host, port):  (u'192.168.20.1', 3128)
-            # build default proxy handler
-            proxy_handler = urllib2.ProxyHandler({'https': "{0}:{1}".format(proxy[0], proxy[1])})
+            # proxy is a tuple of (host, port):  (u'192.168.20.1', 3128)
             proxy_auth = NetworkSettings.getInstance().getProxyAuthDetails()
+            # proxy_auth is a tuple of (login, password) or None
             if proxy_auth is not None:
                 # add login:password@ in front of proxy address
-                new_proxy_address = '{0}:{1}@{2}:{3}'.format(proxy_auth[0], proxy_auth[1], proxy[0], proxy[1])
-                proxy_handler = urllib2.ProxyHandler({'https': new_proxy_address})
+                proxy_handler = urllib2.ProxyHandler({'https': '{0}:{1}@{2}:{3}'.format(
+                    proxy_auth[0], proxy_auth[1], proxy[0], proxy[1])})
+            else:
+                # build proxy handler with no login/pass info
+                proxy_handler = urllib2.ProxyHandler({'https': "{0}:{1}".format(proxy[0], proxy[1])})
             opener = urllib2.build_opener(proxy_handler)
             urllib2.install_opener(opener)
         else:

--- a/service/settings.py
+++ b/service/settings.py
@@ -229,6 +229,10 @@ class NetworkSettings():
             self.serviceNetworkSettings["login"] = None
             self.serviceNetworkSettings["password"] = None
             return
+        if login == "":  # empty login unsets proxy auth info
+            self.serviceNetworkSettings["login"] = None
+            self.serviceNetworkSettings["password"] = None
+            return
         self.serviceNetworkSettings["login"] = login
         self.serviceNetworkSettings["password"] = password
 

--- a/service/settings.py
+++ b/service/settings.py
@@ -113,6 +113,12 @@ class Settings():
 
 class NetworkSettings():
     _instance = None
+
+    # constants for serviceNetworkDefaultSettings["mode"] parameter
+    PROXY_MODE_NONE = 0        # 0 - No proxy
+    PROXY_MODE_AUTODETECT = 1  # 1 - Auto-detected proxy settings
+    PROXY_MODE_MANUAL = 2      # 2 - Manual proxy settings
+
     @classmethod
     def getInstance(cls):
         if cls._instance == None:
@@ -122,13 +128,18 @@ class NetworkSettings():
 
     def __init__(self):
 
-        # mode
-        # 0 - No proxy
-        # 1 - Auto-detected proxy settings
-        # 2 - Manual proxy settings
-        serviceNetworkDefaultSettings = {"mode": 1, "type": "https", "address": "", "port": "", "access": 15}
+        serviceNetworkDefaultSettings = {
+            "mode": self.PROXY_MODE_AUTODETECT,
+            "type": "https",
+            "address": "",
+            "port": "",
+            "access": 15,
+            "login": None,
+            "password": None
+        }
 
-        self.serviceNetworkSettings = SettingsProvider.getInstance().getSettings("pyfaServiceNetworkSettings", serviceNetworkDefaultSettings)
+        self.serviceNetworkSettings = SettingsProvider.getInstance().getSettings(
+            "pyfaServiceNetworkSettings", serviceNetworkDefaultSettings)
 
     def isEnabled(self, type):
         if type & self.serviceNetworkSettings["access"]:
@@ -198,12 +209,20 @@ class NetworkSettings():
 
     def getProxySettings(self):
 
-        if self.getMode() == 0:
+        if self.getMode() == self.PROXY_MODE_NONE:
             return None
-        if self.getMode() == 1:
+        if self.getMode() == self.PROXY_MODE_AUTODETECT:
             return self.autodetect()
-        if self.getMode() == 2:
+        if self.getMode() == self.PROXY_MODE_MANUAL:
             return (self.getAddress(), int(self.getPort()))
+
+    def getProxyAuthDetails(self):
+        if self.getMode() == self.PROXY_MODE_NONE:
+            return None
+        if (self.serviceNetworkSettings["login"] is None) or (self.serviceNetworkSettings["password"] is None):
+            return None
+        # in all other cases, return tuple of (login, password)
+        return (self.serviceNetworkSettings["login"], self.serviceNetworkSettings["password"])
 
 
 

--- a/service/settings.py
+++ b/service/settings.py
@@ -218,9 +218,9 @@ class NetworkSettings():
 
     def getProxyAuthDetails(self):
         if self.getMode() == self.PROXY_MODE_NONE:
-            return None
+            return ("", "")  # never return none, return tuple with empty strings
         if (self.serviceNetworkSettings["login"] is None) or (self.serviceNetworkSettings["password"] is None):
-            return None
+            return ("", "")  # never return none, return tuple with empty strings
         # in all other cases, return tuple of (login, password)
         return (self.serviceNetworkSettings["login"], self.serviceNetworkSettings["password"])
 

--- a/service/settings.py
+++ b/service/settings.py
@@ -224,6 +224,14 @@ class NetworkSettings():
         # in all other cases, return tuple of (login, password)
         return (self.serviceNetworkSettings["login"], self.serviceNetworkSettings["password"])
 
+    def setProxyAuthDetails(self, login, password):
+        if (login is None) or (password is None):
+            self.serviceNetworkSettings["login"] = None
+            self.serviceNetworkSettings["password"] = None
+            return
+        self.serviceNetworkSettings["login"] = login
+        self.serviceNetworkSettings["password"] = password
+
 
 
 """

--- a/service/settings.py
+++ b/service/settings.py
@@ -218,9 +218,9 @@ class NetworkSettings():
 
     def getProxyAuthDetails(self):
         if self.getMode() == self.PROXY_MODE_NONE:
-            return ("", "")  # never return none, return tuple with empty strings
+            return None
         if (self.serviceNetworkSettings["login"] is None) or (self.serviceNetworkSettings["password"] is None):
-            return ("", "")  # never return none, return tuple with empty strings
+            return None
         # in all other cases, return tuple of (login, password)
         return (self.serviceNetworkSettings["login"], self.serviceNetworkSettings["password"])
 


### PR DESCRIPTION
Related to issue #746 HTTP Proxy Username/Password
Briefly, changed 3 files:
- service/settings.py: add fields to store proxy login/pass in NetworkSettings class;
- service/network.py: use proxy login/pass info from NetworkSettings and prepend them to proxy address in form of login:password@host:port
- gui/builtinPreferenceViews/pyfaNetworkPreferences.py: GUI input fields to explicitly configure proxy login/pass

Now it looks like this:
 ![screenshot](http://puu.sh/rvknd/eb20b9cd30.png)
