### PR TITLE
Make Effects Togglable

### DIFF
--- a/eos/db/saveddata/booster.py
+++ b/eos/db/saveddata/booster.py
@@ -31,6 +31,7 @@ boosters_table = Table("boosters", saveddata_meta,
                        Column("active", Boolean),
                        )
 
+# Legacy booster side effect code, should disable but a mapper relies on it.
 activeSideEffects_table = Table("boostersActiveSideEffects", saveddata_meta,
                                 Column("boosterID", ForeignKey("boosters.ID"), primary_key = True),
                                 Column("effectID", Integer, primary_key = True))

--- a/eos/effects/boosterarmorhppenalty.py
+++ b/eos/effects/boosterarmorhppenalty.py
@@ -3,5 +3,6 @@
 # Used by:
 # Implants from group: Booster (12 of 45)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.ship.boostItemAttr("armorHP", booster.getModifiedItemAttr("boosterArmorHPPenalty"))

--- a/eos/effects/boosterarmorrepairamountpenalty.py
+++ b/eos/effects/boosterarmorrepairamountpenalty.py
@@ -5,6 +5,7 @@
 # Implants named like: Mindflood Booster (3 of 4)
 # Implants named like: Sooth Sayer Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.group.name == "Armor Repair Unit",
                                   "armorDamageAmount", booster.getModifiedItemAttr("boosterArmorRepairAmountPenalty"))

--- a/eos/effects/boostercapacitorcapacitypenalty.py
+++ b/eos/effects/boostercapacitorcapacitypenalty.py
@@ -4,5 +4,6 @@
 # Implants named like: Blue Pill Booster (3 of 5)
 # Implants named like: Exile Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.ship.boostItemAttr("capacitorCapacity", booster.getModifiedItemAttr("boosterCapacitorCapacityPenalty"))

--- a/eos/effects/boostermaxvelocitypenalty.py
+++ b/eos/effects/boostermaxvelocitypenalty.py
@@ -3,5 +3,6 @@
 # Used by:
 # Implants from group: Booster (12 of 45)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.ship.boostItemAttr("maxVelocity", booster.getModifiedItemAttr("boosterMaxVelocityPenalty"))

--- a/eos/effects/boostermissileexplosioncloudpenaltyfixed.py
+++ b/eos/effects/boostermissileexplosioncloudpenaltyfixed.py
@@ -4,6 +4,7 @@
 # Implants named like: Exile Booster (3 of 4)
 # Implants named like: Mindflood Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Missile Launcher Operation"),
                                     "aoeCloudSize", booster.getModifiedItemAttr("boosterMissileAOECloudPenalty"))

--- a/eos/effects/boostermissileexplosionvelocitypenalty.py
+++ b/eos/effects/boostermissileexplosionvelocitypenalty.py
@@ -3,6 +3,7 @@
 # Used by:
 # Implants named like: Blue Pill Booster (3 of 5)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Missile Launcher Operation"),
                                     "aoeVelocity", booster.getModifiedItemAttr("boosterAOEVelocityPenalty"))

--- a/eos/effects/boostermissilevelocitypenalty.py
+++ b/eos/effects/boostermissilevelocitypenalty.py
@@ -4,6 +4,7 @@
 # Implants named like: Crash Booster (3 of 4)
 # Implants named like: X Instinct Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Missile Launcher Operation"),
                                     "maxVelocity", "boosterMissileVelocityPenalty")

--- a/eos/effects/boostershieldcapacitypenalty.py
+++ b/eos/effects/boostershieldcapacitypenalty.py
@@ -3,5 +3,6 @@
 # Used by:
 # Implants from group: Booster (12 of 45)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.ship.boostItemAttr("shieldCapacity", booster.getModifiedItemAttr("boosterShieldCapacityPenalty"))

--- a/eos/effects/boosterturretfalloffpenalty.py
+++ b/eos/effects/boosterturretfalloffpenalty.py
@@ -4,6 +4,7 @@
 # Implants named like: Drop Booster (3 of 4)
 # Implants named like: X Instinct Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Gunnery"),
                                   "falloff", booster.getModifiedItemAttr("boosterTurretFalloffPenalty"))

--- a/eos/effects/boosterturretoptimalrangepenalty.py
+++ b/eos/effects/boosterturretoptimalrangepenalty.py
@@ -5,6 +5,7 @@
 # Implants named like: Mindflood Booster (3 of 4)
 # Implants named like: Sooth Sayer Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Gunnery"),
                                   "maxRange", booster.getModifiedItemAttr("boosterTurretOptimalRange"))

--- a/eos/effects/boosterturrettrackingpenalty.py
+++ b/eos/effects/boosterturrettrackingpenalty.py
@@ -4,6 +4,7 @@
 # Implants named like: Exile Booster (3 of 4)
 # Implants named like: Frentix Booster (3 of 4)
 type = "boosterSideEffect"
+activeByDefault = False
 def handler(fit, booster, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Gunnery"),
                                   "trackingSpeed", booster.getModifiedItemAttr("boosterTurretTrackingPenalty"))

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -85,15 +85,25 @@ class Effect(EqBase):
 
     @property
     def activeByDefault(self):
-        '''
-        The runTime that this effect should be run at.
+        """
+        The state that this effect should be be in.
         This property is also automaticly fetched from effects/<effectName>.py if the file exists.
         the possible values are:
         None, True, False
-        None and False are equivalent. True is the default if the effect is also implemented.
 
-        effects that are not active will not be calculated.
-        '''
+        If this is not set:
+        We simply assume that missing/none = True, and set it accordingly
+        (much as we set runTime to Normalif not otherwise set).
+        Nearly all effect files will fall under this category.
+
+        If this is set to True:
+        We would enable it anyway, but hey, it's double enabled.
+        No effect files are currently configured this way (and probably will never be).
+
+        If this is set to False:
+        Basically we simply skip adding the effect to the effect handler when the effect is called,
+        much as if the run time didn't match or other criteria failed.
+        """
         if not self.__generated:
             self.__generateHandler()
 
@@ -101,8 +111,10 @@ class Effect(EqBase):
 
     @activeByDefault.setter
     def activeByDefault(self, value):
-        # Just assign the input values to the ``numbers`` attribute.
-        # You *could* do something more interesting here if you wanted.
+        """
+        Just assign the input values to the activeByDefault attribute.
+        You *could* do something more interesting here if you wanted.
+        """
         self.__activeByDefault = value
 
     @property

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -84,6 +84,28 @@ class Effect(EqBase):
         return self.__runTime
 
     @property
+    def activeByDefault(self):
+        '''
+        The runTime that this effect should be run at.
+        This property is also automaticly fetched from effects/<effectName>.py if the file exists.
+        the possible values are:
+        None, True, False
+        None and False are equivalent. True is the default if the effect is also implemented.
+
+        effects that are not active will not be calculated.
+        '''
+        if not self.__generated:
+            self.__generateHandler()
+
+        return self.__activeByDefault
+
+    @activeByDefault.setter
+    def activeByDefault(self, value):
+        # Just assign the input values to the ``numbers`` attribute.
+        # You *could* do something more interesting here if you wanted.
+        self.__activeByDefault = value
+
+    @property
     def type(self):
         '''
         The type of the effect, automaticly fetched from effects/<effectName>.py if the file exists.
@@ -134,6 +156,11 @@ class Effect(EqBase):
                 self.__runTime = "normal"
 
             try:
+                self.__activeByDefault = getattr(effectModule, "activeByDefault")
+            except AttributeError:
+                self.__activeByDefault = True
+
+            try:
                 t = getattr(effectModule, "type")
             except AttributeError:
                 t = None
@@ -143,6 +170,7 @@ class Effect(EqBase):
         except (ImportError, AttributeError) as e:
             self.__handler = effectDummy
             self.__runTime = "normal"
+            self.__activeByDefault = True
             self.__type = None
         except Exception as e:
             traceback.print_exc(e)

--- a/eos/saveddata/character.py
+++ b/eos/saveddata/character.py
@@ -330,7 +330,10 @@ class Skill(HandledItem):
             return
 
         for effect in item.effects.itervalues():
-            if effect.runTime == runTime and effect.isType("passive") and (not fit.isStructure or effect.isType("structure")):
+            if effect.runTime == runTime and \
+                    effect.isType("passive") and \
+                    (not fit.isStructure or effect.isType("structure")) and \
+                    effect.activeByDefault:
                 try:
                     effect.handler(fit, self, ("skill",))
                 except AttributeError:

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -220,8 +220,9 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
 
         for effect in self.item.effects.itervalues():
             if effect.runTime == runTime and \
-            ((projected == True and effect.isType("projected")) or \
-             projected == False and effect.isType("passive")):
+                effect.activeByDefault and \
+                ((projected == True and effect.isType("projected")) or \
+                 projected == False and effect.isType("passive")):
                 # See GH issue #765
                 if effect.getattr('grouped'):
                     effect.handler(fit, self, context)
@@ -233,7 +234,7 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
 
         if self.charge:
             for effect in self.charge.effects.itervalues():
-                if effect.runTime == runTime:
+                if effect.runTime == runTime and effect.activeByDefault:
                     effect.handler(fit, self, ("droneCharge",))
 
     def __deepcopy__(self, memo):

--- a/eos/saveddata/fighter.py
+++ b/eos/saveddata/fighter.py
@@ -260,6 +260,7 @@ class Fighter(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             if ability.active:
                 effect = ability.effect
                 if effect.runTime == runTime and \
+                effect.activeByDefault and \
                 ((projected and effect.isType("projected")) or not projected):
                     if ability.grouped:
                         effect.handler(fit, self, context)

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -435,7 +435,7 @@ class Fit(object):
         for name, info in self.gangBoosts.iteritems():
             # Unpack all data required to run effect properly
             effect, thing = info[1]
-            if effect.runTime == runTime:
+            if effect.runTime == runTime and effect.activeByDefault:
                 context = ("gang", thing.__class__.__name__.lower())
                 if isinstance(thing, Module):
                     if effect.isType("offline") or (effect.isType("passive") and thing.state >= State.ONLINE) or \

--- a/eos/saveddata/implant.py
+++ b/eos/saveddata/implant.py
@@ -88,7 +88,7 @@ class Implant(HandledItem, ItemAttrShortcut):
         if forceProjected: return
         if self.active == False: return
         for effect in self.item.effects.itervalues():
-            if effect.runTime == runTime and effect.isType("passive"):
+            if effect.runTime == runTime and effect.isType("passive") and effect.activeByDefault:
                 effect.handler(fit, self, ("implant",))
 
     @validates("fitID", "itemID", "active")

--- a/eos/saveddata/mode.py
+++ b/eos/saveddata/mode.py
@@ -50,5 +50,5 @@ class Mode(ItemAttrShortcut, HandledItem):
     def calculateModifiedAttributes(self, fit, runTime, forceProjected = False):
         if self.item:
             for effect in self.item.effects.itervalues():
-                if effect.runTime == runTime:
+                if effect.runTime == runTime and effect.activeByDefault:
                     effect.handler(fit, self, context = ("module",))

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -594,15 +594,16 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             # fix for #82 and it's regression #106
             if not projected or (self.projected and not forceProjected):
                 for effect in self.charge.effects.itervalues():
-                    if effect.runTime == runTime:
+                    if effect.runTime == runTime and effect.activeByDefault:
                         effect.handler(fit, self, ("moduleCharge",))
 
         if self.item:
             if self.state >= State.OVERHEATED:
                 for effect in self.item.effects.itervalues():
                     if effect.runTime == runTime and \
-                       effect.isType("overheat") and \
-                       not forceProjected:
+                            effect.isType("overheat") and \
+                            not forceProjected and \
+                            effect.activeByDefault:
                         effect.handler(fit, self, context)
 
             for effect in self.item.effects.itervalues():
@@ -610,7 +611,8 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
                 (effect.isType("offline") or
                 (effect.isType("passive") and self.state >= State.ONLINE) or \
                 (effect.isType("active") and self.state >= State.ACTIVE)) and \
-                ((projected and effect.isType("projected")) or not projected):
+                ((projected and effect.isType("projected")) or not projected) and \
+                effect.activeByDefault:
                         effect.handler(fit, self, context)
 
     @property

--- a/eos/saveddata/ship.py
+++ b/eos/saveddata/ship.py
@@ -78,7 +78,9 @@ class Ship(ItemAttrShortcut, HandledItem):
     def calculateModifiedAttributes(self, fit, runTime, forceProjected = False):
         if forceProjected: return
         for effect in self.item.effects.itervalues():
-            if effect.runTime == runTime and effect.isType("passive"):
+            if effect.runTime == runTime and \
+                    effect.isType("passive") and \
+                    effect.activeByDefault:
                 # Ships have effects that utilize the level of a skill as an
                 # additional operator to the modifier. These are defined in
                 # the effect itself, and these skillbooks are registered when

--- a/eos/types.py
+++ b/eos/types.py
@@ -34,7 +34,8 @@ from eos.saveddata.fighter import Fighter
 from eos.saveddata.cargo import Cargo
 from eos.saveddata.implant import Implant
 from eos.saveddata.implantSet import ImplantSet
-from eos.saveddata.booster import SideEffect
+# Legacy booster side effect code, disabling as not currently implemented
+# from eos.saveddata.booster import SideEffect
 from eos.saveddata.booster import Booster
 from eos.saveddata.fit import Fit, ImplantLocation
 from eos.saveddata.mode import Mode

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -740,31 +740,44 @@ class ItemRequirements ( wx.Panel ):
 
 class ItemEffects (wx.Panel):
     def __init__(self, parent, stuff, item):
-        wx.Panel.__init__ (self, parent)
-        mainSizer = wx.BoxSizer( wx.VERTICAL )
+        wx.Panel.__init__(self, parent)
+        self.item = item
+
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
 
         self.effectList = AutoListCtrl(self, wx.ID_ANY,
-                                     style =
-                                      #wx.LC_HRULES |
-                                      #wx.LC_NO_HEADER |
-                                      wx.LC_REPORT |wx.LC_SINGLE_SEL |wx.LC_VRULES |wx.NO_BORDER)
-        mainSizer.Add( self.effectList, 1, wx.ALL|wx.EXPAND, 0 )
-        self.SetSizer( mainSizer )
+                                       style=
+                                       # wx.LC_HRULES |
+                                       # wx.LC_NO_HEADER |
+                                       wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.LC_VRULES | wx.NO_BORDER)
+        mainSizer.Add(self.effectList, 1, wx.ALL | wx.EXPAND, 0)
+        self.SetSizer(mainSizer)
 
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnClick, self.effectList)
         if config.debug:
-            self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnClick, self.effectList)
+            self.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnRightClick, self.effectList)
+
+        self.PopulateList()
+
+    def PopulateList(self):
 
         self.effectList.InsertColumn(0,"Name")
-        self.effectList.InsertColumn(1,"Implemented")
+        self.effectList.InsertColumn(1,"Active")
+        self.effectList.InsertColumn(2, "Type")
         if config.debug:
-            self.effectList.InsertColumn(2,"ID")
+            self.effectList.InsertColumn(3, "Run Time")
+            self.effectList.InsertColumn(4,"ID")
 
         #self.effectList.SetColumnWidth(0,385)
 
         self.effectList.setResizeColumn(0)
+        self.effectList.SetColumnWidth(1,50)
+        self.effectList.SetColumnWidth(2, 80)
+        if config.debug:
+            self.effectList.SetColumnWidth(3, 65)
+            self.effectList.SetColumnWidth(4, 40)
 
-        self.effectList.SetColumnWidth(1,100)
-
+        item = self.item
         effects = item.effects
         names = list(effects.iterkeys())
         names.sort()
@@ -772,19 +785,55 @@ class ItemEffects (wx.Panel):
         for name in names:
             index = self.effectList.InsertStringItem(sys.maxint, name)
 
-            try:
-                implemented = "Yes" if effects[name].isImplemented else "No"
-            except:
-                implemented = "Erroneous"
+            if effects[name].isImplemented:
+                if effects[name].activeByDefault:
+                    activeByDefault = "Yes"
+                else:
+                    activeByDefault = "No"
+            else:
+                activeByDefault = ""
 
-            self.effectList.SetStringItem(index, 1, implemented)
+            effectTypeText = ""
+            if effects[name].type:
+                for effectType in effects[name].type:
+                    effectTypeText += effectType + " "
+                    pass
+
+            if effects[name].runTime and effects[name].isImplemented:
+                effectRunTime = str(effects[name].runTime)
+            else:
+                effectRunTime = ""
+
+            self.effectList.SetStringItem(index, 1, activeByDefault)
+            self.effectList.SetStringItem(index, 2, effectTypeText)
             if config.debug:
-                self.effectList.SetStringItem(index, 2, str(effects[name].ID))
+                self.effectList.SetStringItem(index, 3, effectRunTime)
+                self.effectList.SetStringItem(index, 4, str(effects[name].ID))
 
         self.effectList.RefreshRows()
         self.Layout()
 
     def OnClick(self, event):
+        """
+        Debug use: toggle effects on/off.
+        Affects *ALL* items that use that effect.
+        Is not stateful.  Will reset if Pyfa is closed and reopened.
+        """
+
+        try:
+            activeByDefault = getattr(self.item.effects[event.GetText()], "activeByDefault")
+            if activeByDefault:
+                setattr(self.item.effects[event.GetText()], "activeByDefault", False)
+            else:
+                setattr(self.item.effects[event.GetText()], "activeByDefault", True)
+
+        except AttributeError:
+            # Attribute doesn't exist, do nothing
+            pass
+
+        self.RefreshValues(event)
+
+    def OnRightClick(self, event):
         """
         Debug use: open effect file with default application.
         If effect file does not exist, create it
@@ -804,6 +853,14 @@ class ItemEffects (wx.Panel):
             import subprocess
             subprocess.call(["xdg-open", file])
 
+    def RefreshValues(self, event):
+        self.Freeze()
+        self.effectList.ClearAll()
+        self.PopulateList()
+        self.effectList.RefreshRows()
+        self.Layout()
+        self.Thaw()
+        event.Skip()
 
 ###########################################################################
 ## Class ItemAffectedBy


### PR DESCRIPTION
This does a few things.

1. "Implemented" got renamed to Active, and instead of a 2 value (Yes/No) option, it's a 3 value option (Yes, No, Blank).  Yes and No cover the old `isImplemented` Yes option (and represent if the effect is currently being calculated or not), while blank represents the old `isImplemented` No option.
2. Added a Type column.  This displays the types, and is mostly for debugging, but super useful if someone wants to toggle on drug side effects.
3. Added a run time column.  This is only shown when debug mode is on (so only shows when the ID column does).  Super useful for quickly seeing what stage an effect ran under.
4. Resized columns to better fit the various information they show.
5. Moved the debug only double left click to a double right click.  (Sorry @blitzmann !)
6. You can double left click on any effect to toggle it on/off (switch Active state from True to False and vice-versa).  If the effect isn't implemented, nothing happens.  (Way to bury the lede.)
7. Commented out the old booster side effect code.  This is maybe 50% implemented, and hasn't been touched in going on 4 years now.  Commenting out this code will speed up the execution of Pyfa a bit, and if someone down the line ever implements it, it can easily be put back.

This is implemented by introducing a new state called `activeByDefault`.  This is attached to the effect directly, which has some interesting side effects (more on that in a moment, also, pun intended).  So you can find it under (few quick examples):
```
fit.ship.item.effects[].activeByDefault
fit.modules[].item.effects[].activeByDefault
```

You can get the attribute (and also set the attribute) directly against *.effects[].

To use, simple add to an effect file (above `def handler`):
`activeByDefault = False`

This can be added to _any_ effect, though currently aside from booster side effects I can't think of any that we would want to add this to.

If this is not set:
We simply assume that missing/none = True, and set it accordingly (much as we set `runTime` to `Normal `if not otherwise set).  Nearly all effect files will fall under this category.

If this is set to `True`:
We would enable it anyway, but hey, it's double enabled.  No effect files are currently configured this way (and probably will never be).

If this is set to `False`:
Basically we simply skip adding the effect to the effect handler when the effect is called, much as if the run time didn't match or other criteria failed.


Okay, now for the caveats.

1. Toggling this doesn't trigger a refresh the fit calcs.  Not sure how to do this, maybe @blitzmann can chime in.  So once you toggle the effects, you need to modify the fit and trigger a refresh (simply turning a module off then back on works).
2. This _*is not*_ stateful between sessions.  If you close and reopen Pyfa, it will use the default values. (No plans to make this stateful between sessions as it's primarily a debugging tool.)
3. This _*IS*_ stateful within a session.  This is because it's tied to a _effect_, not a particular fit.  So if I turn on side effects for a drug, then _all_ fits with that same drug (or at least the same effects) will have those side effects (once recalculated).

And finally:
![How to toggle effects](https://puu.sh/sc9Rq/56c71f9bab.gif)