### PR TITLE
Add extra info for misc column for fueled boosters (cap, shield, and armor)

### DIFF
--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -243,9 +243,13 @@ class Item(EqBase):
 
         return self.__attributes
 
-    def getAttribute(self, key):
+    def getAttribute(self, key, default=None):
         if key in self.attributes:
             return self.attributes[key].value
+        elif default:
+            return default
+        else:
+            return None
 
     def isType(self, type):
         for effect in self.effects.itervalues():

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -246,10 +246,8 @@ class Item(EqBase):
     def getAttribute(self, key, default=None):
         if key in self.attributes:
             return self.attributes[key].value
-        elif default:
-            return default
         else:
-            return None
+            return default
 
     def isType(self, type):
         for effect in self.effects.itervalues():

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -244,9 +244,12 @@ class Item(EqBase):
         return self.__attributes
 
     def getAttribute(self, key, default=None):
-        if key in self.attributes:
-            return self.attributes[key].value
-        else:
+        try:
+            if key in self.attributes:
+                return self.attributes[key].value
+            else:
+                return default
+        except AttributeError:
             return default
 
     def isType(self, type):

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -26,17 +26,23 @@ cappingAttrKeyCache = {}
 
 class ItemAttrShortcut(object):
     def getModifiedItemAttr(self, key, default=None):
-        if key in self.itemModifiedAttributes:
-            return self.itemModifiedAttributes[key]
-        else:
+        try:
+            if key in self.itemModifiedAttributes:
+                return self.itemModifiedAttributes[key]
+            else:
+                return default
+        except AttributeError:
             return default
 
 
 class ChargeAttrShortcut(object):
     def getModifiedChargeAttr(self, key, default=None):
-        if key in self.chargeModifiedAttributes:
-            return self.chargeModifiedAttributes[key]
-        else:
+        try:
+            if key in self.chargeModifiedAttributes:
+                return self.chargeModifiedAttributes[key]
+            else:
+                return default
+        except AttributeError:
             return default
 
 

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -25,19 +25,19 @@ cappingAttrKeyCache = {}
 
 
 class ItemAttrShortcut(object):
-    def getModifiedItemAttr(self, key):
+    def getModifiedItemAttr(self, key, default=None):
         if key in self.itemModifiedAttributes:
             return self.itemModifiedAttributes[key]
         else:
-            return None
+            return default
 
 
 class ChargeAttrShortcut(object):
-    def getModifiedChargeAttr(self, key):
+    def getModifiedChargeAttr(self, key, default=None):
         if key in self.chargeModifiedAttributes:
             return self.chargeModifiedAttributes[key]
         else:
-            return None
+            return default
 
 
 class ModifiedAttributeDict(collections.MutableMapping):

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -496,7 +496,7 @@ class Miscellanea(ViewColumn):
                 hpRatio = 1
 
             if ("Ancillary" and "Armor") in itemGroup:
-                hpRatio *= 3
+                hpRatio *= stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
 
             ehp = hp * hpRatio
 

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -470,7 +470,7 @@ class Miscellanea(ViewColumn):
 
             if boosted_attribute == "Cap":
                 if hp is None:
-                    local_booster = stuff.charge.getAttribute("capacitorBonus",0)
+                    local_booster = stuff.charge.getAttribute("capacitorBonus", 0)
                     hp = max(local_booster, 0) * cycles
                 reload_time = 10
             elif boosted_attribute == "HP":
@@ -503,7 +503,6 @@ class Miscellanea(ViewColumn):
             if ("Ancillary" and "Armor") in itemGroup:
                 hpRatio *= 3
 
-
             ehp = hp * hpRatio
 
             duration = cycles * cycleTime / 1000
@@ -514,7 +513,11 @@ class Miscellanea(ViewColumn):
                     formatAmount((duration+reload_time)*number_of_cycles, 3, 0, 3),
                     formatAmount(number_of_cycles, 3, 0, 3)
                 )
-            text = "{0} / {1}s (+{2}s)".format(formatAmount(ehp, 3, 0, 9), formatAmount(duration, 3, 0, 3), formatAmount(reload_time, 3, 0, 3))
+            text = "{0} / {1}s (+{2}s)".format(
+                formatAmount(ehp, 3, 0, 9),
+                formatAmount(duration, 3, 0, 3),
+                formatAmount(reload_time, 3, 0, 3)
+            )
 
             return text, tooltip
         elif itemGroup == "Armor Resistance Shift Hardener":

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -496,7 +496,7 @@ class Miscellanea(ViewColumn):
                 hpRatio = 1
 
             if ("Ancillary" and "Armor") in itemGroup:
-                hpRatio *= 3
+                hpRatio *= stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
 
             ehp = hp * hpRatio
 
@@ -508,6 +508,7 @@ class Miscellanea(ViewColumn):
                     formatAmount((duration+reload_time)*number_of_cycles, 3, 0, 3),
                     formatAmount(number_of_cycles, 3, 0, 3)
                 )
+
             text = "{0} / {1}s (+{2}s)".format(
                 formatAmount(ehp, 3, 0, 9),
                 formatAmount(duration, 3, 0, 3),

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -496,7 +496,7 @@ class Miscellanea(ViewColumn):
                 hpRatio = 1
 
             if ("Ancillary" and "Armor") in itemGroup:
-                hpRatio *= stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
+                hpRatio *= 3
 
             ehp = hp * hpRatio
 
@@ -508,7 +508,6 @@ class Miscellanea(ViewColumn):
                     formatAmount((duration+reload_time)*number_of_cycles, 3, 0, 3),
                     formatAmount(number_of_cycles, 3, 0, 3)
                 )
-
             text = "{0} / {1}s (+{2}s)".format(
                 formatAmount(ehp, 3, 0, 9),
                 formatAmount(duration, 3, 0, 3),

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -467,13 +467,13 @@ class Miscellanea(ViewColumn):
                 boosted_attribute = ""
                 reload_time = 0
 
-            cycles = stuff.numShots
-            cycleTime = stuff.rawCycleTime
+            cycles = max(stuff.numShots, 0)
+            cycleTime = max(stuff.rawCycleTime, 0)
 
             # Get HP or boosted amount
-            stuff_hp = stuff.hpBeforeReload
+            stuff_hp = max(stuff.hpBeforeReload, 0)
             armor_hp = stuff.getModifiedItemAttr("armorDamageAmount", 0)
-            capacitor_hp = stuff.charge.getModifiedChargeAttr("capacitorBonus", 0)
+            capacitor_hp = stuff.getModifiedChargeAttr("capacitorBonus", 0)
             shield_hp = stuff.getModifiedItemAttr("shieldBonus", 0)
             hp = max(stuff_hp, armor_hp * cycles, capacitor_hp * cycles, shield_hp * cycles, 0)
 
@@ -495,7 +495,7 @@ class Miscellanea(ViewColumn):
             else:
                 hpRatio = 1
 
-            if ("Ancillary" and "Armor") in itemGroup:
+            if "Ancillary" in itemGroup and "Armor" in itemGroup:
                 hpRatio *= stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
 
             ehp = hp * hpRatio

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -459,28 +459,23 @@ class Miscellanea(ViewColumn):
         ):
             if "Armor" in itemGroup or "Shield" in itemGroup:
                 boosted_attribute = "HP"
+                reload_time = item.getAttribute("reloadTime", 0) / 1000
             elif "Capacitor" in itemGroup:
                 boosted_attribute = "Cap"
+                reload_time = 10
             else:
-                boosted_attribute = None
+                boosted_attribute = ""
+                reload_time = 0
 
-            hp = stuff.hpBeforeReload
             cycles = stuff.numShots
             cycleTime = stuff.rawCycleTime
 
-            if boosted_attribute == "Cap":
-                if hp is None:
-                    local_booster = stuff.charge.getAttribute("capacitorBonus", 0)
-                    hp = max(local_booster, 0) * cycles
-                reload_time = 10
-            elif boosted_attribute == "HP":
-                if hp is None:
-                    armor_repairer = item.getAttribute("armorDamageAmount", None)
-                    shield_booster = item.getAttribute("shieldBonus", None)
-                    hp = max(armor_repairer, shield_booster, 0)
-                reload_time = item.getAttribute("reloadTime", 0) / 1000
-            else:
-                reload_time = 0
+            # Get HP or boosted amount
+            stuff_hp = stuff.hpBeforeReload
+            armor_hp = stuff.getModifiedItemAttr("armorDamageAmount", 0)
+            capacitor_hp = stuff.charge.getModifiedChargeAttr("capacitorBonus", 0)
+            shield_hp = stuff.getModifiedItemAttr("shieldBonus", 0)
+            hp = max(stuff_hp, armor_hp * cycles, capacitor_hp * cycles, shield_hp * cycles, 0)
 
             if not hp or not cycleTime or not cycles:
                 return "", None


### PR DESCRIPTION
Adds the ability to show info for capacitor boosters and remote ancil armor/shield reppers, in addition to the existing local ancil armor/shield reppers.

shows the reload time to make it more clear the span that the total amount of reps lasts.

Added to tooltip the number of charges used, and the amount of time for 5, 10, and 25 cycles of the booster (1 cycle is using all charges + reload time).

A picture is worth a thousand words, so this gif is probably a small novel.
https://puu.sh/tEU9L/bd88811fc9.gif

See #959 for history.