### PR TITLE
Stop overriding copy/paste on macOS

### DIFF
--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -51,10 +51,6 @@ class MainMenuBar(wx.MenuBar):
         self.toggleOverridesId = wx.NewId()
         self.importDatabaseDefaultsId = wx.NewId()
 
-        if 'wxMac' in wx.PlatformInfo and wx.VERSION >= (3,0):
-            wx.ID_COPY = wx.NewId()
-            wx.ID_PASTE = wx.NewId()
-
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         wx.MenuBar.__init__(self)
 


### PR DESCRIPTION
For some reason this causes issues on wxMac 3.0.2.0. The menu accelerators hijack the shortcut and won't allow typical text manipulation inside of text controls.

There's some discussion about this happening for other people in:

* http://trac.wxwidgets.org/ticket/11320
* http://trac.wxwidgets.org/ticket/14953

I have not tested this in wxMac 2.8

This is to fix:

* https://github.com/pyfa-org/Pyfa/issues/490
* https://github.com/pyfa-org/Pyfa/issues/899
* https://github.com/pyfa-org/Pyfa/issues/877
* https://github.com/pyfa-org/Pyfa/issues/887

But I'm not sure if it reverts the fix for: https://github.com/pyfa-org/Pyfa/issues/456#issuecomment-161885962