### PR TITLE
Applied Mining Crystal Bonus to modules

### DIFF
--- a/eos/effects/mininginfomultiplier.py
+++ b/eos/effects/mininginfomultiplier.py
@@ -6,3 +6,5 @@
 type = "passive"
 def handler(fit, module, context):
     module.multiplyItemAttr("specialtyMiningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))
+    fit.modules.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Mining"),
+                              "miningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))

--- a/eos/effects/mininginfomultiplier.py
+++ b/eos/effects/mininginfomultiplier.py
@@ -5,6 +5,5 @@
 # Charges named like: Mining Crystal (32 of 32)
 type = "passive"
 def handler(fit, module, context):
-    module.multiplyItemAttr("specialtyMiningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))
-    fit.modules.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Mining"),
-                              "miningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))
+    #module.multiplyItemAttr("specialtyMiningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))
+    module.multiplyItemAttr("miningAmount", module.getModifiedChargeAttr("specialisationAsteroidYieldMultiplier"))


### PR DESCRIPTION
Previously the mining crystal bonus was not applied to modules, so adding a crystal didn't change the amount mined at all.  This now applies.  Left the old application in place, so it still applies to a nonsense `specialtyMiningAmount` stat if you want to see that seperated out for some weird reason.
