### PR TITLE
Ship browser tooltip

### DIFF
--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -745,14 +745,18 @@ class ShipBrowser(wx.Panel):
             filter = subRacesFilter[ship.race] if ship.race else True
             if override:
                 filter = True
-
+            if ship.traits is not None:
+                shipTrait = ship.traits.traitText
+            else:
+                shipTrait = ""             
+                
             if self.filterShipsWithNoFits:
                 if fits>0:
                     if filter:                       
-                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, fits), ship.race))
+                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
             else:
                 if filter:
-                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, fits), ship.race))
+                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
 
         self.raceselect.RebuildRaces(racesList)
 
@@ -846,9 +850,13 @@ class ShipBrowser(wx.Panel):
 
         self._stage3ShipName = shipName
         self._stage3Data = shipID
+        if ship.traits is not None:
+            shipTrait = ship.traits.traitText 
+        else:
+            shipTrait = ""
 
         for ID, name, booster, timestamp in fitList:
-            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, ship.traits.traitText, name, booster, timestamp),shipID))
+            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp),shipID))
 
         self.lpane.RefreshList()
         self.lpane.Thaw()
@@ -882,11 +890,19 @@ class ShipBrowser(wx.Panel):
             fitList = sFit.searchFits(query)
             
             for ship in ships:
-                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, len(sFit.getFitsWithShip(ship.ID))), ship.race))
+                if ship.traits is not None:
+                    shipTrait = ship.traits.traitText
+                else:
+                    shipTrait =  ""
+                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, len(sFit.getFitsWithShip(ship.ID))), ship.race))
             
             for ID, name, shipID, shipName, booster, timestamp in fitList:
                 ship = sMkt.getItem(shipID)
-                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, ship.traits.traitText, name, booster, timestamp), shipID))
+                if ship.traits is not None: 
+                    shipTrait = ship.traits.traitText
+                else:
+                    shipTrait = ""   
+                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp), shipID))
             if len(ships) == 0 and len(fitList) == 0 :
                 self.lpane.AddWidget(PFStaticText(self.lpane, label = u"No matching results."))
             self.lpane.RefreshList(doFocus = False)
@@ -921,11 +937,15 @@ class ShipBrowser(wx.Panel):
 
         if fits:
             for fit in fits:
+                if fit.ship.traits is None:
+                    shipTrait = ""
+                else:
+                    shipTrait = fit.ship.traits.traitText  
                 self.lpane.AddWidget(FitItem(
                     self.lpane,
                     fit.ID, (
                         fit.ship.item.name,
-                        fit.ship.traits.traitText,
+                        shipTrait,
                         fit.name,
                         fit.booster,
                         fit.timestamp),
@@ -1460,8 +1480,8 @@ class FitItem(SFItem.SFBrowserItem):
         self.dragTLFBmp = None
 
         self.bkBitmap = None
-
-        self.SetToolTip(wx.ToolTip(self.shipName+'\n--------------------------\n'+self.shipTrait)) 
+        if self.shipTrait != "":
+            self.SetToolTip(wx.ToolTip(self.shipName+'\n--------------------------\n'+self.shipTrait)) 
         self.padding = 4
         self.editWidth = 150
 

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -743,17 +743,16 @@ class ShipBrowser(wx.Panel):
             fits = sFit.countFitsWithShip(ship.ID)
             t_fits += fits
             filter = subRacesFilter[ship.race] if ship.race else True
-            shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
             if override:
                 filter = True
 
             if self.filterShipsWithNoFits:
                 if fits>0:
                     if filter:                       
-                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
+                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, fits), ship.race))
             else:
                 if filter:
-                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
+                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, fits), ship.race))
 
         self.raceselect.RebuildRaces(racesList)
 
@@ -844,13 +843,12 @@ class ShipBrowser(wx.Panel):
 
         fitList.sort(key=self.nameKey)
         shipName = ship.name
-        shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
 
         self._stage3ShipName = shipName
         self._stage3Data = shipID
 
         for ID, name, booster, timestamp in fitList:
-            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp),shipID))
+            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, ship.traits.traitText, name, booster, timestamp),shipID))
 
         self.lpane.RefreshList()
         self.lpane.Thaw()
@@ -884,13 +882,11 @@ class ShipBrowser(wx.Panel):
             fitList = sFit.searchFits(query)
             
             for ship in ships:
-                shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
-                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, len(sFit.getFitsWithShip(ship.ID))), ship.race))
+                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, ship.traits.traitText, len(sFit.getFitsWithShip(ship.ID))), ship.race))
             
             for ID, name, shipID, shipName, booster, timestamp in fitList:
                 ship = sMkt.getItem(shipID)
-                shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
-                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp), shipID))
+                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, ship.traits.traitText, name, booster, timestamp), shipID))
             if len(ships) == 0 and len(fitList) == 0 :
                 self.lpane.AddWidget(PFStaticText(self.lpane, label = u"No matching results."))
             self.lpane.RefreshList(doFocus = False)
@@ -929,7 +925,7 @@ class ShipBrowser(wx.Panel):
                     self.lpane,
                     fit.ID, (
                         fit.ship.item.name,
-                        re.sub("<.*?>", " ", fit.ship.traits.traitText),
+                        fit.ship.traits.traitText,
                         fit.name,
                         fit.booster,
                         fit.timestamp),
@@ -1111,6 +1107,7 @@ class ShipItem(SFItem.SFBrowserItem):
 
         self.shipFittingInfo = shipFittingInfo
         self.shipName, self.shipTrait, self.shipFits = shipFittingInfo
+        self.shipTrait = re.sub("<.*?>", " ", self.shipTrait)
 
         self.newBmp = BitmapLoader.getBitmap("fit_add_small", "gui")
         self.acceptBmp = BitmapLoader.getBitmap("faccept_small", "gui")
@@ -1444,7 +1441,7 @@ class FitItem(SFItem.SFBrowserItem):
 
         self.shipFittingInfo = shipFittingInfo
         self.shipName, self.shipTrait, self.fitName, self.fitBooster, self.timestamp = shipFittingInfo
-
+        self.shipTrait = re.sub("<.*?>", " ", self.shipTrait)
         # see GH issue #62
         if self.fitBooster is None: self.fitBooster = False
 

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -1,4 +1,5 @@
 import wx
+import re
 import copy
 from gui.bitmapLoader import BitmapLoader
 import gui.mainFrame
@@ -742,17 +743,17 @@ class ShipBrowser(wx.Panel):
             fits = sFit.countFitsWithShip(ship.ID)
             t_fits += fits
             filter = subRacesFilter[ship.race] if ship.race else True
-
+            shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
             if override:
                 filter = True
 
             if self.filterShipsWithNoFits:
                 if fits>0:
-                    if filter:
-                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, fits), ship.race))
+                    if filter:                       
+                        self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
             else:
                 if filter:
-                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, fits), ship.race))
+                    self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, fits), ship.race))
 
         self.raceselect.RebuildRaces(racesList)
 
@@ -843,12 +844,13 @@ class ShipBrowser(wx.Panel):
 
         fitList.sort(key=self.nameKey)
         shipName = ship.name
+        shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
 
         self._stage3ShipName = shipName
         self._stage3Data = shipID
 
         for ID, name, booster, timestamp in fitList:
-            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, name, booster, timestamp),shipID))
+            self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp),shipID))
 
         self.lpane.RefreshList()
         self.lpane.Thaw()
@@ -880,12 +882,15 @@ class ShipBrowser(wx.Panel):
         if query:
             ships = sMkt.searchShips(query)
             fitList = sFit.searchFits(query)
-
+            
             for ship in ships:
-                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, len(sFit.getFitsWithShip(ship.ID))), ship.race))
-
+                shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
+                self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, len(sFit.getFitsWithShip(ship.ID))), ship.race))
+            
             for ID, name, shipID, shipName, booster, timestamp in fitList:
-                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, name, booster, timestamp), shipID))
+                ship = sMkt.getItem(shipID)
+                shipTrait = re.sub("<.*?>", " ", ship.traits.traitText)
+                self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp), shipID))
             if len(ships) == 0 and len(fitList) == 0 :
                 self.lpane.AddWidget(PFStaticText(self.lpane, label = u"No matching results."))
             self.lpane.RefreshList(doFocus = False)
@@ -924,6 +929,7 @@ class ShipBrowser(wx.Panel):
                     self.lpane,
                     fit.ID, (
                         fit.ship.item.name,
+                        re.sub("<.*?>", " ", fit.ship.traits.traitText),
                         fit.name,
                         fit.booster,
                         fit.timestamp),
@@ -1080,7 +1086,7 @@ class CategoryItem(SFItem.SFBrowserItem):
 
 
 class ShipItem(SFItem.SFBrowserItem):
-    def __init__(self, parent, shipID=None, shipFittingInfo=("Test", 2), itemData=None,
+    def __init__(self, parent, shipID=None, shipFittingInfo=("Test","TestTrait", 2), itemData=None,
                  id=wx.ID_ANY, pos=wx.DefaultPosition,
                  size=(0, 40), style=0):
         SFItem.SFBrowserItem.__init__(self, parent, size = size)
@@ -1104,7 +1110,7 @@ class ShipItem(SFItem.SFBrowserItem):
             self.shipBmp = BitmapLoader.getBitmap("ship_no_image_big", "gui")
 
         self.shipFittingInfo = shipFittingInfo
-        self.shipName, self.shipFits = shipFittingInfo
+        self.shipName, self.shipTrait, self.shipFits = shipFittingInfo
 
         self.newBmp = BitmapLoader.getBitmap("fit_add_small", "gui")
         self.acceptBmp = BitmapLoader.getBitmap("faccept_small", "gui")
@@ -1121,6 +1127,8 @@ class ShipItem(SFItem.SFBrowserItem):
             self.raceBmp = BitmapLoader.getBitmap("fit_delete_small","gui")
 
         self.raceDropShadowBmp = drawUtils.CreateDropShadowBitmap(self.raceBmp, 0.2)
+
+        self.SetToolTip(wx.ToolTip(self.shipTrait)) 
 
         self.shipBrowser = self.Parent.Parent
 
@@ -1198,7 +1206,7 @@ class ShipItem(SFItem.SFBrowserItem):
             self.newBtn.SetBitmap(self.newBmp)
             self.Refresh()
         else:
-            shipName, fittings = self.shipFittingInfo
+            shipName, shipTrait, fittings = self.shipFittingInfo
             if fittings > 0:
                 wx.PostEvent(self.shipBrowser, Stage3Selected(shipID=self.shipID, back=True))
             else:
@@ -1264,7 +1272,7 @@ class ShipItem(SFItem.SFBrowserItem):
 
         self.shipNamey = (rect.height - self.shipBmp.GetHeight()) / 2
 
-        shipName, fittings = self.shipFittingInfo
+        shipName, shipTrait, fittings = self.shipFittingInfo
 
         mdc.SetFont(self.fontBig)
         wtext, htext = mdc.GetTextExtent(shipName)
@@ -1303,7 +1311,7 @@ class ShipItem(SFItem.SFBrowserItem):
         mdc.DrawBitmap(self.raceDropShadowBmp, self.raceBmpx + 1, self.raceBmpy + 1)
         mdc.DrawBitmap(self.raceBmp,self.raceBmpx, self.raceBmpy)
 
-        shipName, fittings = self.shipFittingInfo
+        shipName, shipTrait, fittings = self.shipFittingInfo
 
         if fittings <1:
             fformat = "No fits"
@@ -1401,7 +1409,7 @@ class PFBitmapFrame(wx.Frame):
 
 
 class FitItem(SFItem.SFBrowserItem):
-    def __init__(self, parent, fitID=None, shipFittingInfo=("Test", "cnc's avatar", 0, 0 ), shipID = None, itemData=None,
+    def __init__(self, parent, fitID=None, shipFittingInfo=("Test", "TestTrait", "cnc's avatar", 0, 0 ), shipID = None, itemData=None,
                  id=wx.ID_ANY, pos=wx.DefaultPosition,
                  size=(0, 40), style=0):
 
@@ -1435,7 +1443,7 @@ class FitItem(SFItem.SFBrowserItem):
             self.shipBmp = BitmapLoader.getBitmap("ship_no_image_big","gui")
 
         self.shipFittingInfo = shipFittingInfo
-        self.shipName, self.fitName, self.fitBooster, self.timestamp = shipFittingInfo
+        self.shipName, self.shipTrait, self.fitName, self.fitBooster, self.timestamp = shipFittingInfo
 
         # see GH issue #62
         if self.fitBooster is None: self.fitBooster = False
@@ -1456,6 +1464,7 @@ class FitItem(SFItem.SFBrowserItem):
 
         self.bkBitmap = None
 
+        self.SetToolTip(wx.ToolTip(self.shipName+'\n--------------------------\n'+self.shipTrait)) 
         self.padding = 4
         self.editWidth = 150
 
@@ -1805,7 +1814,7 @@ class FitItem(SFItem.SFBrowserItem):
 
         mdc.DrawBitmap(self.shipBmp, self.shipBmpx, self.shipBmpy, 0)
 
-        shipName, fittings, booster, timestamp = self.shipFittingInfo
+        shipName, shipTrait, fittings, booster, timestamp = self.shipFittingInfo
 
         mdc.SetFont(self.fontNormal)
 

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -745,10 +745,8 @@ class ShipBrowser(wx.Panel):
             filter = subRacesFilter[ship.race] if ship.race else True
             if override:
                 filter = True
-            if ship.traits is not None:
-                shipTrait = ship.traits.traitText
-            else:
-                shipTrait = ""             
+
+            shipTrait = ship.traits.traitText if (ship.traits is not None) else ""  # empty string if no traits
                 
             if self.filterShipsWithNoFits:
                 if fits>0:
@@ -850,10 +848,8 @@ class ShipBrowser(wx.Panel):
 
         self._stage3ShipName = shipName
         self._stage3Data = shipID
-        if ship.traits is not None:
-            shipTrait = ship.traits.traitText 
-        else:
-            shipTrait = ""
+
+        shipTrait = ship.traits.traitText if (ship.traits is not None) else ""  # empty string if no traits
 
         for ID, name, booster, timestamp in fitList:
             self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp),shipID))
@@ -890,18 +886,14 @@ class ShipBrowser(wx.Panel):
             fitList = sFit.searchFits(query)
             
             for ship in ships:
-                if ship.traits is not None:
-                    shipTrait = ship.traits.traitText
-                else:
-                    shipTrait =  ""
+                shipTrait = ship.traits.traitText if (ship.traits is not None) else "" # empty string if no traits
+
                 self.lpane.AddWidget(ShipItem(self.lpane, ship.ID, (ship.name, shipTrait, len(sFit.getFitsWithShip(ship.ID))), ship.race))
             
             for ID, name, shipID, shipName, booster, timestamp in fitList:
                 ship = sMkt.getItem(shipID)
-                if ship.traits is not None: 
-                    shipTrait = ship.traits.traitText
-                else:
-                    shipTrait = ""   
+                shipTrait = ship.traits.traitText if (ship.traits is not None) else ""  # empty string if no traits
+
                 self.lpane.AddWidget(FitItem(self.lpane, ID, (shipName, shipTrait, name, booster, timestamp), shipID))
             if len(ships) == 0 and len(fitList) == 0 :
                 self.lpane.AddWidget(PFStaticText(self.lpane, label = u"No matching results."))
@@ -937,10 +929,8 @@ class ShipBrowser(wx.Panel):
 
         if fits:
             for fit in fits:
-                if fit.ship.traits is None:
-                    shipTrait = ""
-                else:
-                    shipTrait = fit.ship.traits.traitText  
+                shipTrait = fit.ship.traits.traitText if (fit.ship.traits is not None) else ""  # empty string if no traits
+
                 self.lpane.AddWidget(FitItem(
                     self.lpane,
                     fit.ID, (
@@ -1480,7 +1470,7 @@ class FitItem(SFItem.SFBrowserItem):
         self.dragTLFBmp = None
 
         self.bkBitmap = None
-        if self.shipTrait != "":
+        if self.shipTrait != "": # show no tooltip if no trait available
             self.SetToolTip(wx.ToolTip(self.shipName+'\n--------------------------\n'+self.shipTrait)) 
         self.padding = 4
         self.editWidth = 150


### PR DESCRIPTION
This will add trait tooltips to the shipbrowser.
-Category-View: no tooltips
-Ship-View: show trait as tooltip
-Fit-View&Search-View: show shiptype and trait as tooltip

the way how the browser handles the different items is "special" here and there but i think i finally got it.
Made a lot of crosstests to make sure the different stages are working fine.
Also, it was a request from @Sellec #786 