### PR TITLE
Database Validation and Cleanup

### DIFF
--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -40,13 +40,9 @@ class DatabaseCleanup:
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM characterSkills "
                                                "WHERE characterID NOT IN (SELECT ID from characters)")
 
-            count_results = 0
-            for result in results:
-                count_results = result[0]
-                break
+            row = results.first()
 
-            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
-            if count_results > 0:
+            if row and row['num'] > 0:
                 delete = saveddata_engine.execute("DELETE FROM characterSkills WHERE characterID NOT IN (SELECT ID from characters)")
                 logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
 
@@ -62,13 +58,9 @@ class DatabaseCleanup:
             logger.debug("Running database cleanup for orphaned damage patterns attached to fits.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE damagePatternID not in (select ID from damagePatterns)")
 
-            count_results = 0
-            for result in results:
-                count_results = result[0]
-                break
+            row = results.first()
 
-            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
-            if count_results > 0:
+            if row and row['num'] > 0:
                 # Get Uniform damage pattern ID
                 uniform_results = saveddata_engine.execute("select ID from damagePatterns WHERE name = 'Uniform'")
 
@@ -97,13 +89,9 @@ class DatabaseCleanup:
             logger.debug("Running database cleanup for orphaned characters attached to fits.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE characterID NOT IN (SELECT ID FROM characters)")
 
-            count_results = 0
-            for result in results:
-                count_results = result[0]
-                break
+            row = results.first()
 
-            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
-            if count_results > 0:
+            if row and row['num'] > 0:
                 # Get All 5 character ID
                 all5_results = saveddata_engine.execute("SELECT ID FROM characters WHERE name = 'All 5'")
 

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -1,0 +1,122 @@
+# ===============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# ===============================================================================
+
+import sqlalchemy
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseCleanup:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def OrphanedCharacterSkills(saveddata_engine):
+        # Finds and fixes database corruption issues.
+        logger.debug("Start databsae validation and cleanup.")
+
+        # Find orphaned character skills.
+        # This solves an issue where the character doesn't exist, but skills for that character do.
+        # See issue #917
+        try:
+            logger.debug("Running database cleanup for character skills.")
+            results = saveddata_engine.execute("SELECT * FROM characterSkills "
+                                               "WHERE characterID NOT IN (SELECT ID from characters)")
+
+            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
+            result_count = 0
+            for _ in results:
+                result_count += 1
+
+            if result_count > 0:
+                logger.error("Database corruption found. Cleaning up %d records.", result_count)
+                saveddata_engine.execute("DELETE FROM characterSkills WHERE characterID NOT IN (SELECT ID from characters)")
+        except sqlalchemy.exc.DatabaseError:
+            logger.error("Failed to connect to database.")
+
+    @staticmethod
+    def OrphanedFitDamagePatterns(saveddata_engine):
+        # Find orphaned damage patterns.
+        # This solves an issue where the damage pattern doesn't exist, but fits reference the pattern.
+        # See issue #777
+        try:
+            logger.debug("Running database cleanup for orphaned damage patterns attached to fits.")
+            results = saveddata_engine.execute("SELECT * FROM fits WHERE damagePatternID not in (select ID from damagePatterns)")
+
+            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
+            result_count = 0
+            for _ in results:
+                result_count += 1
+
+            if result_count > 0:
+                # Get Uniform damage pattern ID
+                uniform_results = saveddata_engine.execute("select ID from damagePatterns WHERE name = 'Uniform'")
+
+                uniform_result_count = 0
+                uniform_damage_pattern_id = 0
+                for uniform_result in uniform_results:
+                    uniform_damage_pattern_id = uniform_result[0]
+                    uniform_result_count += 1
+
+                if uniform_result_count == 0:
+                    logger.error("Missing uniform damage pattern.")
+                elif uniform_result_count > 1:
+                    logger.error("More than one uniform damage pattern found.")
+                else:
+                    logger.error("Database corruption found. Cleaning up %d records.", result_count)
+                    saveddata_engine.execute("UPDATE 'fits' SET 'damagePatternID' = ? "
+                                             "WHERE damagePatternID NOT IN (SELECT ID FROM damagePatterns)",
+                                             uniform_damage_pattern_id)
+        except sqlalchemy.exc.DatabaseError:
+            logger.error("Failed to connect to database.")
+
+    @staticmethod
+    def OrphanedFitCharacterIDs(saveddata_engine):
+        # Find orphaned character IDs. This solves an issue where the chaaracter doesn't exist, but fits reference the pattern.
+        try:
+            logger.debug("Running database cleanup for orphaned characters attached to fits.")
+            results = saveddata_engine.execute("SELECT * FROM fits WHERE characterID NOT IN (SELECT ID FROM characters)")
+
+            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
+            result_count = 0
+            for _ in results:
+                result_count += 1
+
+            if result_count > 0:
+                # Get All 5 character ID
+                all5_results = saveddata_engine.execute("SELECT ID FROM characters WHERE name = 'All 5'")
+
+                all5_result_count = 0
+                all5_id = 0
+                for all5_result in all5_results:
+                    all5_id = all5_result[0]
+                    all5_result_count += 1
+
+                if all5_result_count == 0:
+                    logger.error("Missing 'All 5' character.")
+                elif all5_result_count > 1:
+                    logger.error("More than one 'All 5' character found.")
+                else:
+                    logger.error("Database corruption found. Cleaning up %d records.", result_count)
+                    saveddata_engine.execute("UPDATE 'fits' SET 'damagePatternID' = ? "
+                                             "WHERE damagePatternID not in (select ID from damagePatterns)",
+                                             all5_id)
+        except sqlalchemy.exc.DatabaseError:
+            logger.error("Failed to connect to database.")

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -40,7 +40,13 @@ class DatabaseCleanup:
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM characterSkills "
                                                "WHERE characterID NOT IN (SELECT ID from characters)")
 
-            if results.fetchone()['num'] > 0:
+            count_results = 0
+            for result in results:
+                count_results = result[0]
+                break
+
+            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
+            if count_results > 0:
                 delete = saveddata_engine.execute("DELETE FROM characterSkills WHERE characterID NOT IN (SELECT ID from characters)")
                 logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
 
@@ -56,7 +62,13 @@ class DatabaseCleanup:
             logger.debug("Running database cleanup for orphaned damage patterns attached to fits.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE damagePatternID not in (select ID from damagePatterns)")
 
-            if results.fetchone()['num'] > 0:
+            count_results = 0
+            for result in results:
+                count_results = result[0]
+                break
+
+            # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
+            if count_results > 0:
                 # Get Uniform damage pattern ID
                 uniform_results = saveddata_engine.execute("select ID from damagePatterns WHERE name = 'Uniform'")
 
@@ -80,13 +92,18 @@ class DatabaseCleanup:
 
     @staticmethod
     def OrphanedFitCharacterIDs(saveddata_engine):
-        # Find orphaned character IDs. This solves an issue where the chaaracter doesn't exist, but fits reference the pattern.
+        # Find orphaned character IDs. This solves an issue where the character doesn't exist, but fits reference the pattern.
         try:
             logger.debug("Running database cleanup for orphaned characters attached to fits.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE characterID NOT IN (SELECT ID FROM characters)")
 
+            count_results = 0
+            for result in results:
+                count_results = result[0]
+                break
+
             # Count how many records exist.  This is ugly, but SQLAlchemy doesn't return a count from a select query.
-            if results.fetchone()['num'] > 0:
+            if count_results > 0:
                 # Get All 5 character ID
                 all5_results = saveddata_engine.execute("SELECT ID FROM characters WHERE name = 'All 5'")
 

--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -407,6 +407,22 @@ def getCrestCharacter(lookfor, eager=None):
         raise TypeError("Need integer or string as argument")
     return character
 
+def executeDatabaseQuery(saveddata_engine, query):
+    # Executes a query against the database, and returns a dict instead of a resultsproxy
+    results = saveddata_engine.execute(query)
+
+    return_list = []
+
+    for row in results:
+        internal_row = {}
+        for key in row._keymap:
+            idx = row._keymap[key][2]
+            internal_row.update({key: row._row[idx]})
+
+        return_list.append(internal_row)
+
+    return return_list
+
 def getOverrides(itemID, eager=None):
     if isinstance(itemID, int):
         return saveddata_session.query(Override).filter(Override.itemID == itemID).all()

--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -407,22 +407,6 @@ def getCrestCharacter(lookfor, eager=None):
         raise TypeError("Need integer or string as argument")
     return character
 
-def executeDatabaseQuery(saveddata_engine, query):
-    # Executes a query against the database, and returns a dict instead of a resultsproxy
-    results = saveddata_engine.execute(query)
-
-    return_list = []
-
-    for row in results:
-        internal_row = {}
-        for key in row._keymap:
-            idx = row._keymap[key][2]
-            internal_row.update({key: row._row[idx]})
-
-        return_list.append(internal_row)
-
-    return return_list
-
 def getOverrides(itemID, eager=None):
     if isinstance(itemID, int):
         return saveddata_session.query(Override).filter(Override.itemID == itemID).all()

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -23,6 +23,11 @@ import os
 import eos.types
 import eos.db.migration as migration
 from eos.db.saveddata.loadDefaultDatabaseValues import DefaultDatabaseValues
+from eos.db.saveddata.databaseRepair import DatabaseCleanup
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class PrefetchThread(threading.Thread):
     def run(self):
@@ -55,6 +60,14 @@ if os.path.isfile(config.saveDB):
     # Import default database values
     # Import values that must exist otherwise Pyfa breaks
     DefaultDatabaseValues.importRequiredDefaults()
+
+    logging.debug("Starting database validation.")
+    database_cleanup_instance = DatabaseCleanup()
+    database_cleanup_instance.OrphanedCharacterSkills(eos.db.saveddata_engine)
+    database_cleanup_instance.OrphanedFitCharacterIDs(eos.db.saveddata_engine)
+    database_cleanup_instance.OrphanedFitDamagePatterns(eos.db.saveddata_engine)
+    logging.debug("Completed database validation.")
+
 else:
     # If database does not exist, do not worry about migration. Simply
     # create and set version
@@ -67,4 +80,3 @@ else:
     DefaultDatabaseValues.importDamageProfileDefaults()
     # Import default values for target resist profiles
     DefaultDatabaseValues.importResistProfileDefaults()
-


### PR DESCRIPTION
This addresses three issues:

1. Character skills exist for a character that doesn't.  See #917
2. Damage pattern on a fit is set to a damage pattern that doesn't exist.  See #777
3. Character on a fit is set to a character that doesn't exist. (Can't find which issue mentioned this.)

@blitzmann I know that you wanted to avoid running database validation and cleanup each time, but I don't think it's avoidable.  We are running into scenarios where people can't even launch Pyfa, so they can't get to a point when they _could_ click a button to fix it.

And yes, I know that the first two issues won't cause that scenario.  But since a lot of users won't ever take the time to post here or on the forums about it (just rage quit and go to another tool), I think that this is the best approach.

Plus, this takes basically nil time.  For a clean DB:
```
2016-12-26 21:39:18,069 root                     DEBUG    Starting database validation.
2016-12-26 21:39:18,072 eos.db.saveddata.databaseRepair DEBUG    Start databsae validation and cleanup.
2016-12-26 21:39:18,075 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for character skills.
2016-12-26 21:39:18,082 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned characters attached to fits.
2016-12-26 21:39:18,089 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned damage patterns attached to fits.
2016-12-26 21:39:18,098 root                     DEBUG    Completed database validation.
```

Takes all of 26 milliseconds and likely most of that is from the actual logging.

Ran against my personal DB (where I figured out the uniform damage profile issue), only took literally a handful of milliseconds more to clean up hundreds of records.

Now, this doesn't _fix_ the root issue.  But since we don't know what causes it exactly, and we have people who are currently broken and non-functional, we might as well clean it up to get them back on their feet.

Broke this out into it's own class so we can easily extend it with more checks.