### PR TITLE
Run recalc as a timer service

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -117,8 +117,8 @@ class Fit(object):
             "showMarketShortcuts": False,
             "enableGaugeAnimation": True,
             "exportCharges": True,
-            "openFitInNew":False
-            }
+            "openFitInNew": False
+        }
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(
             "pyfaServiceFittingOptions", serviceFittingDefaultOptions)
@@ -1213,21 +1213,12 @@ class Fit(object):
             else:
                 recalcJobID = schedule.enter(1, 1, self.triggerRecalc, args)
 
-            #schedule.run()
+                # schedule.run()
         else:
             logger.debug("Fit empty, skipping job creation.")
 
-
     def triggerRecalc(self):
-        global recalcJobID
-        if schedule.empty():
-            logger.debug("Scheduler empty")
-            pass
-        else:
-            pass
-
         logger.debug("Running recalc job")
-        # RecalcTimer = RecalcJob()
         self.RecalcTimer.resume()
 
 
@@ -1243,7 +1234,7 @@ class RecalcJob(threading.Thread):
         self.resume()  # unpause self
         while True:
             if self.paused:
-                #logger.debug("Nothing to run")
+                # logger.debug("Nothing to run")
                 if not schedule.empty():
                     if schedule.queue[0].time < time.time():
                         #  Check if we're past the scheduled time for the job, then run it
@@ -1317,7 +1308,7 @@ class RecalcJob(threading.Thread):
                         # fit.inited = True
                         logger.debug("=" * 10 + "recalc end" + "=" * 10)
 
-                #  Don't run the recalc again, unless something went wrong
+                # Don't run the recalc again, unless something went wrong
                 if not skipPause:
                     self.pause()
 

--- a/service/fit.py
+++ b/service/fit.py
@@ -1305,8 +1305,7 @@ class RecalcJob(threading.Thread):
                         skipPause = True
                         logger.debug("DB commit error")
 
-                        # fit.inited = True
-                        logger.debug("=" * 10 + "recalc end" + "=" * 10)
+                    logger.debug("=" * 10 + "recalc end" + "=" * 10)
 
                 # Don't run the recalc again, unless something went wrong
                 if not skipPause:


### PR DESCRIPTION
Replaces #735

So this does a couple things.

First off, we have a new thread that simply runs through a recalc.  There is a .5 second delay between runs, or a 1 second delay if we're in debug mode (because logging slows down the processing a lot, so since this is threaded we can run it faster than everything else can run).

The second half of this is we create a scheduled task to flag the thread that a recalc needs to be run, if something requests a recalc.  This creates the job on a 1 second delay, or 2 second if running in debug mode.

If a recalc is requested, we perform the following steps:
1. Check to see if a scheduler to run the recalc job already exists, if it does then destroy it and create a new one.  This allows the end user to indefinitely extend the delay before the recalc job is run, so we don't try and run the job while they're clicking around on things.
2. Once the scheduler timer is up, we flag the job to actually run the recalculations.
3. The scheduled task runs, saves to DB, recalcs, and refreshes the GUI.  If everything goes okay, it flags itself to not run anymore, if any exceptions occur we do _not_ set this so the recalculations will run again.

@blitzmann I think this is ready to merge.  We can play with the timing on it (shorten/lengthen it) if you want it to feel more/less responsive.  The down side to making it any shorter is that the recalc job might run while the user is still clicking around.  Of course if we take too long to trigger it, the user might think that Pyfa is slow.

This _drastically_ helps with things such as adding 8 guns, or 20 drones, etc.  The 1 second timer for the scheduler seems to work for me for doing things such as duplicating objects (turrets with ammo, for example), a shorter delay results in the job running before I'm done with the task I'm doing.

The threaded job could be shortened as well.  However, if I ran it too quickly (especially when in debug mode), it'll run fast enough to step on itself and this causes things like the DB isn't ready, so we get weird DB errors, or the fit object isn't fully created so `fit.clear()` fails.  This _may_ be why it's run 2-3 times, because things _seem_ to calculate correctly running it only once if we slow things down a bit.

And of course, if there _is_ an error on one of the DB commits, or `fit.clear()`, etc, we will rerun the recalc job again, to hopefully clear it up.  This seems to work fine, but by slowing it down a bit (hence the .1 second delays you see in the job) we don't seem to run into these.  Even though we're adding 200 ms to the job (plus the time it takes to actually run it), we're no longer running it 3 times, so it's a net win.

Play around with it, and let me know what you think. 