### PR TITLE
Database Corruption: Multiple Items in Single Slot on Fit

### DIFF
--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -61,11 +61,13 @@ if os.path.isfile(config.saveDB):
     # Import values that must exist otherwise Pyfa breaks
     DefaultDatabaseValues.importRequiredDefaults()
 
+    # Finds and fixes database corruption issues.
     logging.debug("Starting database validation.")
     database_cleanup_instance = DatabaseCleanup()
     database_cleanup_instance.OrphanedCharacterSkills(eos.db.saveddata_engine)
     database_cleanup_instance.OrphanedFitCharacterIDs(eos.db.saveddata_engine)
     database_cleanup_instance.OrphanedFitDamagePatterns(eos.db.saveddata_engine)
+    database_cleanup_instance.DuplicateModulesOnFit(eos.db.saveddata_engine)
     logging.debug("Completed database validation.")
 
 else:


### PR DESCRIPTION
Fixes an issue where duplicate items will get added to a single slot.  See #932

Not sure where this comes from, possible source of database corruption is:
1) Cloning existing fit
2) Swapping T3 subsystems (as this rapidly adds/removes slots from the fit)
3) Race condition where the fit is calculated while still populating (because we trigger calculations multiple times)

This is definately the brute force method by just nuking the conflicting modules.

Unfortunately, I don't really see another way to do it.  When we have multiple modules, we don't know which module is good and which is bad.  We could run through a series of deletions to clean up some more obvious ones (like removing nulls before modules), but that then starts to become expensive time wise, especially since this sort of SQL query is expensive.

Even in my fairly large DB, this amounted to just a handful of fits, so it's a rare issue.  While I _hate_ removing data, the issue should be rare enough and the amount of data removed small enough that I'm leaning toward the simpler method.

Even though this isn't a very efficient SQL query, it's still pretty fast.  I wouldn't want to start chaining a bunch of these though.

```
2017-01-04 12:33:16,773 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for character skills.
2017-01-04 12:33:16,792 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned characters attached to fits.
2017-01-04 12:33:16,822 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned damage patterns attached to fits.
2017-01-04 12:33:16,835 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for multiple modules in a single slot on a fit.
2017-01-04 12:33:17,098 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 49 records.
```