### PR TITLE
Update database to 1111328

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1097,10 +1097,8 @@ class Fit(object):
         if energyNeutralizerSignatureResolution:
             capNeed = capNeed * min(1, signatureRadius / energyNeutralizerSignatureResolution)
 
-        # Check if source module has the attribute to for remote neut resistance
-        if src.getModifiedItemAttr("remoteResistanceID") == 2045:
-            resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
-            self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))
+        resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
+        self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))
 
     def removeDrain(self, i):
         del self.__extraDrains[i]

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1097,8 +1097,10 @@ class Fit(object):
         if energyNeutralizerSignatureResolution:
             capNeed = capNeed * min(1, signatureRadius / energyNeutralizerSignatureResolution)
 
-        resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
-        self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))
+        # Check if source module has the attribute to for remote neut resistance
+        if src.getModifiedItemAttr("remoteResistanceID") == 2045:
+            resistance = self.ship.getModifiedItemAttr("energyWarfareResistance") or 1 if capNeed > 0 else 1
+            self.__extraDrains.append((cycleTime, capNeed * resistance, clipSize))
 
     def removeDrain(self, i):
         del self.__extraDrains[i]


### PR DESCRIPTION


```
Comparing databases:
1106372 -> 1111328


Renamed items:
    "Korranis DNA": "Korrani's DNA",
    "Drezins DNA": "Drezin's DNA",
    "Naval Capsuleer Enlistment (Amarr)": "Enlistment (Amarr) for Naval Capsuleers",
    "Naval Capsuleer Enlistment (Caldari)": "Enlistment (Caldari) for Naval Capsuleers",
    "Naval Capsuleer Enlistment (Gallente)": "Enlistment (Gallente) for Naval Capsuleers",
    "Naval Capsuleer Enlistment (Minmatar)": "Enlistment (Minmatar) for Naval Capsuleers",
    "Naval Capsuleer Blueprint Documents": "Blueprint Documents for Naval Capsuleers",
[+] - new item
[-] - removed item
[*] - changed item
(x => y) - group changes
  [+] - effect or attribute has been added to item
  [-] - effect or attribute has been removed from item
  [y] - effect is implemented
  [n] - effect is not implemented

Items:

[-] QA Cross Protocol Analyzer
  [-|y] doHacking
  [-|n] medPower
  [-|n] online

[-] QA Damage Module
  [-|n] damageMultiplierMultiplierActivation
  [-|y] electronicAttributeModifyOnline
  [-|y] energyWeaponDamageMultiply
  [-|y] gunneryFalloffBonusOnline
  [-|y] gunneryMaxRangeBonusOnline
  [-|y] gunneryTrackingSpeedBonusOnline
  [-|y] hybridWeaponDamageMultiply
  [-|n] loPower
  [-|n] missileDamageMultiplier
  [-|n] online
  [-|y] projectileWeaponDamageMultiply
  [-|n] setMaxLockedTargets
  [-|y] shipScanResolutionBonusOnline

[-] QA ECCM
  [-|n] medPower
  [-|n] online
  [-|y] scanStrengthBonusPercentActivate

[-] QA Immunity Module
  [-|n] medPower
  [-|n] modifyShieldArmorHullResonancePostPercent
  [-|n] online

[-] QA Multiship Module - 10 Players
  [-|y] armorHPMultiply
  [-|y] energyWeaponDamageMultiply
  [-|y] hybridWeaponDamageMultiply
  [-|n] loPower
  [-|y] missileDMGBonus
  [-|y] modifyShieldRechargeRate
  [-|n] online
  [-|y] projectileWeaponDamageMultiply
  [-|y] shieldManagementShieldCapacityBonusPostPercentCapacityLocationShipGroupShield
  [-|y] structuralAnalysisEffect
  [-|y] structureHPMultiply

[-] QA Multiship Module - 20 Players
  [-|y] armorHPMultiply
  [-|y] energyWeaponDamageMultiply
  [-|y] hybridWeaponDamageMultiply
  [-|n] loPower
  [-|y] missileDMGBonus
  [-|y] modifyShieldRechargeRate
  [-|n] online
  [-|y] projectileWeaponDamageMultiply
  [-|y] shieldManagementShieldCapacityBonusPostPercentCapacityLocationShipGroupShield
  [-|y] structuralAnalysisEffect
  [-|y] structureHPMultiply

[-] QA Multiship Module - 40 Players
  [-|y] armorHPMultiply
  [-|y] energyWeaponDamageMultiply
  [-|y] hybridWeaponDamageMultiply
  [-|n] loPower
  [-|y] missileDMGBonus
  [-|y] modifyShieldRechargeRate
  [-|n] online
  [-|y] projectileWeaponDamageMultiply
  [-|y] shieldManagementShieldCapacityBonusPostPercentCapacityLocationShipGroupShield
  [-|y] structuralAnalysisEffect
  [-|y] structureHPMultiply

[-] QA Multiship Module - 5 Players
  [-|y] armorHPMultiply
  [-|y] energyWeaponDamageMultiply
  [-|y] hybridWeaponDamageMultiply
  [-|n] loPower
  [-|y] missileDMGBonus
  [-|y] modifyShieldRechargeRate
  [-|n] online
  [-|y] projectileWeaponDamageMultiply
  [-|y] shieldManagementShieldCapacityBonusPostPercentCapacityLocationShipGroupShield
  [-|y] structuralAnalysisEffect
  [-|y] structureHPMultiply

[-] QA Remote Armor Repair System - 5 Players
  [-|n] hiPower
  [-|n] online
  [-|y] overloadSelfDurationBonus
  [-|y] targetArmorRepair

[-] QA Shield Transporter - 5 Players
  [-|n] hiPower
  [-|n] online
  [-|y] overloadSelfDurationBonus
  [-|y] shieldTransfer

[*] Ahremen's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Ammatar Navy Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Ammatar Navy Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Ammatar Navy Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Brokara's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Capital Energy Neutralizer I
  [-] remoteResistanceID: 2045.0

[*] Capital Energy Neutralizer II
  [-] remoteResistanceID: 2045.0

[*] Capital Gremlin Compact Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Capital Infectious Scoped Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Chelm's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpii A-Type Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpii B-Type Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpii C-Type Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpum A-Type Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpum B-Type Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpum C-Type Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpus A-Type Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpus B-Type Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpus C-Type Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Corpus X-Type Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Dark Blood Capital Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Dark Blood Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Dark Blood Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Dark Blood Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Draclira's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Heavy 'Moat' Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Heavy Energy Neutralizer I
  [-] remoteResistanceID: 2045.0

[*] Heavy Energy Neutralizer II
  [-] remoteResistanceID: 2045.0

[*] Heavy Gremlin Compact Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Heavy Infectious Scoped Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Imperial Navy Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Imperial Navy Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Imperial Navy Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Medium 'Ditch' Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Medium Energy Neutralizer I
  [-] remoteResistanceID: 2045.0

[*] Medium Energy Neutralizer II
  [-] remoteResistanceID: 2045.0

[*] Medium Gremlin Compact Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Medium Infectious Scoped Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Raysere's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Selynne's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Small 'Caltrop' Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Small Energy Neutralizer I
  [-] remoteResistanceID: 2045.0

[*] Small Energy Neutralizer II
  [-] remoteResistanceID: 2045.0

[*] Small Gremlin Compact Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Small Infectious Scoped Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Tairei's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] True Sansha Capital Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] True Sansha Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] True Sansha Medium Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] True Sansha Small Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Vizan's Modified Heavy Energy Neutralizer
  [-] remoteResistanceID: 2045.0

[*] Bosonic Field Generator
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] Gravitational Transportation Field Oscillator
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Cold Wind’ Kinetic Reaper
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Divine Harvest’ Electromagnetic Reaper
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Geiravor’ Explosive Lance
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Guillotine’ Thermal Reaper
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Holy Destiny’ Electromagnetic Lance
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Iron Pike’ Kinetic Lance
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Jormungandr’ Explosive Reaper
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ‘Phalarica’ Thermal Lance
  [+] doomsdayEnergyNeutResistanceID: 2045.0

[*] ORE Expanded Cargohold
  [*] radius: 0 => 1.0

[*] Standup Void Guided Bomb
  [+] remoteResistanceID: 2045.0

[*] Acolyte EV-300
  [-] remoteResistanceID: 2045.0

[*] Infiltrator EV-600
  [-] remoteResistanceID: 2045.0

[*] Praetor EV-900
  [-] remoteResistanceID: 2045.0

[+] Holiday_impact_Amarr1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Angels1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_BloodRaiders1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Caldari1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Celebration1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Celebration2.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Celebration3.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_CrimsonHarvest1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Gallente1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Guristas1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Minmatar1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Sansha1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1

[+] Holiday_impact_Serpentis1.red
  [+|y] ammoSpeedMultiplier
  [+|n] snowBallLaunching
  [+] agility: 3000.0
  [+] aimedLaunch: 1.0
  [+] armorPiercingChance: 1.0
  [+] baseArmorDamage: 0
  [+] baseShieldDamage: 0
  [+] capacity: 0
  [+] detonationRange: 35.0
  [+] explosionDelay: 100000.0
  [+] hp: 10.0
  [+] launcherGroup: 56.0
  [+] mass: 100.0
  [+] maxVelocity: 1000.0
  [+] missileNeverDoesDamage: 1.0
  [+] radius: 1.0
  [+] requiredSkill1Level: 1.0
  [+] requiredSkill2Level: 1.0
  [+] speedMultiplier: 1.0
  [+] structureUniformity: 1.0
  [+] techLevel: 1.0
  [+] volume: 0.1
```