### PR TITLE
Remembers user's meta filtering choices

### DIFF
--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -94,26 +94,23 @@ class MarketBrowser(wx.Panel):
 
     def toggleMetaButton(self, event):
         """Process clicks on toggle buttons"""
-        ctrl = wx.GetMouseState().CmdDown()
-        ebtn = event.EventObject
-        if not ctrl:
-            for btn in self.metaButtons:
-                if btn.Enabled:
-                    btn.setUserSelection(btn == ebtn)
-        else:
-            # Note: using the 'wrong' value for clicked button might seem weird,
-            # But the button is toggled by wx and we should deal with it
-            activeBtns = set()
-            for btn in self.metaButtons:
-                if (btn.GetValue() is True and btn != ebtn) or (btn.GetValue() is False and btn == ebtn):
-                    activeBtns.add(btn)
-            # Do 'nothing' if we're trying to turn last active button off
-            if len(activeBtns) == 1 and activeBtns.pop() == ebtn:
+        appendMeta = wx.GetMouseState().CmdDown()
+        clickedBtn = event.EventObject
+
+        if appendMeta:
+            activeBtns = [btn for btn in self.metaButtons if btn.GetValue()]
+            if activeBtns:
+                clickedBtn.setUserSelection(clickedBtn.GetValue())
+                self.itemView.filterItemStore()
+            else:
+                # Do 'nothing' if we're trying to turn last active button off
                 # Keep button in the same state
-                ebtn.setUserSelection(True)
-                return
-        # Leave old unfiltered list contents, just re-filter them and show
-        self.itemView.filterItemStore()
+                clickedBtn.setUserSelection(True)
+        else:
+            for btn in self.metaButtons:
+                btn.setUserSelection(btn == clickedBtn)
+
+            self.itemView.filterItemStore()
 
     def jump(self, item):
         self.marketView.jump(item)


### PR DESCRIPTION
There is a lot of logic that overwrites the user's choices of meta
filtering on every search.

That's a little too clever. Especially if the user is looking for
different variations of a certain meta.

If a user wants to include the other meta buttons they can re-add them
after filtering.

Extra care has to be taken with Windows. If a button is Enabled=False AND
SetValue=True, then it looks like it's Enabled=True, but clicking it
doesn't do anything. So we handle that logic in it's own class

closes: https://github.com/pyfa-org/Pyfa/issues/818
take 2 of: https://github.com/pyfa-org/Pyfa/pull/829

---

This branch is against the current Pyfa master. To quickly see the difference between my last branch and this branch you can run: `$ git diff cfa57a70dc17a8f80bff2e354498372fa42534cd -- gui/marketBrowser.py`