### PR TITLE
Groups drones before generating DNA

### DIFF
--- a/service/port.py
+++ b/service/port.py
@@ -792,8 +792,13 @@ class Port(object):
         for mod in mods:
             dna += ":{0};{1}".format(mod, mods[mod])
 
+        # drones are known to be in split stacks
+        groupedDrones = OrderedDict()
         for drone in fit.drones:
-            dna += ":{0};{1}".format(drone.itemID, drone.amount)
+            groupedDrones[drone.itemID] = groupedDrones.get(drone.itemID, 0) + drone.amount
+
+        for droneItemID in groupedDrones:
+            dna += ":{0};{1}".format(droneItemID, groupedDrones[droneItemID])
 
         for cargo in fit.cargo:
             # DNA format is a simple/dumb format. As CCP uses the slot information of the item itself


### PR DESCRIPTION
Drones can and often are in different stacks due to bandwidth and skills. The DNA would mess up in these cases because they would include duplicate ids with different numbers.

This commit groups the drones by the itemID before generating the DNA.

closes: https://github.com/pyfa-org/Pyfa/issues/367