### PR TITLE
Add ability to sort compare list

### DIFF
--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -628,11 +628,23 @@ class ItemCompare(wx.Panel):
             self.paramList.SetStringItem(i, len(self.attrs)+1, formatAmount(price.price, 3, 3, 9, currency=True))
 
     def PopulateList(self, sort=None):
-        if sort:
+        if sort is not None:
             if isinstance(sort, basestring):
-                # Do nothing to the string
-                pass
-            if not isinstance(sort, basestring):
+                # A string was passed in, see if we can sort by that attribute name
+                try:
+                    sort = str(self.attrs.keys()[sort])
+                except IndexError:
+                    # attribute must not exist
+                    sort = None
+            elif isinstance(sort, int) and sort == 0:
+                try:
+                    # Column 0 is the name.  We can't sort by name (it's not an attribute),
+                    # BUT we CAN default back to the metaLevel sorting
+                    sort = 'metaLevel'
+                except IndexError:
+                    # Clicked on a column that's not part of our array (price most likely)
+                    sort = None
+            elif isinstance(sort, int):
                 try:
                     # Remember to reduce by 1, because the attrs array
                     # starts at 0 while the list has the item name as column 0.
@@ -640,10 +652,7 @@ class ItemCompare(wx.Panel):
                 except IndexError:
                     # Clicked on a column that's not part of our array (price most likely)
                     sort = None
-            else:
-                sort = None
-        else:
-            sort = None
+
 
         self.items = sorted(self.items,key=lambda x: x.attributes[sort].value if sort in x.attributes else None)
 

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -599,6 +599,13 @@ class ItemCompare(wx.Panel):
         self.PopulateList()
 
         self.toggleViewBtn.Bind(wx.EVT_TOGGLEBUTTON, self.ToggleViewMode)
+        self.Bind(wx.EVT_LIST_COL_CLICK, self.SortCompareCols)
+
+    def SortCompareCols(self,event):
+        self.Freeze()
+        self.paramList.ClearAll()
+        self.PopulateList(event.Column)
+        self.Thaw()
 
     def UpdateList(self):
         self.Freeze()
@@ -620,7 +627,26 @@ class ItemCompare(wx.Panel):
         for i, price in enumerate(prices):
             self.paramList.SetStringItem(i, len(self.attrs)+1, formatAmount(price.price, 3, 3, 9, currency=True))
 
-    def PopulateList(self):
+    def PopulateList(self, sort=None):
+        if sort:
+            if isinstance(sort, basestring):
+                # Do nothing to the string
+                pass
+            if not isinstance(sort, basestring):
+                try:
+                    # Remember to reduce by 1, because the attrs array
+                    # starts at 0 while the list has the item name as column 0.
+                    sort = str(self.attrs.keys()[sort - 1])
+                except IndexError:
+                    # Clicked on a column that's not part of our array (price most likely)
+                    sort = None
+            else:
+                sort = None
+        else:
+            sort = None
+
+        self.items = sorted(self.items,key=lambda x: x.attributes[sort].value if sort in x.attributes else None)
+
         self.paramList.InsertColumn(0, "Item")
         self.paramList.SetColumnWidth(0, 200)
 


### PR DESCRIPTION
See: https://puu.sh/swp4e/058450d696.gif

You can pass in either the column number or the attribute name to sort on.  We attempt to handle it cleanly, and default back to no sorting if something goes wrong.

The sort parameter is not required, so anything else using it won't break.

We don't handle reverse sorts (clicking on the column header twice) and for `reasons` sometimes it sorts up and sometimes it sorts down.  Most likely has to do with different types, but not terribly worried about it.

Also, since Name and Price aren't part of the `attrs` array we can't sort on those.  If you click on those columns, it doesn't sort at all, to prevent various issues.

@blitzmann this is ready to be merged.