### PR TITLE
Drops null-sec.com as an option

### DIFF
--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -17,7 +17,6 @@ class PFHTMLExportPref ( PreferenceView):
             "in a regular web browser to open them at NULL-SEC.com or Osmium."
     desc2 = "Enabling automatic exporting will update the HTML file after any change "+\
             "to a fit is made. Under certain circumstance, this may cause performance issues."
-    desc3 = "Preferred website to view fits while not using in-game browser can be selected below."
     desc4 = "Export Fittings in a minmal HTML Version, just containing the Fittingslinks " +\
             "without any visual styling or javscript features"
 
@@ -59,35 +58,17 @@ class PFHTMLExportPref ( PreferenceView):
         self.exportEnabled.SetValue(self.HTMLExportSettings.getEnabled())
         self.exportEnabled.Bind(wx.EVT_CHECKBOX, self.OnExportEnabledChange)
         mainSizer.Add( self.exportEnabled, 0, wx.ALL|wx.EXPAND, 5 )
-        
-        
-        
+
+
+
         self.stDesc4 = wx.StaticText( panel, wx.ID_ANY, self.desc4, wx.DefaultPosition, wx.DefaultSize, 0 )
         self.stDesc4.Wrap(dlgWidth - 50)
-        mainSizer.Add( self.stDesc4, 0, wx.ALL, 5 )        
-        
+        mainSizer.Add( self.stDesc4, 0, wx.ALL, 5 )
+
         self.exportMinimal = wx.CheckBox( panel, wx.ID_ANY, u"Enable minimal export Format", wx.DefaultPosition, wx.DefaultSize, 0 )
         self.exportMinimal.SetValue(self.HTMLExportSettings.getMinimalEnabled())
         self.exportMinimal.Bind(wx.EVT_CHECKBOX, self.OnMinimalEnabledChange)
         mainSizer.Add( self.exportMinimal, 0, wx.ALL|wx.EXPAND, 5 )
-
-        self.stDesc3 = wx.StaticText( panel, wx.ID_ANY, self.desc3, wx.DefaultPosition, wx.DefaultSize, 0 )
-        self.stDesc3.Wrap(dlgWidth - 50)
-        mainSizer.Add( self.stDesc3, 0, wx.ALL, 5 )
-
-        websiteSizer = wx.BoxSizer( wx.HORIZONTAL )
-
-        self.stWebsite = wx.StaticText( panel, wx.ID_ANY, u"Website:", wx.DefaultPosition, wx.DefaultSize, 0 )
-        self.stWebsite.Wrap( -1 )
-        websiteSizer.Add( self.stWebsite, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
-
-        self.chWebsiteChoices = [ "o.smium.org", "null-sec.com" ]
-        self.chWebsiteType = wx.Choice( panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, self.chWebsiteChoices, 0 )
-        self.chWebsiteType.SetStringSelection( self.HTMLExportSettings.getWebsite() )
-        websiteSizer.Add( self.chWebsiteType, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
-        self.chWebsiteType.Bind(wx.EVT_CHOICE, self.OnCHWebsiteTypeSelect)
-
-        mainSizer.Add( websiteSizer, 0, wx.EXPAND, 5 )
 
         panel.SetSizer( mainSizer )
         panel.Layout()
@@ -106,13 +87,9 @@ class PFHTMLExportPref ( PreferenceView):
 
     def OnExportEnabledChange(self, event):
         self.HTMLExportSettings.setEnabled(self.exportEnabled.GetValue())
-        
+
     def OnMinimalEnabledChange(self, event):
         self.HTMLExportSettings.setMinimalEnabled(self.exportMinimal.GetValue())
-
-    def OnCHWebsiteTypeSelect(self, event):
-        choice = self.chWebsiteType.GetStringSelection()
-        self.HTMLExportSettings.setWebsite(choice)
 
     def getImage(self):
         return BitmapLoader.getBitmap("prefs_html", "gui")

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -45,14 +45,10 @@ class exportHtmlThread(threading.Thread):
 
         timestamp = time.localtime(time.time())
         localDate = "%d/%02d/%02d %02d:%02d" % (timestamp[0], timestamp[1], timestamp[2], timestamp[3], timestamp[4])
-        
+
         minimal = settings.getMinimalEnabled();
-        website = settings.getWebsite()
-        if website == "o.smium.org":
-            dnaUrl = "https://o.smium.org/loadout/dna/"
-        elif website == "null-sec.com":
-            dnaUrl = "https://null-sec.com/hangar/?dna="
-        
+        dnaUrl = "https://o.smium.org/loadout/dna/"
+
         if minimal:
             HTML = self.generateMinimalHTML(sMkt,sFit, dnaUrl)
         else:

--- a/service/settings.py
+++ b/service/settings.py
@@ -252,7 +252,7 @@ class HTMLExportSettings():
         return cls._instance
 
     def __init__(self):
-        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html', "website": "null-sec.com", "minimal": False }
+        serviceHTMLExportDefaultSettings = {"enabled": False, "path": config.pyfaPath + os.sep + 'pyfaFits.html', "minimal": False }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings("pyfaServiceHTMLExportSettings", serviceHTMLExportDefaultSettings)
 
     def getEnabled(self):
@@ -274,12 +274,6 @@ class HTMLExportSettings():
 
     def setPath(self, path):
         self.serviceHTMLExportSettings["path"] = path
-
-    def getWebsite(self):
-        return self.serviceHTMLExportSettings["website"]
-
-    def setWebsite(self, website):
-        self.serviceHTMLExportSettings["website"] = website
 
 """
 Settings used by update notification


### PR DESCRIPTION
It seems like it would be a good idea to make this user configurable so they could enter whatever domain they want.

However with this entire HTML export feature being questionable, I didn't go that far. https://github.com/pyfa-org/Pyfa/issues/825

closes: https://github.com/pyfa-org/Pyfa/issues/826