### PR TITLE
Orphaned item cleanup

### DIFF
--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -160,3 +160,42 @@ class DatabaseCleanup:
             query = "UPDATE 'targetResists' SET 'name' = 'Unknown' WHERE name IS NULL OR name = ''"
             delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
             logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
+
+    @staticmethod
+    def OrphanedFitIDItemID(saveddata_engine):
+        # Orphaned items that are missing the fit ID or item ID.
+        # See issue #954
+        for table in ['drones', 'cargo', 'fighters', 'modules']:
+            logger.debug("Running database cleanup for orphaned %s items.", table)
+            query = "SELECT COUNT(*) AS num FROM " + table + " WHERE itemID IS NULL OR itemID = '' or itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
+            results = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+
+            if results is None:
+                return
+
+            row = results.first()
+
+            if row and row['num']:
+                query = "DELETE FROM " + table + " WHERE itemID IS NULL OR itemID = '' or itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
+                delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+                logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
+
+    @staticmethod
+    def NullDamageTargetPatternValues(saveddata_engine):
+        # Find patterns that have null values
+        # See issue #954
+        for profileType in ['damagePatterns', 'targetResists']:
+            for damageType in ['em', 'thermal', 'kinetic', 'explosive']:
+                logger.debug("Running database cleanup for null %s values. (%s)", profileType, damageType)
+                query = "SELECT COUNT(*) AS num FROM " + profileType + " WHERE " + damageType + "Amount IS NULL OR " + damageType + "Amount = ''"
+                results = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+
+                if results is None:
+                    return
+
+                row = results.first()
+
+                if row and row['num']:
+                    query = "UPDATE '" + profileType + "' SET '" + damageType + "Amount' = '0' WHERE " + damageType + "Amount IS NULL OR emAmount = ''"
+                    delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+                    logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -165,7 +165,7 @@ class DatabaseCleanup:
     def OrphanedFitIDItemID(saveddata_engine):
         # Orphaned items that are missing the fit ID or item ID.
         # See issue #954
-        for table in ['drones', 'cargo', 'fighters', 'modules']:
+        for table in ['drones', 'cargo', 'fighters']:
             logger.debug("Running database cleanup for orphaned %s items.", table)
             query = "SELECT COUNT(*) AS num FROM " + table + " WHERE itemID IS NULL OR itemID = '' or itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
             results = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
@@ -177,6 +177,21 @@ class DatabaseCleanup:
 
             if row and row['num']:
                 query = "DELETE FROM " + table + " WHERE itemID IS NULL OR itemID = '' or itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
+                delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+                logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
+
+        for table in ['modules']:
+            logger.debug("Running database cleanup for orphaned %s items.", table)
+            query = "SELECT COUNT(*) AS num FROM " + table + " WHERE itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
+            results = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+
+            if results is None:
+                return
+
+            row = results.first()
+
+            if row and row['num']:
+                query = "DELETE FROM " + table + " WHERE itemID = '0' or fitID IS NULL OR fitID = '' or fitID = '0'"
                 delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
                 logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
 

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -199,3 +199,21 @@ class DatabaseCleanup:
                     query = "UPDATE '" + profileType + "' SET '" + damageType + "Amount' = '0' WHERE " + damageType + "Amount IS NULL OR emAmount = ''"
                     delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
                     logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
+
+    @staticmethod
+    def DuplicateSelectedAmmoName(saveddata_engine):
+        # Orphaned items that are missing the fit ID or item ID.
+        # See issue #954
+        logger.debug("Running database cleanup for duplicated selected ammo profiles.")
+        query = "SELECT COUNT(*) AS num FROM damagePatterns WHERE name = 'Selected Ammo'"
+        results = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+
+        if results is None:
+            return
+
+        row = results.first()
+
+        if row and row['num'] > 1:
+            query = "DELETE FROM damagePatterns WHERE name = 'Selected Ammo'"
+            delete = DatabaseCleanup.ExecuteSQLQuery(saveddata_engine, query)
+            logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -69,6 +69,7 @@ if os.path.isfile(config.saveDB):
     database_cleanup_instance.OrphanedFitDamagePatterns(eos.db.saveddata_engine)
     database_cleanup_instance.OrphanedFitIDItemID(eos.db.saveddata_engine)
     database_cleanup_instance.NullDamageTargetPatternValues(eos.db.saveddata_engine)
+    database_cleanup_instance.DuplicateSelectedAmmoName(eos.db.saveddata_engine)
     logging.debug("Completed database validation.")
 
 else:

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -67,6 +67,8 @@ if os.path.isfile(config.saveDB):
     database_cleanup_instance.OrphanedCharacterSkills(eos.db.saveddata_engine)
     database_cleanup_instance.OrphanedFitCharacterIDs(eos.db.saveddata_engine)
     database_cleanup_instance.OrphanedFitDamagePatterns(eos.db.saveddata_engine)
+    database_cleanup_instance.OrphanedFitIDItemID(eos.db.saveddata_engine)
+    database_cleanup_instance.NullDamageTargetPatternValues(eos.db.saveddata_engine)
     logging.debug("Completed database validation.")
 
 else:


### PR DESCRIPTION
See #954 for some history.

Here's an example output from cleaning up a very large and very old database.

```
2017-01-27 13:36:46,260 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned drones items.
2017-01-27 13:36:46,306 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 21 records.
2017-01-27 13:36:46,315 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned cargo items.
2017-01-27 13:36:46,357 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 3 records.
2017-01-27 13:36:46,358 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned fighters items.
2017-01-27 13:36:46,362 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for orphaned modules items.
2017-01-27 13:36:46,517 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 3251 records.
2017-01-27 13:36:46,519 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null damagePatterns values. (em)
2017-01-27 13:36:46,548 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 1 records.
2017-01-27 13:36:46,549 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null damagePatterns values. (thermal)
2017-01-27 13:36:46,576 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 1 records.
2017-01-27 13:36:46,578 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null damagePatterns values. (kinetic)
2017-01-27 13:36:46,611 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 2 records.
2017-01-27 13:36:46,612 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null damagePatterns values. (explosive)
2017-01-27 13:36:46,653 eos.db.saveddata.databaseRepair ERROR    Database corruption found. Cleaning up 2 records.
2017-01-27 13:36:46,654 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null targetResists values. (em)
2017-01-27 13:36:46,660 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null targetResists values. (thermal)
2017-01-27 13:36:46,664 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null targetResists values. (kinetic)
2017-01-27 13:36:46,668 eos.db.saveddata.databaseRepair DEBUG    Running database cleanup for null targetResists values. (explosive)
```

Primarily we're cleaning up cargo, drones, fighters, and modules that no longer have either a `itemID` or `fitID` (so the item doesn't exist, or the fit doesn't exist).

We're also catching any damage or target profiles that have a null value, and setting it to 0.

Finally, we're catching a scenario where multiple `Selected Ammo` profiles can exist.