### PR TITLE
open fittings in new page by default

### DIFF
--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -64,6 +64,9 @@ class PFGeneralPref ( PreferenceView):
 
         self.cbExportCharges = wx.CheckBox( panel, wx.ID_ANY, u"Export loaded charges", wx.DefaultPosition, wx.DefaultSize, 0 )
         mainSizer.Add( self.cbExportCharges, 0, wx.ALL|wx.EXPAND, 5 )
+        
+        self.cbOpenFitInNew = wx.CheckBox( panel, wx.ID_ANY, u"Open fittings in a new page by default", wx.DefaultPosition, wx.DefaultSize, 0 )
+        mainSizer.Add( self.cbOpenFitInNew, 0, wx.ALL|wx.EXPAND, 5 )
 
         defCharSizer = wx.BoxSizer( wx.HORIZONTAL )
 
@@ -81,6 +84,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbMarketShortcuts.SetValue(self.sFit.serviceFittingOptions["showMarketShortcuts"] or False)
         self.cbGaugeAnimation.SetValue(self.sFit.serviceFittingOptions["enableGaugeAnimation"])
         self.cbExportCharges.SetValue(self.sFit.serviceFittingOptions["exportCharges"])
+        self.cbOpenFitInNew.SetValue(self.sFit.serviceFittingOptions["openFitInNew"])
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalCharStateChange)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalDmgPatternStateChange)
@@ -94,6 +98,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbMarketShortcuts.Bind(wx.EVT_CHECKBOX, self.onCBShowShortcuts)
         self.cbGaugeAnimation.Bind(wx.EVT_CHECKBOX, self.onCBGaugeAnimation)
         self.cbExportCharges.Bind(wx.EVT_CHECKBOX, self.onCBExportCharges)
+        self.cbOpenFitInNew.Bind(wx.EVT_CHECKBOX, self.onCBOpenFitInNew)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 
@@ -158,6 +163,9 @@ class PFGeneralPref ( PreferenceView):
 
     def onCBExportCharges(self, event):
         self.sFit.serviceFittingOptions["exportCharges"] = self.cbExportCharges.GetValue()
+    
+    def onCBOpenFitInNew(self, event):
+        self.sFit.serviceFittingOptions["openFitInNew"] = self.cbOpenFitInNew.GetValue()
 
     def getImage(self):
         return BitmapLoader.getBitmap("prefs_settings", "gui")

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -55,9 +55,11 @@ class FitSpawner(gui.multiSwitch.TabSpawner):
                 pass
         if count < 0:
             startup = getattr(event, "startup", False)  # see OpenFitsThread in gui.mainFrame
+            sFit = service.Fit.getInstance()
+            openFitInNew = sFit.serviceFittingOptions["openFitInNew"]
             mstate = wx.GetMouseState()
 
-            if mstate.CmdDown() or startup:
+            if mstate.CmdDown() or startup or openFitInNew:
                 self.multiSwitch.AddPage()
 
             view = FittingView(self.multiSwitch)

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -59,7 +59,7 @@ class FitSpawner(gui.multiSwitch.TabSpawner):
             openFitInNew = sFit.serviceFittingOptions["openFitInNew"]
             mstate = wx.GetMouseState()
 
-            if mstate.CmdDown() or startup or openFitInNew:
+            if (not openFitInNew and mstate.CmdDown()) or startup or (openFitInNew and not mstate.CmdDown()):
                 self.multiSwitch.AddPage()
 
             view = FittingView(self.multiSwitch)

--- a/service/fit.py
+++ b/service/fit.py
@@ -106,7 +106,9 @@ class Fit(object):
             "showTooltip": True,
             "showMarketShortcuts": False,
             "enableGaugeAnimation": True,
-            "exportCharges": True}
+            "exportCharges": True,
+            "openFitInNew":False
+            }
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(
             "pyfaServiceFittingOptions", serviceFittingDefaultOptions)
@@ -237,7 +239,6 @@ class Fit(object):
 
     def getFit(self, fitID, projected=False, basic=False):
         ''' Gets fit from database, and populates fleet data.
-
         Projected is a recursion flag that is set to reduce recursions into projected fits
         Basic is a flag to simply return the fit without any other processing
         '''
@@ -512,7 +513,6 @@ class Fit(object):
         """
         Moves cargo to fitting window. Can either do a copy, move, or swap with current module
         If we try to copy/move into a spot with a non-empty module, we swap instead.
-
         To avoid redundancy in converting Cargo item, this function does the
         sanity checks as opposed to the GUI View. This is different than how the
         normal .swapModules() does things, which is mostly a blind swap.
@@ -578,7 +578,6 @@ class Fit(object):
     def cloneModule(self, fitID, src, dst):
         """
         Clone a module from src to dst
-
         This will overwrite dst! Checking for empty module must be
         done at a higher level
         """
@@ -942,7 +941,6 @@ class Fit(object):
         Imports fits from file(s). First processes all provided paths and stores
         assembled fits into a list. This allows us to call back to the GUI as
         fits are processed as well as when fits are being saved.
-
         returns
         """
         defcodepage = locale.getpreferredencoding()


### PR DESCRIPTION
This is a new option for a pyfa behavior disturbing me since I started to use it: I have to press CTRL to open a fitting in a new tab - and I always mess it up...
With the option in "Preferences=> General" you can change the behavior to "Open fittings in a new page by default".
Every time you select a fitting, it will open a new page.
If the option is set, the behavior of CTRL is inverted and will open the fitting in the selected tab.
The option is set false by default.

I know it is no big thing, but as soon as you miss click, restore your fitting tabs the way you want needs a lot of clicks.
