### PR TITLE
Subsystems calculate after projection calcs

### DIFF
--- a/eos/effects/subsystembonusamarrdefensive2remotearmorrepairamount.py
+++ b/eos/effects/subsystembonusamarrdefensive2remotearmorrepairamount.py
@@ -3,6 +3,7 @@
 # Used by:
 # Subsystem: Legion Defensive - Adaptive Augmenter
 type = "passive"
+runTime = "early"
 def handler(fit, module, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Remote Armor Repair Systems"),
                                   "armorDamageAmount", module.getModifiedItemAttr("subsystemBonusAmarrDefensive2"), skill="Amarr Defensive Systems")

--- a/eos/effects/subsystembonuscaldaridefensive2remoteshieldtransporteramount.py
+++ b/eos/effects/subsystembonuscaldaridefensive2remoteshieldtransporteramount.py
@@ -3,6 +3,7 @@
 # Used by:
 # Subsystem: Tengu Defensive - Adaptive Shielding
 type = "passive"
+runTime = "early"
 def handler(fit, module, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Shield Emission Systems"),
                                   "shieldBonus", module.getModifiedItemAttr("subsystemBonusCaldariDefensive2"), skill="Caldari Defensive Systems")

--- a/eos/effects/subsystembonusgallentedefensive2remotearmorrepairamount.py
+++ b/eos/effects/subsystembonusgallentedefensive2remotearmorrepairamount.py
@@ -3,6 +3,7 @@
 # Used by:
 # Subsystem: Proteus Defensive - Adaptive Augmenter
 type = "passive"
+runTime = "early"
 def handler(fit, module, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Remote Armor Repair Systems"),
                                   "armorDamageAmount", module.getModifiedItemAttr("subsystemBonusGallenteDefensive2"), skill="Gallente Defensive Systems")

--- a/eos/effects/subsystembonusminmatardefensive2remoteshieldtransporteramount.py
+++ b/eos/effects/subsystembonusminmatardefensive2remoteshieldtransporteramount.py
@@ -3,6 +3,7 @@
 # Used by:
 # Subsystem: Loki Defensive - Adaptive Shielding
 type = "passive"
+runTime = "early"
 def handler(fit, module, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Shield Emission Systems"),
                                   "shieldBonus", module.getModifiedItemAttr("subsystemBonusMinmatarDefensive2"), skill="Minmatar Defensive Systems")


### PR DESCRIPTION
Moved the 4 remote rep subsystem effect bonuses to calculate early in the engine.  This correctly calculates these bonuses for effects, previously these effect bonuses wouldn't be calculated until after projection calcs ran.
