### PR TITLE
Tooltip: Total dps tanked

### DIFF
--- a/gui/builtinStatsViews/rechargeViewFull.py
+++ b/gui/builtinStatsViews/rechargeViewFull.py
@@ -105,7 +105,9 @@ class RechargeViewFull(StatsView):
                 lbl = getattr(self, "labelTank%s%sActive" % (stability.capitalize(), name.capitalize()))
                 if tank is not None:
                     lbl.SetLabel("%.1f" % tank["%sRepair" % name])
-                    if (tank["%sRepair" % name] > 0) & (not fit.capStable): #show tooltip only if fit is not capstable
+                    if (stability == "reinforced") & \
+                       (tank["%sRepair" % name] > 0) & \
+                       (not fit.capStable): #show tooltip only if fit is not capstable
                         totalDPSTank = tank["%sRepair" % name] * fit.capState
                         lbl.SetToolTip(wx.ToolTip("Total DPS Tank: %.0f HP" % totalDPSTank))
                 else:

--- a/gui/builtinStatsViews/rechargeViewFull.py
+++ b/gui/builtinStatsViews/rechargeViewFull.py
@@ -123,7 +123,7 @@ class RechargeViewFull(StatsView):
             label = getattr(self, "labelTankSustainedShieldPassive")
             label.SetLabel("0")
 
-        label.SetToolTip(wx.ToolTip("Passive Tank %.3f" % value))
+        label.SetToolTip(wx.ToolTip("Passive Tank: %.3f HP/s" % value))
         self.panel.Layout()
         self.headerPanel.Layout()
 

--- a/gui/builtinStatsViews/rechargeViewFull.py
+++ b/gui/builtinStatsViews/rechargeViewFull.py
@@ -105,6 +105,9 @@ class RechargeViewFull(StatsView):
                 lbl = getattr(self, "labelTank%s%sActive" % (stability.capitalize(), name.capitalize()))
                 if tank is not None:
                     lbl.SetLabel("%.1f" % tank["%sRepair" % name])
+                    if (tank["%sRepair" % name] > 0) & (not fit.capStable): #show tooltip only if fit is not capstable
+                        totalDPSTank = tank["%sRepair" % name] * fit.capState
+                        lbl.SetToolTip(wx.ToolTip("Total DPS Tank: %.0f HP" % totalDPSTank))
                 else:
                     lbl.SetLabel("0.0")
 
@@ -118,7 +121,7 @@ class RechargeViewFull(StatsView):
             label = getattr(self, "labelTankSustainedShieldPassive")
             label.SetLabel("0")
 
-        label.SetToolTip(wx.ToolTip("%.3f" % value))
+        label.SetToolTip(wx.ToolTip("Passive Tank %.3f" % value))
         self.panel.Layout()
         self.headerPanel.Layout()
 


### PR DESCRIPTION
Added tool tips to the reinforced labels which show the total tankable HP based on the capacitor available time `(HP/s * CapLastTime)`.

![Example](http://i.imgur.com/01mC0Kt.png)

The tooltip is only available if the fitting is not capstable.

This tool tip makes it much easier to compare passive tanked  ships vs active tanked ships.
Additionally I added some more text to the "passive tank" tool tip.