### PR TITLE
Activate fighter standard attack and limit active fighters

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -658,6 +658,13 @@ class Fit(object):
             '''
             if fighter is None:
                 fighter = eos.types.Fighter(item)
+                used = fit.getSlotsUsed(fighter.slot)
+                total = fit.getNumSlots(fighter.slot)
+                for ability in fighter.abilities:
+                    ability.active = True if ability.effect.isImplemented else False
+                if used >= total:
+                    fighter.active = False
+
                 if fighter.fits(fit) is True:
                     fit.fighters.append(fighter)
                 else:

--- a/service/fit.py
+++ b/service/fit.py
@@ -660,8 +660,20 @@ class Fit(object):
                 fighter = eos.types.Fighter(item)
                 used = fit.getSlotsUsed(fighter.slot)
                 total = fit.getNumSlots(fighter.slot)
+                standardAttackActive = False;
                 for ability in fighter.abilities:
-                    ability.active = True if ability.effect.isImplemented else False
+                    if (ability.effect.isImplemented and ability.effect.handlerName == u'fighterabilityattackm'):
+                        # Activate "standard attack" if available
+                        ability.active = True
+                        standardAttackActive = True
+                    else:
+                        # Activate all other abilities (Neut, Web, etc) except propmods if no standard attack is active
+                        if (ability.effect.isImplemented
+                            and standardAttackActive == False
+                            and ability.effect.handlerName != u'fighterabilitymicrowarpdrive'
+                            and ability.effect.handlerName != u'fighterabilityevasivemaneuvers'):
+                            ability.active = True
+
                 if used >= total:
                     fighter.active = False
 


### PR DESCRIPTION
  #755 @Rylleyryelle said: 
> i as a user, would much prefer to have to DISABLE what i dont want running on them, rather than having to enable every stupid bleepity bleeping thing every time i change out a fighter to tinker.
- Adding Fighters: Activate all implemented abilities by default
-- Because you don't add deactivated modules to fittings, too
-- The usability of fighters is not optimal, so let's make it a little bit easier for the daily use.
- Adding Fighters: Deactivate fighter groups if more than the maximum number of active fighters are in bay (soft limit)
--It is still possible to activate more fighter then allowed for testing, switching fighters, etc...