### PR TITLE
ECM Burst Projectors effect

### DIFF
--- a/eos/effects/skillremoteecmdurationbonus.py
+++ b/eos/effects/skillremoteecmdurationbonus.py
@@ -6,5 +6,28 @@ type = "passive"
 
 
 def handler(fit, skill, context):
-    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation"),
-                                  "durationECMJammerBurstProjector", skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+    # We need to make sure that the attribute exists, otherwise we add attributes that don't belong.  See #927
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation") and
+                                              mod.item.getAttribute("duration"),
+                                  "duration",
+                                  skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation") and
+                                              mod.item.getAttribute("durationECMJammerBurstProjector"),
+                                  "durationECMJammerBurstProjector",
+                                  skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation") and
+                                              mod.item.getAttribute("durationTargetIlluminationBurstProjector"),
+                                  "durationTargetIlluminationBurstProjector",
+                                  skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation") and
+                                              mod.item.getAttribute("durationSensorDampeningBurstProjector"),
+                                  "durationSensorDampeningBurstProjector",
+                                  skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation") and
+                                              mod.item.getAttribute("durationWeaponDisruptionBurstProjector"),
+                                  "durationWeaponDisruptionBurstProjector",
+                                  skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)

--- a/eos/effects/skillremoteecmdurationbonus.py
+++ b/eos/effects/skillremoteecmdurationbonus.py
@@ -6,5 +6,5 @@ type = "passive"
 
 
 def handler(fit, skill, context):
-    fit.modules.filteredItemBoost(lambda mod: mod.item.group.name == "Burst Projectors",
-                                  "duration", skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Burst Projector Operation"),
+                                  "durationECMJammerBurstProjector", skill.getModifiedItemAttr("projECMDurationBonus") * skill.level)


### PR DESCRIPTION
Change to use skill rather than group, and modify correct attribute.

Another ECM burst bug that's been this way for years.  I swear, no one uses these things.

Thanks to saeka for reporting the bug.

@blitzmann this is ready to be merged.