### PR TITLE
Patch 1105543

### DIFF
--- a/eos/effects/modulebonusfightersupportunit.py
+++ b/eos/effects/modulebonusfightersupportunit.py
@@ -6,16 +6,16 @@ type = "passive"
 
 
 def handler(fit, src, context):
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "shieldCapacity",
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"), "shieldCapacity",
                                    src.getModifiedItemAttr("fighterBonusShieldCapacityPercent"))
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "maxVelocity",
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"), "maxVelocity",
                                    src.getModifiedItemAttr("fighterBonusVelocityPercent"), stackingPenalties=True)
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"),
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"),
                                    "fighterAbilityAttackMissileDuration",
                                    src.getModifiedItemAttr("fighterBonusROFPercent"), stackingPenalties=True)
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "fighterAbilityAttackTurretDuration",
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"), "fighterAbilityAttackTurretDuration",
                                    src.getModifiedItemAttr("fighterBonusROFPercent"), stackingPenalties=True)
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "fighterAbilityMissilesDuration",
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"), "fighterAbilityMissilesDuration",
                                    src.getModifiedItemAttr("fighterBonusROFPercent"), stackingPenalties=True)
-    fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "shieldRechargeRate",
+    fit.fighters.filteredItemMultiply(lambda mod: mod.item.requiresSkill("Fighters"), "shieldRechargeRate",
                                    src.getModifiedItemAttr("fighterBonusShieldRechargePercent"))

--- a/eos/effects/shipbonuscommanddestroyerrole1defenderbonus.py
+++ b/eos/effects/shipbonuscommanddestroyerrole1defenderbonus.py
@@ -1,0 +1,6 @@
+type = "passive"
+
+
+def handler(fit, ship, context):
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Defender Missiles"),
+                                  "moduleReactivationDelay", ship.getModifiedItemAttr("shipBonusRole1"))

--- a/eos/effects/skillmultiplierdefendermissilevelocity.py
+++ b/eos/effects/skillmultiplierdefendermissilevelocity.py
@@ -1,0 +1,6 @@
+type = "passive"
+
+
+def handler(fit, skill, context):
+    fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Defender Missiles"),
+                                    "maxVelocity", skill.getModifiedItemAttr("missileVelocityBonus") * skill.level)

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -265,7 +265,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             flightTime = self.getModifiedChargeAttr("explosionDelay") / 1000.0
             mass = self.getModifiedChargeAttr("mass")
             agility = self.getModifiedChargeAttr("agility")
-            if maxVelocity and flightTime and mass and agility:
+            if maxVelocity and (flightTime or mass or agility):
                 accelTime = min(flightTime, mass * agility / 1000000)
                 # Average distance done during acceleration
                 duringAcceleration = maxVelocity / 2 * accelTime


### PR DESCRIPTION
Update DB.  Find changes here:
https://gist.github.com/Ebag333/32221b0adb06cc11e224b73830aacc66

Add effect for defender missile launchers (add 50% RoF bonus on command dessies).

Also fixed the effect for `Fighter Support Unit`.  CCP changed it from a percent to a multiple when they fixed the issue where it made the shield tank worse instead of better.
```
[*] Hermes Compact Fighter Support Unit
  [*] fighterBonusROFPercent: -5.5 => 0.945
  [*] fighterBonusShieldCapacityPercent: 5.5 => 1.055
  [*] fighterBonusShieldRechargePercent: 5.5 => 0.945
  [*] fighterBonusVelocityPercent: 5.5 => 1.055
```

One thing left to investigate (though nothing preventing this from being merged).  I _believe_ that there's an effect on the defender skill to increase range.  That hasn't been implemented yet.

Speaking of range, range is broken on the defender missiles because of the formula we use.  Defender missiles have agility of 0, so just had to allow that to pass into the calcs (use or instead of and, since python counts `agility = 0` the same as `agility = False`).