### PR TITLE
Integrated Hacking Modules Give Double Bonus Incorrectly

### DIFF
--- a/eos/effects/minigamevirusstrengthbonus.py
+++ b/eos/effects/minigamevirusstrengthbonus.py
@@ -13,7 +13,5 @@
 type = "passive"
 def handler(fit, container, context):
     level = container.level if "skill" in context else 1
-    fit.modules.filteredItemIncrease(lambda mod: mod.item.requiresSkill("Hacking"),
-                                     "virusStrength", container.getModifiedItemAttr("virusStrengthBonus") * level)
-    fit.modules.filteredItemIncrease(lambda mod: mod.item.requiresSkill("Archaeology"),
+    fit.modules.filteredItemIncrease(lambda mod: (mod.item.requiresSkill("Hacking") or mod.item.requiresSkill("Archaeology")),
                                      "virusStrength", container.getModifiedItemAttr("virusStrengthBonus") * level)


### PR DESCRIPTION
Because integrated modules are a single module with both Data and Relic analizer built into one, ship hulls were giving a bonus twice over.
Changed it from adding the bonus for each individually (which worked fine when it was broken out) to simply adding it if either Hacking or Archaeology skill is present.