### PR TITLE
Revert back to /s for mining. Adds /hour to tooltips.

### DIFF
--- a/gui/builtinStatsViews/miningyieldViewFull.py
+++ b/gui/builtinStatsViews/miningyieldViewFull.py
@@ -124,9 +124,9 @@ class MiningYieldViewFull(StatsView):
     def refreshPanel(self, fit):
         #If we did anything intresting, we'd update our labels to reflect the new fit's stats here
 
-        stats = (("labelFullminingyieldMiner", lambda: fit.minerYield * 3600, 3, 0, 0, u"%s m\u00B3/h",None),
-                 ("labelFullminingyieldDrone", lambda: fit.droneYield * 3600, 3, 0, 0, u"%s m\u00B3/h", None),
-                 ("labelFullminingyieldTotal", lambda: fit.totalYield * 3600, 3, 0, 0, u"%s m\u00B3/h", None))
+        stats = (("labelFullminingyieldMiner", lambda: fit.minerYield, 3, 0, 0, u"%s m\u00B3/s",None),
+                 ("labelFullminingyieldDrone", lambda: fit.droneYield, 3, 0, 0, u"%s m\u00B3/s", None),
+                 ("labelFullminingyieldTotal", lambda: fit.totalYield, 3, 0, 0, u"%s m\u00B3/s", None))
 
         counter = 0
         for labelName, value, prec, lowest, highest, valueFormat, altFormat in stats:
@@ -136,7 +136,7 @@ class MiningYieldViewFull(StatsView):
             if self._cachedValues[counter] != value:
                 valueStr = formatAmount(value, prec, lowest, highest)
                 label.SetLabel(valueFormat % valueStr)
-                tipStr = valueFormat % valueStr if altFormat is None else altFormat % value
+                tipStr = "Mining Yield per second ({0} per hour)".format(formatAmount(value * 3600, 3, 0, 3))
                 label.SetToolTip(wx.ToolTip(tipStr))
                 self._cachedValues[counter] = value
             counter +=1

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -400,14 +400,14 @@ class Miscellanea(ViewColumn):
             text = "{0}m".format(formatAmount(optimalSig, 3, 0, 3))
             tooltip = "Optimal signature radius"
             return text, tooltip
-        elif itemGroup in ("Frequency Mining Laser", "Strip Miner", "Mining Laser", "Gas Cloud Harvester"):
+        elif itemGroup in ("Frequency Mining Laser", "Strip Miner", "Mining Laser", "Gas Cloud Harvester", "Mining Drone"):
             miningAmount = stuff.getModifiedItemAttr("specialtyMiningAmount") or stuff.getModifiedItemAttr("miningAmount")
-            cycleTime = stuff.cycleTime
+            cycleTime = getattr(stuff, 'cycleTime', stuff.getModifiedItemAttr("duration"))
             if not miningAmount or not cycleTime:
                 return "", None
-            minePerHour = (float(miningAmount) * 1000 / cycleTime) * 3600
-            text = "{0}/h".format(formatAmount(minePerHour, 3, 0, 3))
-            tooltip = "Mining Yield per hour"
+            minePerSec = (float(miningAmount) * 1000 / cycleTime)
+            text = "{0} m3/s".format(formatAmount(minePerSec, 3, 0, 3))
+            tooltip = "Mining Yield per second ({0} per hour)".format(formatAmount(minePerSec * 3600, 3, 0, 3))
             return text, tooltip
         elif itemGroup == "Logistic Drone":
             armorAmount = stuff.getModifiedItemAttr("armorDamageAmount")
@@ -436,15 +436,6 @@ class Miscellanea(ViewColumn):
             capPerSec = float(-neutAmount) * 1000 / cycleTime
             text = "{0}/s".format(formatAmount(capPerSec, 3, 0, 3))
             tooltip = "Energy neutralization per second"
-            return text, tooltip
-        elif itemGroup == "Mining Drone":
-            miningAmount = stuff.getModifiedItemAttr("miningAmount")
-            cycleTime = stuff.getModifiedItemAttr("duration")
-            if not miningAmount or not cycleTime:
-                return "", None
-            minePerHour = (float(miningAmount) * 1000 / cycleTime) * 3600
-            text = "{0}/h".format(formatAmount(minePerHour, 3, 0, 3))
-            tooltip = "Mining Yield per hour"
             return text, tooltip
         elif itemGroup == "Micro Jump Drive":
             cycleTime = stuff.getModifiedItemAttr("duration") / 1000


### PR DESCRIPTION
From #790 
>Linking https://www.reddit.com/r/Eve/comments/5o2npc/miner_qol_improvement_m3s_calculated_inclient_on/ where people disagree that m3/h is useful.
>Now that EVE has m3/s, it probably makes sense to revert this and stick with what EVE represents.

Since no one can agree whether /s or /h is better, why not have both?

Reverts the default display back to /s since that's what CCP has added and is shown in the client.

Moves /h into tooltips, so you can quickly see the /h rate if that's what you prefer.
If @blitzmann doesn't mind, can add a second line to the mining yield stats pane to add /h to be displayed below the /s.  So we'd effectively have both displayed in the GUI (without having to go to the tooltip).

Also, fixed the tooltips for the Mining Yield stats pane, so it shows something useful instead of just the same number again (now matches the misc tab tooltip).

Bit of housekeeping and cleanup (mining drones were their own `elif`, bit redundant).

@blitzmann this is ready to be merged.