### PR TITLE
Logbook (Logging Improvements)

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ logger = Logger(__name__)
 try:
     import configforced
 except ImportError:
+    logger.warning("Failed to import: configforced")
     configforced = None
 
 # Turns on debug mode

--- a/config.py
+++ b/config.py
@@ -1,10 +1,8 @@
 import os
 import sys
 
-# TODO: move all logging back to pyfa.py main loop
-# We moved it here just to avoid rebuilding windows skeleton for now (any change to pyfa.py needs it)
-import logging
-import logging.handlers
+from logbook import Logger
+logger = Logger(__name__)
 
 # Load variable overrides specific to distribution type
 try:
@@ -29,23 +27,6 @@ savePath = None
 saveDB = None
 gameDB = None
 
-
-class StreamToLogger(object):
-    """
-    Fake file-like stream object that redirects writes to a logger instance.
-    From: http://www.electricmonk.nl/log/2011/08/14/redirect-stdout-and-stderr-to-a-logger-in-python/
-    """
-
-    def __init__(self, logger, log_level=logging.INFO):
-        self.logger = logger
-        self.log_level = log_level
-        self.linebuf = ''
-
-    def write(self, buf):
-        for line in buf.rstrip().splitlines():
-            self.logger.log(self.log_level, line.rstrip())
-
-
 def isFrozen():
     if hasattr(sys, 'frozen'):
         return True
@@ -66,10 +47,7 @@ def defPaths(customSavePath):
     global gameDB
     global saveInRoot
 
-    if debug:
-        logLevel = logging.DEBUG
-    else:
-        logLevel = logging.WARN
+    logger.debug("Configuring Pyfa")
 
     # The main pyfa directory which contains run.py
     # Python 2.X uses ANSI by default, so we need to convert the character encoding
@@ -97,19 +75,9 @@ def defPaths(customSavePath):
         os.environ["REQUESTS_CA_BUNDLE"] = getPyfaPath(certName).encode('utf8')
         os.environ["SSL_CERT_FILE"] = getPyfaPath(certName).encode('utf8')
 
-    loggingFormat = '%(asctime)s %(name)-24s %(levelname)-8s %(message)s'
-    logging.basicConfig(format=loggingFormat, level=logLevel)
-    handler = logging.handlers.RotatingFileHandler(getSavePath("log.txt"), maxBytes=1000000, backupCount=3)
-    formatter = logging.Formatter(loggingFormat)
-    handler.setFormatter(formatter)
-    logging.getLogger('').addHandler(handler)
-
-    logging.info("Starting pyfa")
 
     if hasattr(sys, 'frozen'):
-        stdout_logger = logging.getLogger('STDOUT')
-        sl = StreamToLogger(stdout_logger, logging.INFO)
-        sys.stdout = sl
+        pass
 
         # This interferes with cx_Freeze's own handling of exceptions. Find a way to fix this.
         # stderr_logger = logging.getLogger('STDERR')

--- a/config.py
+++ b/config.py
@@ -2,13 +2,13 @@ import os
 import sys
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 # Load variable overrides specific to distribution type
 try:
     import configforced
 except ImportError:
-    logger.warning("Failed to import: configforced")
+    logging.warning("Failed to import: configforced")
     configforced = None
 
 # Turns on debug mode
@@ -48,7 +48,7 @@ def defPaths(customSavePath):
     global gameDB
     global saveInRoot
 
-    logger.debug("Configuring Pyfa")
+    logging.debug("Configuring Pyfa")
 
     # The main pyfa directory which contains run.py
     # Python 2.X uses ANSI by default, so we need to convert the character encoding

--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -25,8 +25,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import pool
 from logbook import Logger
 
-log = Logger(__name__)
-log.debug("Initializing")
+logger = Logger(__name__)
+logger.debug("Initializing")
 
 import migration
 from eos import config
@@ -53,6 +53,7 @@ try:
         "SELECT `field_value` FROM `metadata` WHERE `field_name` LIKE 'client_build'"
     ).fetchone()[0]
 except:
+    logger.warning("Missing gamedata version.")
     config.gamedata_version = None
 
 saveddata_connectionstring = config.saveddata_connectionstring

--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -23,7 +23,10 @@ from sqlalchemy import MetaData, create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import pool
+from logbook import Logger
 
+log = Logger(__name__)
+log.debug("Initializing")
 
 import migration
 from eos import config

--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -25,8 +25,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import pool
 from logbook import Logger
 
-logger = Logger(__name__)
-logger.debug("Initializing")
+logging = Logger(__name__)
+logging.debug("Initializing")
 
 import migration
 from eos import config
@@ -53,7 +53,7 @@ try:
         "SELECT `field_value` FROM `metadata` WHERE `field_name` LIKE 'client_build'"
     ).fetchone()[0]
 except:
-    logger.warning("Missing gamedata version.")
+    logging.warning("Missing gamedata version.")
     config.gamedata_version = None
 
 saveddata_connectionstring = config.saveddata_connectionstring

--- a/eos/db/migration.py
+++ b/eos/db/migration.py
@@ -37,7 +37,7 @@ def update(saveddata_engine):
         for version in xrange(dbVersion, appVersion):
             func = migrations.updates[version + 1]
             if func:
-                logger.info("Applying database update: %d", version + 1)
+                logger.info("Applying database update: {0}", version + 1)
                 func(saveddata_engine)
 
         # when all is said and done, set version to current

--- a/eos/db/migration.py
+++ b/eos/db/migration.py
@@ -1,11 +1,11 @@
-import logging
+from logbook import Logger
+logger = Logger(__name__)
+
 import shutil
 import time
 
 import config
 import migrations
-
-logger = logging.getLogger(__name__)
 
 
 def getVersion(db):

--- a/eos/db/migration.py
+++ b/eos/db/migration.py
@@ -1,5 +1,5 @@
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import shutil
 import time
@@ -37,7 +37,7 @@ def update(saveddata_engine):
         for version in xrange(dbVersion, appVersion):
             func = migrations.updates[version + 1]
             if func:
-                logger.info("Applying database update: {0}", version + 1)
+                logging.info("Applying database update: {0}", version + 1)
                 func(saveddata_engine)
 
         # when all is said and done, set version to current

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -42,7 +42,7 @@ class DatabaseCleanup:
 
             if row and row['num']:
                 delete = saveddata_engine.execute("DELETE FROM characterSkills WHERE characterID NOT IN (SELECT ID from characters)")
-                logger.error("Database corruption found. Cleaning up %d records.", delete.rowcount)
+                logger.error("Database corruption found. Cleaning up {0} records.", delete.rowcount)
 
         except sqlalchemy.exc.DatabaseError:
             logger.error("Failed to connect to database.")
@@ -72,7 +72,7 @@ class DatabaseCleanup:
                     update = saveddata_engine.execute("UPDATE 'fits' SET 'damagePatternID' = ? "
                                                       "WHERE damagePatternID NOT IN (SELECT ID FROM damagePatterns) OR damagePatternID IS NULL",
                                                        uniform_damage_pattern_id)
-                    logger.error("Database corruption found. Cleaning up %d records.", update.rowcount)
+                    logger.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
         except sqlalchemy.exc.DatabaseError:
             logger.error("Failed to connect to database.")
 
@@ -98,6 +98,6 @@ class DatabaseCleanup:
                     update = saveddata_engine.execute("UPDATE 'fits' SET 'characterID' = ? "
                                                       "WHERE characterID not in (select ID from characters) OR characterID IS NULL",
                                                        all5_id)
-                    logger.error("Database corruption found. Cleaning up %d records.", update.rowcount)
+                    logger.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
         except sqlalchemy.exc.DatabaseError:
             logger.error("Failed to connect to database.")

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -18,9 +18,8 @@
 # ===============================================================================
 
 import sqlalchemy
-import logging
-
-logger = logging.getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class DatabaseCleanup:

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -19,7 +19,7 @@
 
 import sqlalchemy
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class DatabaseCleanup:
@@ -29,23 +29,23 @@ class DatabaseCleanup:
     @staticmethod
     def OrphanedCharacterSkills(saveddata_engine):
         # Finds and fixes database corruption issues.
-        logger.debug("Start databsae validation and cleanup.")
+        logging.debug("Start databsae validation and cleanup.")
 
         # Find orphaned character skills.
         # This solves an issue where the character doesn't exist, but skills for that character do.
         # See issue #917
         try:
-            logger.debug("Running database cleanup for character skills.")
+            logging.debug("Running database cleanup for character skills.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM characterSkills "
                                                "WHERE characterID NOT IN (SELECT ID from characters)")
             row = results.first()
 
             if row and row['num']:
                 delete = saveddata_engine.execute("DELETE FROM characterSkills WHERE characterID NOT IN (SELECT ID from characters)")
-                logger.error("Database corruption found. Cleaning up {0} records.", delete.rowcount)
+                logging.error("Database corruption found. Cleaning up {0} records.", delete.rowcount)
 
         except sqlalchemy.exc.DatabaseError:
-            logger.error("Failed to connect to database.")
+            logging.error("Failed to connect to database.")
 
     @staticmethod
     def OrphanedFitDamagePatterns(saveddata_engine):
@@ -53,7 +53,7 @@ class DatabaseCleanup:
         # This solves an issue where the damage pattern doesn't exist, but fits reference the pattern.
         # See issue #777
         try:
-            logger.debug("Running database cleanup for orphaned damage patterns attached to fits.")
+            logging.debug("Running database cleanup for orphaned damage patterns attached to fits.")
 
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE damagePatternID NOT IN (SELECT ID FROM damagePatterns) OR damagePatternID IS NULL")
             row = results.first()
@@ -64,23 +64,23 @@ class DatabaseCleanup:
                 rows = query.fetchall()
 
                 if len(rows) == 0:
-                    logger.error("Missing uniform damage pattern.")
+                    logging.error("Missing uniform damage pattern.")
                 elif len(rows) > 1:
-                    logger.error("More than one uniform damage pattern found.")
+                    logging.error("More than one uniform damage pattern found.")
                 else:
                     uniform_damage_pattern_id = rows[0]['ID']
                     update = saveddata_engine.execute("UPDATE 'fits' SET 'damagePatternID' = ? "
                                                       "WHERE damagePatternID NOT IN (SELECT ID FROM damagePatterns) OR damagePatternID IS NULL",
                                                        uniform_damage_pattern_id)
-                    logger.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
+                    logging.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
         except sqlalchemy.exc.DatabaseError:
-            logger.error("Failed to connect to database.")
+            logging.error("Failed to connect to database.")
 
     @staticmethod
     def OrphanedFitCharacterIDs(saveddata_engine):
         # Find orphaned character IDs. This solves an issue where the character doesn't exist, but fits reference the pattern.
         try:
-            logger.debug("Running database cleanup for orphaned characters attached to fits.")
+            logging.debug("Running database cleanup for orphaned characters attached to fits.")
             results = saveddata_engine.execute("SELECT COUNT(*) AS num FROM fits WHERE characterID NOT IN (SELECT ID FROM characters) OR characterID IS NULL")
             row = results.first()
 
@@ -90,14 +90,14 @@ class DatabaseCleanup:
                 rows = query.fetchall()
 
                 if len(rows) == 0:
-                    logger.error("Missing 'All 5' character.")
+                    logging.error("Missing 'All 5' character.")
                 elif len(rows) > 1:
-                    logger.error("More than one 'All 5' character found.")
+                    logging.error("More than one 'All 5' character found.")
                 else:
                     all5_id = rows[0]['ID']
                     update = saveddata_engine.execute("UPDATE 'fits' SET 'characterID' = ? "
                                                       "WHERE characterID not in (select ID from characters) OR characterID IS NULL",
                                                        all5_id)
-                    logger.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
+                    logging.error("Database corruption found. Cleaning up {0} records.", update.rowcount)
         except sqlalchemy.exc.DatabaseError:
-            logger.error("Failed to connect to database.")
+            logging.error("Failed to connect to database.")

--- a/eos/effectHandlerHelpers.py
+++ b/eos/effectHandlerHelpers.py
@@ -18,11 +18,10 @@
 # ===============================================================================
 
 # from sqlalchemy.orm.attributes import flag_modified
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import eos.db
-
-logger = logging.getLogger(__name__)
 
 
 class HandledList(list):

--- a/eos/effectHandlerHelpers.py
+++ b/eos/effectHandlerHelpers.py
@@ -19,7 +19,7 @@
 
 # from sqlalchemy.orm.attributes import flag_modified
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import eos.db
 

--- a/eos/effects/adaptivearmorhardener.py
+++ b/eos/effects/adaptivearmorhardener.py
@@ -2,9 +2,8 @@
 #
 # Used by:
 # Module: Reactive Armor Hardener
-import logging
-
-logger = logging.getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 runTime = "late"
 type = "active"

--- a/eos/effects/adaptivearmorhardener.py
+++ b/eos/effects/adaptivearmorhardener.py
@@ -97,7 +97,7 @@ def handler(fit, module, context):
             cycleList.append(list(RAHResistance))
 
         if loopStart < 0:
-            logger.error("Reactive Armor Hardener failed to find equilibrium. Damage profile after armor: %f/%f/%f/%f",
+            logger.error("Reactive Armor Hardener failed to find equilibrium. Damage profile after armor: {0}/{1}/{2}/{3}",
                          baseDamageTaken[0], baseDamageTaken[1], baseDamageTaken[2], baseDamageTaken[3])
 
         # Average the profiles in the RAH loop, or the last 20 if it didn't find a loop.

--- a/eos/effects/adaptivearmorhardener.py
+++ b/eos/effects/adaptivearmorhardener.py
@@ -3,7 +3,7 @@
 # Used by:
 # Module: Reactive Armor Hardener
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 runTime = "late"
 type = "active"
@@ -14,8 +14,8 @@ def handler(fit, module, context):
 
     # Skip if there is no damage pattern. Example: projected ships or fleet boosters
     if damagePattern:
-        # logger.debug("Damage Pattern: %f/%f/%f/%f", damagePattern.emAmount, damagePattern.thermalAmount, damagePattern.kineticAmount, damagePattern.explosiveAmount)
-        # logger.debug("Original Armor Resists: %f/%f/%f/%f", fit.ship.getModifiedItemAttr('armorEmDamageResonance'), fit.ship.getModifiedItemAttr('armorThermalDamageResonance'), fit.ship.getModifiedItemAttr('armorKineticDamageResonance'), fit.ship.getModifiedItemAttr('armorExplosiveDamageResonance'))
+        # logging.debug("Damage Pattern: %f/%f/%f/%f", damagePattern.emAmount, damagePattern.thermalAmount, damagePattern.kineticAmount, damagePattern.explosiveAmount)
+        # logging.debug("Original Armor Resists: %f/%f/%f/%f", fit.ship.getModifiedItemAttr('armorEmDamageResonance'), fit.ship.getModifiedItemAttr('armorThermalDamageResonance'), fit.ship.getModifiedItemAttr('armorKineticDamageResonance'), fit.ship.getModifiedItemAttr('armorExplosiveDamageResonance'))
 
         # Populate a tuple with the damage profile modified by current armor resists.
         baseDamageTaken = (
@@ -24,7 +24,7 @@ def handler(fit, module, context):
             damagePattern.kineticAmount * fit.ship.getModifiedItemAttr('armorKineticDamageResonance'),
             damagePattern.explosiveAmount * fit.ship.getModifiedItemAttr('armorExplosiveDamageResonance'),
         )
-        # logger.debug("Damage Adjusted for Armor Resists: %f/%f/%f/%f", baseDamageTaken[0], baseDamageTaken[1], baseDamageTaken[2], baseDamageTaken[3])
+        # logging.debug("Damage Adjusted for Armor Resists: %f/%f/%f/%f", baseDamageTaken[0], baseDamageTaken[1], baseDamageTaken[2], baseDamageTaken[3])
 
         resistanceShiftAmount = module.getModifiedItemAttr(
             'resistanceShiftAmount') / 100  # The attribute is in percent and we want a fraction
@@ -40,7 +40,7 @@ def handler(fit, module, context):
         cycleList = []
         loopStart = -20
         for num in range(50):
-            # logger.debug("Starting cycle %d.", num)
+            # logging.debug("Starting cycle %d.", num)
             # The strange order is to emulate the ingame sorting when different types have taken the same amount of damage.
             # This doesn't take into account stacking penalties. In a few cases fitting a Damage Control causes an inaccurate result.
             damagePattern_tuples = [
@@ -49,7 +49,7 @@ def handler(fit, module, context):
                 (2, baseDamageTaken[2] * RAHResistance[2], RAHResistance[2]),
                 (1, baseDamageTaken[1] * RAHResistance[1], RAHResistance[1]),
             ]
-            # logger.debug("Damage taken this cycle: %f/%f/%f/%f", damagePattern_tuples[0][1], damagePattern_tuples[3][1], damagePattern_tuples[2][1], damagePattern_tuples[1][1])
+            # logging.debug("Damage taken this cycle: %f/%f/%f/%f", damagePattern_tuples[0][1], damagePattern_tuples[3][1], damagePattern_tuples[2][1], damagePattern_tuples[1][1])
 
             # Sort the tuple to drop the highest damage value to the bottom
             sortedDamagePattern_tuples = sorted(damagePattern_tuples, key=lambda damagePattern: damagePattern[1])
@@ -79,7 +79,7 @@ def handler(fit, module, context):
             RAHResistance[sortedDamagePattern_tuples[1][0]] = sortedDamagePattern_tuples[1][2] + change1
             RAHResistance[sortedDamagePattern_tuples[2][0]] = sortedDamagePattern_tuples[2][2] + change2
             RAHResistance[sortedDamagePattern_tuples[3][0]] = sortedDamagePattern_tuples[3][2] + change3
-            # logger.debug("Resistances shifted to %f/%f/%f/%f", RAHResistance[0], RAHResistance[1], RAHResistance[2], RAHResistance[3])
+            # logging.debug("Resistances shifted to %f/%f/%f/%f", RAHResistance[0], RAHResistance[1], RAHResistance[2], RAHResistance[3])
 
             # See if the current RAH profile has been encountered before, indicating a loop.
             for i, val in enumerate(cycleList):
@@ -89,7 +89,7 @@ def handler(fit, module, context):
                             abs(RAHResistance[2] - val[2]) <= tolerance and \
                             abs(RAHResistance[3] - val[3]) <= tolerance:
                     loopStart = i
-                    # logger.debug("Loop found: %d-%d", loopStart, num)
+                    # logging.debug("Loop found: %d-%d", loopStart, num)
                     break
             if loopStart >= 0:
                 break
@@ -97,7 +97,7 @@ def handler(fit, module, context):
             cycleList.append(list(RAHResistance))
 
         if loopStart < 0:
-            logger.error("Reactive Armor Hardener failed to find equilibrium. Damage profile after armor: {0}/{1}/{2}/{3}",
+            logging.error("Reactive Armor Hardener failed to find equilibrium. Damage profile after armor: {0}/{1}/{2}/{3}",
                          baseDamageTaken[0], baseDamageTaken[1], baseDamageTaken[2], baseDamageTaken[3])
 
         # Average the profiles in the RAH loop, or the last 20 if it didn't find a loop.
@@ -112,7 +112,7 @@ def handler(fit, module, context):
             average[i] = round(average[i] / numCycles, 3)
 
         # Set the new resistances
-        # logger.debug("Setting new resist profile: %f/%f/%f/%f", average[0], average[1], average[2],average[3])
+        # logging.debug("Setting new resist profile: %f/%f/%f/%f", average[0], average[1], average[2],average[3])
         for i, attr in enumerate((
                 'armorEmDamageResonance', 'armorThermalDamageResonance', 'armorKineticDamageResonance',
                 'armorExplosiveDamageResonance')):

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -30,6 +30,9 @@ try:
 except ImportError:
     from utils.compat import OrderedDict
 
+from logbook import Logger
+logger = Logger(__name__)
+
 
 class Effect(EqBase):
     """
@@ -63,6 +66,8 @@ class Effect(EqBase):
         """
         if not self.__generated:
             self.__generateHandler()
+
+        logger.debug("Generating effect: {0} ({1}) [runTime: {2}]", self.name, self.effectID, self.runTime)
 
         return self.__handler
 
@@ -138,7 +143,7 @@ class Effect(EqBase):
     @property
     def isImplemented(self):
         """
-        Wether this effect is implemented in code or not,
+        Whether this effect is implemented in code or not,
         unimplemented effects simply do nothing at all when run
         """
         return self.handler != effectDummy

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -31,7 +31,7 @@ except ImportError:
     from utils.compat import OrderedDict
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class Effect(EqBase):
@@ -67,7 +67,7 @@ class Effect(EqBase):
         if not self.__generated:
             self.__generateHandler()
 
-        logger.debug("Generating effect: {0} ({1}) [runTime: {2}]", self.name, self.effectID, self.runTime)
+        logging.debug("Generating effect: {0} ({1}) [runTime: {2}]", self.name, self.effectID, self.runTime)
 
         return self.__handler
 

--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -22,6 +22,9 @@ from math import log, sin, radians, exp
 from eos.graph import Graph
 from eos.types import Hardpoint, State
 
+from logbook import Logger
+logger = Logger(__name__)
+
 
 class FitDpsGraph(Graph):
     defaults = {"angle": 0,
@@ -66,6 +69,7 @@ class FitDpsGraph(Graph):
                     val *= 1 + (bonus - 1) * exp(- i ** 2 / 7.1289)
                 data[attr] = val
             except:
+                logger.warning("Caught exception in calcDPS.")
                 pass
 
         for mod in fit.modules:

--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -23,7 +23,7 @@ from eos.graph import Graph
 from eos.types import Hardpoint, State
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class FitDpsGraph(Graph):
@@ -69,7 +69,7 @@ class FitDpsGraph(Graph):
                     val *= 1 + (bonus - 1) * exp(- i ** 2 / 7.1289)
                 data[attr] = val
             except:
-                logger.warning("Caught exception in calcDPS.")
+                logging.warning("Caught exception in calcDPS.")
                 pass
 
         for mod in fit.modules:

--- a/eos/saveddata/booster.py
+++ b/eos/saveddata/booster.py
@@ -46,11 +46,11 @@ class Booster(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: %d) is not a Booser", self.itemID)
+            logger.error("Item (id: {0}) is not a Booser", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/booster.py
+++ b/eos/saveddata/booster.py
@@ -17,15 +17,14 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor, validates
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut
-
-logger = logging.getLogger(__name__)
 
 
 class Booster(HandledItem, ItemAttrShortcut):

--- a/eos/saveddata/booster.py
+++ b/eos/saveddata/booster.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor, validates
 
@@ -46,11 +46,11 @@ class Booster(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: {0}) is not a Booser", self.itemID)
+            logging.error("Item (id: {0}) is not a Booser", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/cargo.py
+++ b/eos/saveddata/cargo.py
@@ -45,7 +45,7 @@ class Cargo(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         self.__itemModifiedAttributes = ModifiedAttributeDict()

--- a/eos/saveddata/cargo.py
+++ b/eos/saveddata/cargo.py
@@ -17,15 +17,14 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut
-
-logger = logging.getLogger(__name__)
 
 
 class Cargo(HandledItem, ItemAttrShortcut):

--- a/eos/saveddata/cargo.py
+++ b/eos/saveddata/cargo.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -45,7 +45,7 @@ class Cargo(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         self.__itemModifiedAttributes = ModifiedAttributeDict()

--- a/eos/saveddata/character.py
+++ b/eos/saveddata/character.py
@@ -18,7 +18,9 @@
 # ===============================================================================
 
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
+
 from itertools import chain
 
 from sqlalchemy.orm import validates, reconstructor
@@ -27,8 +29,6 @@ import eos
 import eos.db
 import eos.types
 from eos.effectHandlerHelpers import HandledItem, HandledImplantBoosterList
-
-logger = logging.getLogger(__name__)
 
 
 class Character(object):

--- a/eos/saveddata/character.py
+++ b/eos/saveddata/character.py
@@ -19,7 +19,7 @@
 
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from itertools import chain
 

--- a/eos/saveddata/citadel.py
+++ b/eos/saveddata/citadel.py
@@ -17,11 +17,10 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from eos.types import Ship
-
-logger = logging.getLogger(__name__)
 
 
 class Citadel(Ship):

--- a/eos/saveddata/citadel.py
+++ b/eos/saveddata/citadel.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from eos.types import Ship
 

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -17,15 +17,14 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem, HandledCharge
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut, ChargeAttrShortcut
-
-logger = logging.getLogger(__name__)
 
 
 class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -52,11 +52,11 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: %d) is not a Drone", self.itemID)
+            logger.error("Item (id: {0}) is not a Drone", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -52,11 +52,11 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: {0}) is not a Drone", self.itemID)
+            logging.error("Item (id: {0}) is not a Drone", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/fighter.py
+++ b/eos/saveddata/fighter.py
@@ -59,11 +59,11 @@ class Fighter(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: %d) is not a Fighter", self.itemID)
+            logger.error("Item (id: {0}) is not a Fighter", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/fighter.py
+++ b/eos/saveddata/fighter.py
@@ -17,7 +17,8 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -25,8 +26,6 @@ import eos.db
 from eos.effectHandlerHelpers import HandledItem, HandledCharge
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut, ChargeAttrShortcut
 from eos.types import FighterAbility, Slot
-
-logger = logging.getLogger(__name__)
 
 
 class Fighter(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):

--- a/eos/saveddata/fighter.py
+++ b/eos/saveddata/fighter.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -59,11 +59,11 @@ class Fighter(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: {0}) is not a Fighter", self.itemID)
+            logging.error("Item (id: {0}) is not a Fighter", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/fighterAbility.py
+++ b/eos/saveddata/fighterAbility.py
@@ -58,7 +58,7 @@ class FighterAbility(object):
         if self.effectID:
             self.__effect = next((x for x in self.fighter.item.effects.itervalues() if x.ID == self.effectID), None)
             if self.__effect is None:
-                logger.error("Effect (id: %d) does not exist", self.effectID)
+                logger.error("Effect (id: {0}) does not exist", self.effectID)
                 return
 
         self.build()

--- a/eos/saveddata/fighterAbility.py
+++ b/eos/saveddata/fighterAbility.py
@@ -17,11 +17,10 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor
-
-logger = logging.getLogger(__name__)
 
 
 class FighterAbility(object):

--- a/eos/saveddata/fighterAbility.py
+++ b/eos/saveddata/fighterAbility.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor
 
@@ -58,7 +58,7 @@ class FighterAbility(object):
         if self.effectID:
             self.__effect = next((x for x in self.fighter.item.effects.itervalues() if x.ID == self.effectID), None)
             if self.__effect is None:
-                logger.error("Effect (id: {0}) does not exist", self.effectID)
+                logging.error("Effect (id: {0}) does not exist", self.effectID)
                 return
 
         self.build()

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -636,13 +636,13 @@ class Fit(object):
 
     def calculateModifiedAttributes(self, targetFit=None, withBoosters=False, dirtyStorage=None):
         timer = Timer(u'Fit: {}, {}'.format(self.ID, self.name), logger)
-        logger.debug("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
+        logger.info("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
 
         shadow = False
         if targetFit and not withBoosters:
             logger.debug("Applying projections to target: {0}", targetFit)
             projectionInfo = self.getProjectionInfo(targetFit.ID)
-            logger.debug("ProjectionInfo: {0}", projectionInfo)
+            logger.info("ProjectionInfo: {0}", projectionInfo)
             if self == targetFit:
                 copied = self  # original fit
                 shadow = True

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -33,9 +33,8 @@ from eos.enum import Enum
 from eos.saveddata.module import State, Hardpoint
 from eos.types import Ship, Character, Slot, Module, Citadel
 from utils.timer import Timer
-import logging
-
-logger = logging.getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 try:
     from collections import OrderedDict

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -91,7 +91,7 @@ class Fit(object):
         if self.shipID:
             item = eos.db.getItem(self.shipID)
             if item is None:
-                logger.error("Item (id: %d) does not exist", self.shipID)
+                logger.error("Item (id: {0}) does not exist", self.shipID)
                 return
 
             try:
@@ -104,7 +104,7 @@ class Fit(object):
                 # change all instances in source). Remove this at some point
                 self.extraAttributes = self.__ship.itemModifiedAttributes
             except ValueError:
-                logger.error("Item (id: %d) is not a Ship", self.shipID)
+                logger.error("Item (id: {0}) is not a Ship", self.shipID)
                 return
 
         if self.modeID and self.__ship:
@@ -453,7 +453,7 @@ class Fit(object):
             self.commandBonuses[warfareBuffID] = (runTime, value, module, effect)
 
     def __runCommandBoosts(self, runTime="normal"):
-        logger.debug("Applying gang boosts for %r", self)
+        logger.debug("Applying gang boosts for {0}", self)
         for warfareBuffID in self.commandBonuses.keys():
             # Unpack all data required to run effect properly
             effect_runTime, value, thing, effect = self.commandBonuses[warfareBuffID]
@@ -636,20 +636,20 @@ class Fit(object):
 
     def calculateModifiedAttributes(self, targetFit=None, withBoosters=False, dirtyStorage=None):
         timer = Timer(u'Fit: {}, {}'.format(self.ID, self.name), logger)
-        logger.debug("Starting fit calculation on: %r, withBoosters: %s", self, withBoosters)
+        logger.debug("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
 
         shadow = False
         if targetFit and not withBoosters:
-            logger.debug("Applying projections to target: %r", targetFit)
+            logger.debug("Applying projections to target: {0}", targetFit)
             projectionInfo = self.getProjectionInfo(targetFit.ID)
-            logger.debug("ProjectionInfo: %s", projectionInfo)
+            logger.debug("ProjectionInfo: {0}", projectionInfo)
             if self == targetFit:
                 copied = self  # original fit
                 shadow = True
                 # Don't inspect this, we genuinely want to reassign self
                 # noinspection PyMethodFirstArgAssignment
                 self = copy.deepcopy(self)
-                logger.debug("Handling self projection - making shadow copy of fit. %r => %r", copied, self)
+                logger.debug("Handling self projection - making shadow copy of fit. {0} => {1}", copied, self)
                 # we delete the fit because when we copy a fit, flush() is
                 # called to properly handle projection updates. However, we do
                 # not want to save this fit to the database, so simply remove it
@@ -684,7 +684,7 @@ class Fit(object):
         # projection have modifying stuff applied, such as gang boosts and other
         # local modules that may help
         if self.__calculated and not projected and not withBoosters:
-            logger.debug("Fit has already been calculated and is not projected, returning: %r", self)
+            logger.debug("Fit has already been calculated and is not projected, returning: {0}", self)
             return
 
         for runTime in ("early", "normal", "late"):

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -34,7 +34,7 @@ from eos.saveddata.module import State, Hardpoint
 from eos.types import Ship, Character, Slot, Module, Citadel
 from utils.timer import Timer
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 try:
     from collections import OrderedDict
@@ -91,7 +91,7 @@ class Fit(object):
         if self.shipID:
             item = eos.db.getItem(self.shipID)
             if item is None:
-                logger.error("Item (id: {0}) does not exist", self.shipID)
+                logging.error("Item (id: {0}) does not exist", self.shipID)
                 return
 
             try:
@@ -104,7 +104,7 @@ class Fit(object):
                 # change all instances in source). Remove this at some point
                 self.extraAttributes = self.__ship.itemModifiedAttributes
             except ValueError:
-                logger.error("Item (id: {0}) is not a Ship", self.shipID)
+                logging.error("Item (id: {0}) is not a Ship", self.shipID)
                 return
 
         if self.modeID and self.__ship:
@@ -453,7 +453,7 @@ class Fit(object):
             self.commandBonuses[warfareBuffID] = (runTime, value, module, effect)
 
     def __runCommandBoosts(self, runTime="normal"):
-        logger.debug("Applying gang boosts for {0}", self)
+        logging.debug("Applying gang boosts for {0}", self)
         for warfareBuffID in self.commandBonuses.keys():
             # Unpack all data required to run effect properly
             effect_runTime, value, thing, effect = self.commandBonuses[warfareBuffID]
@@ -636,20 +636,20 @@ class Fit(object):
 
     def calculateModifiedAttributes(self, targetFit=None, withBoosters=False, dirtyStorage=None):
         timer = Timer(u'Fit: {}, {}'.format(self.ID, self.name), logger)
-        logger.info("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
+        logging.info("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
 
         shadow = False
         if targetFit and not withBoosters:
-            logger.debug("Applying projections to target: {0}", targetFit)
+            logging.debug("Applying projections to target: {0}", targetFit)
             projectionInfo = self.getProjectionInfo(targetFit.ID)
-            logger.info("ProjectionInfo: {0}", projectionInfo)
+            logging.info("ProjectionInfo: {0}", projectionInfo)
             if self == targetFit:
                 copied = self  # original fit
                 shadow = True
                 # Don't inspect this, we genuinely want to reassign self
                 # noinspection PyMethodFirstArgAssignment
                 self = copy.deepcopy(self)
-                logger.debug("Handling self projection - making shadow copy of fit. {0} => {1}", copied, self)
+                logging.debug("Handling self projection - making shadow copy of fit. {0} => {1}", copied, self)
                 # we delete the fit because when we copy a fit, flush() is
                 # called to properly handle projection updates. However, we do
                 # not want to save this fit to the database, so simply remove it
@@ -684,7 +684,7 @@ class Fit(object):
         # projection have modifying stuff applied, such as gang boosts and other
         # local modules that may help
         if self.__calculated and not projected and not withBoosters:
-            logger.debug("Fit has already been calculated and is not projected, returning: {0}", self)
+            logging.debug("Fit has already been calculated and is not projected, returning: {0}", self)
             return
 
         for runTime in ("early", "normal", "late"):
@@ -755,7 +755,7 @@ class Fit(object):
         timer.checkpoint('Done with fit calculation')
 
         if shadow:
-            logger.debug("Delete shadow fit object")
+            logging.debug("Delete shadow fit object")
             del self
 
     def fill(self):

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -635,7 +635,7 @@ class Fit(object):
             del self.commandBonuses[warfareBuffID]
 
     def calculateModifiedAttributes(self, targetFit=None, withBoosters=False, dirtyStorage=None):
-        timer = Timer(u'Fit: {}, {}'.format(self.ID, self.name), logger)
+        timer = Timer(u'Fit: {}, {}'.format(self.ID, self.name), logging)
         logging.info("Starting fit calculation on: {0}, withBoosters: {1}", self, withBoosters)
 
         shadow = False

--- a/eos/saveddata/implant.py
+++ b/eos/saveddata/implant.py
@@ -45,11 +45,11 @@ class Implant(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: %d) is not an Implant", self.itemID)
+            logger.error("Item (id: {0}) is not an Implant", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/implant.py
+++ b/eos/saveddata/implant.py
@@ -17,15 +17,14 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut
-
-logger = logging.getLogger(__name__)
 
 
 class Implant(HandledItem, ItemAttrShortcut):

--- a/eos/saveddata/implant.py
+++ b/eos/saveddata/implant.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -45,11 +45,11 @@ class Implant(HandledItem, ItemAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: {0}) is not an Implant", self.itemID)
+            logging.error("Item (id: {0}) is not an Implant", self.itemID)
             return
 
         self.build()

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -17,7 +17,8 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -27,8 +28,6 @@ from eos.enum import Enum
 from eos.mathUtils import floorFloat
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut, ChargeAttrShortcut
 from eos.types import Citadel
-
-logger = logging.getLogger(__name__)
 
 
 class State(Enum):

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -93,11 +93,11 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: %d) is not a Module", self.itemID)
+            logger.error("Item (id: {0}) is not a Module", self.itemID)
             return
 
         if self.chargeID:

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import validates, reconstructor
 
@@ -93,11 +93,11 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
         if self.isInvalid:
-            logger.error("Item (id: {0}) is not a Module", self.itemID)
+            logging.error("Item (id: {0}) is not a Module", self.itemID)
             return
 
         if self.chargeID:

--- a/eos/saveddata/override.py
+++ b/eos/saveddata/override.py
@@ -17,14 +17,13 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor
 
 import eos.db
 from eos.eqBase import EqBase
-
-logger = logging.getLogger(__name__)
 
 
 class Override(EqBase):

--- a/eos/saveddata/override.py
+++ b/eos/saveddata/override.py
@@ -42,13 +42,13 @@ class Override(EqBase):
         if self.attrID:
             self.__attr = eos.db.getAttributeInfo(self.attrID)
             if self.__attr is None:
-                logger.error("Attribute (id: %d) does not exist", self.attrID)
+                logger.error("Attribute (id: {0}) does not exist", self.attrID)
                 return
 
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: %d) does not exist", self.itemID)
+                logger.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
     @property

--- a/eos/saveddata/override.py
+++ b/eos/saveddata/override.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from sqlalchemy.orm import reconstructor
 
@@ -42,13 +42,13 @@ class Override(EqBase):
         if self.attrID:
             self.__attr = eos.db.getAttributeInfo(self.attrID)
             if self.__attr is None:
-                logger.error("Attribute (id: {0}) does not exist", self.attrID)
+                logging.error("Attribute (id: {0}) does not exist", self.attrID)
                 return
 
         if self.itemID:
             self.__item = eos.db.getItem(self.itemID)
             if self.__item is None:
-                logger.error("Item (id: {0}) does not exist", self.itemID)
+                logging.error("Item (id: {0}) does not exist", self.itemID)
                 return
 
     @property

--- a/eos/saveddata/ship.py
+++ b/eos/saveddata/ship.py
@@ -17,14 +17,13 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem
 from eos.modifiedAttributeDict import ModifiedAttributeDict, ItemAttrShortcut, cappingAttrKeyCache
 from eos.saveddata.mode import Mode
-
-logger = logging.getLogger(__name__)
 
 
 class Ship(ItemAttrShortcut, HandledItem):

--- a/eos/saveddata/ship.py
+++ b/eos/saveddata/ship.py
@@ -18,7 +18,7 @@
 # ===============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import eos.db
 from eos.effectHandlerHelpers import HandledItem

--- a/gui/bitmapLoader.py
+++ b/gui/bitmapLoader.py
@@ -26,6 +26,9 @@ import wx
 
 import config
 
+from logbook import Logger
+logger = Logger(__name__)
+
 try:
     from collections import OrderedDict
 except ImportError:
@@ -36,6 +39,7 @@ class BitmapLoader():
     try:
         archive = zipfile.ZipFile(config.getPyfaPath('imgs.zip'), 'r')
     except IOError:
+        logger.info("Using local image files instead of zip.")
         archive = None
 
     cachedBitmaps = OrderedDict()

--- a/gui/bitmapLoader.py
+++ b/gui/bitmapLoader.py
@@ -27,7 +27,7 @@ import wx
 import config
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 try:
     from collections import OrderedDict
@@ -39,7 +39,7 @@ class BitmapLoader():
     try:
         archive = zipfile.ZipFile(config.getPyfaPath('imgs.zip'), 'r')
     except IOError:
-        logger.info("Using local image files instead of zip.")
+        logging.info("Using local image files instead of zip.")
         archive = None
 
     cachedBitmaps = OrderedDict()

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -30,14 +30,14 @@ from gui.builtinViewColumns.state import State
 from gui.bitmapLoader import BitmapLoader
 import gui.builtinViews.emptyView
 from gui.utils.exportHtml import exportHtml
-from logging import getLogger, Formatter
 
 from service.fit import Fit
 from service.market import Market
 
 import gui.globalEvents as GE
 
-logger = getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 
 # Tab spawning handler

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -58,6 +58,7 @@ class FitSpawner(gui.multiSwitch.TabSpawner):
                     wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=event.fitID))
                     break
             except:
+                logger.warning("Caught exception in fitSelected")
                 pass
         if count < 0:
             startup = getattr(event, "startup", False)  # see OpenFitsThread in gui.mainFrame
@@ -274,6 +275,7 @@ class FittingView(d.Display):
             sFit.refreshFit(self.getActiveFit())
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.activeFitID))
         except wx._core.PyDeadObjectError:
+            logger.warning("Caught dead object")
             pass
 
         event.Skip()
@@ -476,6 +478,7 @@ class FittingView(d.Display):
 
             self.Show(self.activeFitID is not None and self.activeFitID == event.fitID)
         except wx._core.PyDeadObjectError:
+            logger.warning("Caught dead object")
             pass
         finally:
             event.Skip()
@@ -630,6 +633,7 @@ class FittingView(d.Display):
             try:
                 self.MakeSnapshot()
             except:
+                logger.warning("Failed to make snapshot")
                 pass
 
     def OnShow(self, event):
@@ -637,6 +641,7 @@ class FittingView(d.Display):
             try:
                 self.MakeSnapshot()
             except:
+                logger.warning("Failed to make snapshot")
                 pass
         event.Skip()
 
@@ -662,6 +667,7 @@ class FittingView(d.Display):
         try:
             fit = sFit.getFit(self.activeFitID)
         except:
+            logger.warning("Failed to get fit")
             return
 
         if fit is None:

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -37,7 +37,7 @@ from service.market import Market
 import gui.globalEvents as GE
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 # Tab spawning handler
@@ -58,7 +58,7 @@ class FitSpawner(gui.multiSwitch.TabSpawner):
                     wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=event.fitID))
                     break
             except:
-                logger.warning("Caught exception in fitSelected")
+                logging.warning("Caught exception in fitSelected")
                 pass
         if count < 0:
             startup = getattr(event, "startup", False)  # see OpenFitsThread in gui.mainFrame
@@ -275,7 +275,7 @@ class FittingView(d.Display):
             sFit.refreshFit(self.getActiveFit())
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.activeFitID))
         except wx._core.PyDeadObjectError:
-            logger.warning("Caught dead object")
+            logging.warning("Caught dead object")
             pass
 
         event.Skip()
@@ -478,7 +478,7 @@ class FittingView(d.Display):
 
             self.Show(self.activeFitID is not None and self.activeFitID == event.fitID)
         except wx._core.PyDeadObjectError:
-            logger.warning("Caught dead object")
+            logging.warning("Caught dead object")
             pass
         finally:
             event.Skip()
@@ -633,7 +633,7 @@ class FittingView(d.Display):
             try:
                 self.MakeSnapshot()
             except:
-                logger.warning("Failed to make snapshot")
+                logging.warning("Failed to make snapshot")
                 pass
 
     def OnShow(self, event):
@@ -641,7 +641,7 @@ class FittingView(d.Display):
             try:
                 self.MakeSnapshot()
             except:
-                logger.warning("Failed to make snapshot")
+                logging.warning("Failed to make snapshot")
                 pass
         event.Skip()
 
@@ -667,7 +667,7 @@ class FittingView(d.Display):
         try:
             fit = sFit.getFit(self.activeFitID)
         except:
-            logger.warning("Failed to get fit")
+            logging.warning("Failed to get fit")
             return
 
         if fit is None:

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -30,6 +30,8 @@ from service.fit import Fit
 from service.character import Character
 from service.network import AuthenticationError, TimeoutError
 from service.market import Market
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class CharacterTextValidor(BaseValidator):
@@ -52,6 +54,7 @@ class CharacterTextValidor(BaseValidator):
 
             return True
         except ValueError, e:
+            logger.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -626,10 +629,15 @@ class APIView(wx.Panel):
             activeChar = self.charEditor.entityEditor.getActiveEntity()
             list = sChar.apiCharList(activeChar.ID, self.inputID.GetLineText(0), self.inputKey.GetLineText(0))
         except AuthenticationError, e:
-            self.stStatus.SetLabel("Authentication failure. Please check keyID and vCode combination.")
+            msg = "Authentication failure. Please check keyID and vCode combination."
+            logger.info(msg)
+            self.stStatus.SetLabel(msg)
         except TimeoutError, e:
-            self.stStatus.SetLabel("Request timed out. Please check network connectivity and/or proxy settings.")
+            msg = "Request timed out. Please check network connectivity and/or proxy settings."
+            logger.info(msg)
+            self.stStatus.SetLabel(msg)
         except Exception, e:
+            logger.error(e)
             self.stStatus.SetLabel("Error:\n%s" % e.message)
         else:
             self.charChoice.Clear()
@@ -652,6 +660,7 @@ class APIView(wx.Panel):
                 sChar.apiFetch(activeChar.ID, charName)
                 self.stStatus.SetLabel("Successfully fetched %s\'s skills from EVE API." % charName)
             except Exception, e:
+                logger.error("Unable to retrieve %s\'s skills. Error message:\n%s" % (charName, e))
                 self.stStatus.SetLabel("Unable to retrieve %s\'s skills. Error message:\n%s" % (charName, e))
 
 

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -660,7 +660,7 @@ class APIView(wx.Panel):
                 sChar.apiFetch(activeChar.ID, charName)
                 self.stStatus.SetLabel("Successfully fetched %s\'s skills from EVE API." % charName)
             except Exception, e:
-                logger.error("Unable to retrieve %s\'s skills. Error message:\n%s" % (charName, e))
+                logger.error("Unable to retrieve {0}\'s skills. Error message:\n{1}", charName, e)
                 self.stStatus.SetLabel("Unable to retrieve %s\'s skills. Error message:\n%s" % (charName, e))
 
 

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -31,7 +31,7 @@ from service.character import Character
 from service.network import AuthenticationError, TimeoutError
 from service.market import Market
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class CharacterTextValidor(BaseValidator):
@@ -54,7 +54,7 @@ class CharacterTextValidor(BaseValidator):
 
             return True
         except ValueError, e:
-            logger.error(e)
+            logging.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -630,14 +630,14 @@ class APIView(wx.Panel):
             list = sChar.apiCharList(activeChar.ID, self.inputID.GetLineText(0), self.inputKey.GetLineText(0))
         except AuthenticationError, e:
             msg = "Authentication failure. Please check keyID and vCode combination."
-            logger.info(msg)
+            logging.info(msg)
             self.stStatus.SetLabel(msg)
         except TimeoutError, e:
             msg = "Request timed out. Please check network connectivity and/or proxy settings."
-            logger.info(msg)
+            logging.info(msg)
             self.stStatus.SetLabel(msg)
         except Exception, e:
-            logger.error(e)
+            logging.error(e)
             self.stStatus.SetLabel("Error:\n%s" % e.message)
         else:
             self.charChoice.Clear()
@@ -660,7 +660,7 @@ class APIView(wx.Panel):
                 sChar.apiFetch(activeChar.ID, charName)
                 self.stStatus.SetLabel("Successfully fetched %s\'s skills from EVE API." % charName)
             except Exception, e:
-                logger.error("Unable to retrieve {0}\'s skills. Error message:\n{1}", charName, e)
+                logging.error("Unable to retrieve {0}\'s skills. Error message:\n{1}", charName, e)
                 self.stStatus.SetLabel("Unable to retrieve %s\'s skills. Error message:\n%s" % (charName, e))
 
 

--- a/gui/characterSelection.py
+++ b/gui/characterSelection.py
@@ -23,6 +23,8 @@ import gui.globalEvents as GE
 import gui.mainFrame
 from service.character import Character
 from service.fit import Fit
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class CharacterSelection(wx.Panel):
@@ -113,6 +115,7 @@ class CharacterSelection(wx.Panel):
                 sChar.apiFetch(self.getActiveCharacter(), charName)
             except:
                 # can we do a popup, notifying user of API error?
+                logger.error("API fetch error")
                 pass
         self.refreshCharacterList()
 

--- a/gui/characterSelection.py
+++ b/gui/characterSelection.py
@@ -24,7 +24,7 @@ import gui.mainFrame
 from service.character import Character
 from service.fit import Fit
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class CharacterSelection(wx.Panel):
@@ -115,7 +115,7 @@ class CharacterSelection(wx.Panel):
                 sChar.apiFetch(self.getActiveCharacter(), charName)
             except:
                 # can we do a popup, notifying user of API error?
-                logger.error("API fetch error")
+                logging.error("API fetch error")
                 pass
         self.refreshCharacterList()
 

--- a/gui/chromeTabs.py
+++ b/gui/chromeTabs.py
@@ -23,6 +23,8 @@ import gui.utils.colorUtils as colorUtils
 import gui.utils.drawUtils as drawUtils
 import gui.utils.fonts as fonts
 from gui.bitmapLoader import BitmapLoader
+from logbook import Logger
+logger = Logger(__name__)
 
 from service.fit import Fit
 
@@ -1088,6 +1090,7 @@ class PFTabsContainer(wx.Panel):
                             self.previewTimer.Start(500, True)
                             break
                     except:
+                        logger.warning("Exception caught in CheckTabPreview.")
                         pass
 
     def CheckAddHighlighted(self, x, y):

--- a/gui/chromeTabs.py
+++ b/gui/chromeTabs.py
@@ -24,7 +24,7 @@ import gui.utils.drawUtils as drawUtils
 import gui.utils.fonts as fonts
 from gui.bitmapLoader import BitmapLoader
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 from service.fit import Fit
 
@@ -1090,7 +1090,7 @@ class PFTabsContainer(wx.Panel):
                             self.previewTimer.Start(500, True)
                             break
                     except:
-                        logger.warning("Exception caught in CheckTabPreview.")
+                        logging.warning("Exception caught in CheckTabPreview.")
                         pass
 
     def CheckAddHighlighted(self, x, y):

--- a/gui/contextMenu.py
+++ b/gui/contextMenu.py
@@ -18,9 +18,8 @@
 # =============================================================================
 
 import wx
-import logging
-
-logger = logging.getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class ContextMenu(object):

--- a/gui/contextMenu.py
+++ b/gui/contextMenu.py
@@ -119,7 +119,7 @@ class ContextMenu(object):
 
         debug_end = len(cls._ids)
         if (debug_end - debug_start):
-            logger.debug("%d new IDs created for this menu" % (debug_end - debug_start))
+            logger.debug("{0} new IDs created for this menu", (debug_end - debug_start))
 
         return rootMenu if empty is False else None
 

--- a/gui/contextMenu.py
+++ b/gui/contextMenu.py
@@ -19,7 +19,7 @@
 
 import wx
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class ContextMenu(object):
@@ -119,7 +119,7 @@ class ContextMenu(object):
 
         debug_end = len(cls._ids)
         if (debug_end - debug_start):
-            logger.debug("{0} new IDs created for this menu", (debug_end - debug_start))
+            logging.debug("{0} new IDs created for this menu", (debug_end - debug_start))
 
         return rootMenu if empty is False else None
 

--- a/gui/crestFittings.py
+++ b/gui/crestFittings.py
@@ -16,6 +16,9 @@ from eos.db import getItem
 import gui.display as d
 import gui.globalEvents as GE
 
+from logbook import Logger
+logger = Logger(__name__)
+
 
 class CrestFittings(wx.Frame):
     def __init__(self, parent):
@@ -145,7 +148,9 @@ class CrestFittings(wx.Frame):
             self.cacheTimer.Start(1000)
             self.fitTree.populateSkillTree(fittings)
         except requests.exceptions.ConnectionError:
-            self.statusbar.SetStatusText("Connection error, please check your internet connection")
+            msg = "Connection error, please check your internet connection"
+            logger.error(msg)
+            self.statusbar.SetStatusText(msg)
         finally:
             del waitDialog
 
@@ -173,7 +178,9 @@ class CrestFittings(wx.Frame):
             try:
                 sCrest.delFitting(self.getActiveCharacter(), data['fittingID'])
             except requests.exceptions.ConnectionError:
-                self.statusbar.SetStatusText("Connection error, please check your internet connection")
+                msg = "Connection error, please check your internet connection"
+                logger.error(msg)
+                self.statusbar.SetStatusText(msg)
 
 
 class ExportToEve(wx.Frame):
@@ -281,9 +288,12 @@ class ExportToEve(wx.Frame):
                 text = json.loads(res.text)
                 self.statusbar.SetStatusText(text['message'], 1)
             except ValueError:
+                logger.warning("Value error on loading JSON.")
                 self.statusbar.SetStatusText("", 1)
         except requests.exceptions.ConnectionError:
-            self.statusbar.SetStatusText("Connection error, please check your internet connection", 1)
+            msg = "Connection error, please check your internet connection"
+            logger.error(msg)
+            self.statusbar.SetStatusText(msg)
 
 
 class CrestMgmt(wx.Dialog):
@@ -405,6 +415,7 @@ class FittingsTreeView(wx.Panel):
                 cargo.amount = item['quantity']
                 list.append(cargo)
             except:
+                logger.error("Exception caught in displayFit")
                 pass
 
         self.parent.fitView.fitSelection = selection

--- a/gui/crestFittings.py
+++ b/gui/crestFittings.py
@@ -17,7 +17,7 @@ import gui.display as d
 import gui.globalEvents as GE
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class CrestFittings(wx.Frame):
@@ -149,7 +149,7 @@ class CrestFittings(wx.Frame):
             self.fitTree.populateSkillTree(fittings)
         except requests.exceptions.ConnectionError:
             msg = "Connection error, please check your internet connection"
-            logger.error(msg)
+            logging.error(msg)
             self.statusbar.SetStatusText(msg)
         finally:
             del waitDialog
@@ -179,7 +179,7 @@ class CrestFittings(wx.Frame):
                 sCrest.delFitting(self.getActiveCharacter(), data['fittingID'])
             except requests.exceptions.ConnectionError:
                 msg = "Connection error, please check your internet connection"
-                logger.error(msg)
+                logging.error(msg)
                 self.statusbar.SetStatusText(msg)
 
 
@@ -288,11 +288,11 @@ class ExportToEve(wx.Frame):
                 text = json.loads(res.text)
                 self.statusbar.SetStatusText(text['message'], 1)
             except ValueError:
-                logger.warning("Value error on loading JSON.")
+                logging.warning("Value error on loading JSON.")
                 self.statusbar.SetStatusText("", 1)
         except requests.exceptions.ConnectionError:
             msg = "Connection error, please check your internet connection"
-            logger.error(msg)
+            logging.error(msg)
             self.statusbar.SetStatusText(msg)
 
 
@@ -415,7 +415,7 @@ class FittingsTreeView(wx.Panel):
                 cargo.amount = item['quantity']
                 list.append(cargo)
             except:
-                logger.error("Exception caught in displayFit")
+                logging.error("Exception caught in displayFit")
                 pass
 
         self.parent.fitView.fitSelection = selection

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -18,8 +18,8 @@
 # =============================================================================
 
 import os
-import logging
-logger = logging.getLogger(__name__)
+from logbook import Logger
+logger = Logger(__name__)
 
 import wx
 

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -220,7 +220,9 @@ class GraphFrame(wx.Frame):
                 self.subplot.plot(x, y)
                 legend.append(fit.name)
             except:
-                self.SetStatusText("Invalid values in '%s'" % fit.name)
+                msg = "Invalid values in '%s'" % fit.name
+                logger.error(msg)
+                self.SetStatusText(msg)
                 self.canvas.draw()
                 return
 

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -19,7 +19,7 @@
 
 import os
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import wx
 
@@ -39,7 +39,7 @@ try:
     mplImported = False
 except ImportError:
     enabled = False
-    logger.info("Problems importing matplotlib; continuing without graphs")
+    logging.info("Problems importing matplotlib; continuing without graphs")
 
 
 class GraphFrame(wx.Frame):
@@ -221,7 +221,7 @@ class GraphFrame(wx.Frame):
                 legend.append(fit.name)
             except:
                 msg = "Invalid values in '%s'" % fit.name
-                logger.error(msg)
+                logging.error(msg)
                 self.SetStatusText(msg)
                 self.canvas.draw()
                 return

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -19,7 +19,8 @@
 
 import sys
 import os.path
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import sqlalchemy
 import wx
@@ -87,7 +88,8 @@ if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION 
         print("Error loading Attribute Editor: %s.\nAccess to Attribute Editor is disabled." % e.message)
         disableOverrideEditor = True
 
-logger = logging.getLogger("pyfa.gui.mainFrame")
+# TODO: Remove this if we don't need a special name for it
+# logger = logging.getLogger("pyfa.gui.mainFrame")
 
 
 # dummy panel(no paint no erasebk)

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -139,6 +139,7 @@ class MainFrame(wx.Frame):
         return cls.__instance if cls.__instance is not None else MainFrame()
 
     def __init__(self, title):
+        logger.debug("Initialize MainFrame")
         self.title = title
         wx.Frame.__init__(self, None, wx.ID_ANY, self.title)
 
@@ -706,7 +707,7 @@ class MainFrame(wx.Frame):
         try:
             fits = Port().importFitFromBuffer(clipboard, self.getActiveFit())
         except:
-            logger.error("Attempt to import failed:\n%s", clipboard)
+            logger.error("Attempt to import failed:\n{0}", clipboard)
         else:
             self._openAfterImport(fits)
 

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -20,7 +20,7 @@
 import sys
 import os.path
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import sqlalchemy
 import wx
@@ -139,7 +139,7 @@ class MainFrame(wx.Frame):
         return cls.__instance if cls.__instance is not None else MainFrame()
 
     def __init__(self, title):
-        logger.debug("Initialize MainFrame")
+        logging.debug("Initialize MainFrame")
         self.title = title
         wx.Frame.__init__(self, None, wx.ID_ANY, self.title)
 
@@ -707,7 +707,7 @@ class MainFrame(wx.Frame):
         try:
             fits = Port().importFitFromBuffer(clipboard, self.getActiveFit())
         except:
-            logger.error("Attempt to import failed:\n{0}", clipboard)
+            logging.error("Attempt to import failed:\n{0}", clipboard)
         else:
             self._openAfterImport(fits)
 

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -167,7 +167,7 @@ class MainMenuBar(wx.MenuBar):
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
 
     def fitChanged(self, event):
-        logger.debug("fitChanged - Start")
+        logger.debug("fitChanged triggered")
         enable = event.fitID is not None
         self.Enable(wx.ID_SAVEAS, enable)
         self.Enable(wx.ID_COPY, enable)

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -183,5 +183,3 @@ class MainMenuBar(wx.MenuBar):
         self.Enable(self.revertCharId, char.isDirty)
 
         event.Skip()
-
-        logger.debug("fitChanged - End")

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -26,6 +26,9 @@ import gui.graphFrame
 import gui.globalEvents as GE
 from gui.bitmapLoader import BitmapLoader
 
+from logbook import Logger
+logger = Logger(__name__)
+
 if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION >= (3, 0)):
     from service.crest import Crest
     from service.crest import CrestModes
@@ -33,6 +36,7 @@ if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION 
 
 class MainMenuBar(wx.MenuBar):
     def __init__(self):
+        logger.debug("Initialize MainMenuBar")
         self.characterEditorId = wx.NewId()
         self.damagePatternEditorId = wx.NewId()
         self.targetResistsEditorId = wx.NewId()
@@ -163,6 +167,7 @@ class MainMenuBar(wx.MenuBar):
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
 
     def fitChanged(self, event):
+        logger.debug("fitChanged - Start")
         enable = event.fitID is not None
         self.Enable(wx.ID_SAVEAS, enable)
         self.Enable(wx.ID_COPY, enable)
@@ -178,3 +183,5 @@ class MainMenuBar(wx.MenuBar):
         self.Enable(self.revertCharId, char.isDirty)
 
         event.Skip()
+
+        logger.debug("fitChanged - End")

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -27,7 +27,7 @@ import gui.globalEvents as GE
 from gui.bitmapLoader import BitmapLoader
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION >= (3, 0)):
     from service.crest import Crest
@@ -36,7 +36,7 @@ if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION 
 
 class MainMenuBar(wx.MenuBar):
     def __init__(self):
-        logger.debug("Initialize MainMenuBar")
+        logging.debug("Initialize MainMenuBar")
         self.characterEditorId = wx.NewId()
         self.damagePatternEditorId = wx.NewId()
         self.targetResistsEditorId = wx.NewId()
@@ -167,7 +167,7 @@ class MainMenuBar(wx.MenuBar):
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
 
     def fitChanged(self, event):
-        logger.debug("fitChanged triggered")
+        logging.debug("fitChanged triggered")
         enable = event.fitID is not None
         self.Enable(wx.ID_SAVEAS, enable)
         self.Enable(wx.ID_COPY, enable)

--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -54,6 +54,7 @@ class MetaButton(wx.ToggleButton):
 
 class MarketBrowser(wx.Panel):
     def __init__(self, parent):
+        logger.debug("Initialize marketBrowser")
         wx.Panel.__init__(self, parent)
         vbox = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(vbox)
@@ -131,6 +132,7 @@ class SearchBox(SBox.PFSearchBox):
 
 class MarketTree(wx.TreeCtrl):
     def __init__(self, parent, marketBrowser):
+        logger.debug("Initialize marketTree")
         wx.TreeCtrl.__init__(self, parent, style=wx.TR_DEFAULT_STYLE | wx.TR_HIDE_ROOT)
         self.root = self.AddRoot("root")
 
@@ -224,6 +226,7 @@ class ItemView(d.Display):
                     "attr:cpu,,,True"]
 
     def __init__(self, parent, marketBrowser):
+        logger.debug("Initialize ItemView")
         d.Display.__init__(self, parent)
         marketBrowser.Bind(wx.EVT_TREE_SEL_CHANGED, self.selectionMade)
 
@@ -251,6 +254,7 @@ class ItemView(d.Display):
         self.metaMap = self.makeReverseMetaMap()
 
         # Fill up recently used modules set
+        logger.debug("Fill up recently used modules set")
         for itemID in self.sMkt.serviceMarketRecentlyUsedModules["pyfaMarketRecentlyUsedModules"]:
             self.recentlyUsedModules.add(self.sMkt.getItem(itemID))
 

--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -25,6 +25,8 @@ import gui.PFSearchBox as SBox
 from gui.cachingImageList import CachingImageList
 from gui.contextMenu import ContextMenu
 from gui.bitmapLoader import BitmapLoader
+from logbook import Logger
+logger = Logger(__name__)
 
 ItemSelected, ITEM_SELECTED = wx.lib.newevent.NewEvent()
 
@@ -179,6 +181,7 @@ class MarketTree(wx.TreeCtrl):
                 try:
                     childId = self.AppendItem(root, childMktGrp.name, iconId, data=wx.TreeItemData(childMktGrp.ID))
                 except:
+                    logger.debug("Error appending item.")
                     continue
                 if sMkt.marketGroupHasTypesCheck(childMktGrp) is False:
                     self.AppendItem(childId, "dummy")

--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -26,7 +26,7 @@ from gui.cachingImageList import CachingImageList
 from gui.contextMenu import ContextMenu
 from gui.bitmapLoader import BitmapLoader
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 ItemSelected, ITEM_SELECTED = wx.lib.newevent.NewEvent()
 
@@ -54,7 +54,7 @@ class MetaButton(wx.ToggleButton):
 
 class MarketBrowser(wx.Panel):
     def __init__(self, parent):
-        logger.debug("Initialize marketBrowser")
+        logging.debug("Initialize marketBrowser")
         wx.Panel.__init__(self, parent)
         vbox = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(vbox)
@@ -132,7 +132,7 @@ class SearchBox(SBox.PFSearchBox):
 
 class MarketTree(wx.TreeCtrl):
     def __init__(self, parent, marketBrowser):
-        logger.debug("Initialize marketTree")
+        logging.debug("Initialize marketTree")
         wx.TreeCtrl.__init__(self, parent, style=wx.TR_DEFAULT_STYLE | wx.TR_HIDE_ROOT)
         self.root = self.AddRoot("root")
 
@@ -183,7 +183,7 @@ class MarketTree(wx.TreeCtrl):
                 try:
                     childId = self.AppendItem(root, childMktGrp.name, iconId, data=wx.TreeItemData(childMktGrp.ID))
                 except:
-                    logger.debug("Error appending item.")
+                    logging.debug("Error appending item.")
                     continue
                 if sMkt.marketGroupHasTypesCheck(childMktGrp) is False:
                     self.AppendItem(childId, "dummy")
@@ -226,7 +226,7 @@ class ItemView(d.Display):
                     "attr:cpu,,,True"]
 
     def __init__(self, parent, marketBrowser):
-        logger.debug("Initialize ItemView")
+        logging.debug("Initialize ItemView")
         d.Display.__init__(self, parent)
         marketBrowser.Bind(wx.EVT_TREE_SEL_CHANGED, self.selectionMade)
 
@@ -254,7 +254,7 @@ class ItemView(d.Display):
         self.metaMap = self.makeReverseMetaMap()
 
         # Fill up recently used modules set
-        logger.debug("Fill up recently used modules set")
+        logging.debug("Fill up recently used modules set")
         for itemID in self.sMkt.serviceMarketRecentlyUsedModules["pyfaMarketRecentlyUsedModules"]:
             self.recentlyUsedModules.add(self.sMkt.getItem(itemID))
 

--- a/gui/patternEditor.py
+++ b/gui/patternEditor.py
@@ -23,6 +23,8 @@ from wx.lib.intctrl import IntCtrl
 from gui.utils.clipboard import toClipboard, fromClipboard
 from gui.builtinViews.entityEditor import EntityEditor, BaseValidator
 from service.damagePattern import DamagePattern, ImportError
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class DmgPatternTextValidor(BaseValidator):
@@ -45,6 +47,7 @@ class DmgPatternTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
+            logger.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -254,9 +257,12 @@ class DmgPatternEditorDlg(wx.Dialog):
                 sDP.importPatterns(text)
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
             except ImportError as e:
+                logger.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception:
-                self.stNotice.SetLabel("Could not import from clipboard: unknown errors")
+                msg = "Could not import from clipboard: unknown errors"
+                logger.warning(msg)
+                self.stNotice.SetLabel(msg)
             finally:
                 self.entityEditor.refreshEntityList()
         else:

--- a/gui/patternEditor.py
+++ b/gui/patternEditor.py
@@ -24,7 +24,7 @@ from gui.utils.clipboard import toClipboard, fromClipboard
 from gui.builtinViews.entityEditor import EntityEditor, BaseValidator
 from service.damagePattern import DamagePattern, ImportError
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class DmgPatternTextValidor(BaseValidator):
@@ -47,7 +47,7 @@ class DmgPatternTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
-            logger.error(e)
+            logging.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -257,11 +257,11 @@ class DmgPatternEditorDlg(wx.Dialog):
                 sDP.importPatterns(text)
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
             except ImportError as e:
-                logger.error(e)
+                logging.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception:
                 msg = "Could not import from clipboard: unknown errors"
-                logger.warning(msg)
+                logging.warning(msg)
                 self.stNotice.SetLabel(msg)
             finally:
                 self.entityEditor.refreshEntityList()

--- a/gui/propertyEditor.py
+++ b/gui/propertyEditor.py
@@ -267,7 +267,7 @@ class AttributeGrid(wxpg.PropertyGrid):
 
         self.itemView.updateItems()
 
-        logger.debug('%s changed to "%s"' % (p.GetName(), p.GetValueAsString()))
+        logger.debug('{0} changed to "{1}"', p.GetName(), p.GetValueAsString())
 
     def OnPropGridSelect(self, event):
         pass

--- a/gui/propertyEditor.py
+++ b/gui/propertyEditor.py
@@ -1,5 +1,6 @@
 import csv
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import wx
 
@@ -18,8 +19,6 @@ import gui.globalEvents as GE
 import gui.PFSearchBox as SBox
 from gui.marketBrowser import SearchBox
 from gui.bitmapLoader import BitmapLoader
-
-logger = logging.getLogger(__name__)
 
 
 class AttributeEditor(wx.Frame):

--- a/gui/propertyEditor.py
+++ b/gui/propertyEditor.py
@@ -1,6 +1,6 @@
 import csv
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import wx
 
@@ -267,7 +267,7 @@ class AttributeGrid(wxpg.PropertyGrid):
 
         self.itemView.updateItems()
 
-        logger.debug('{0} changed to "{1}"', p.GetName(), p.GetValueAsString())
+        logging.debug('{0} changed to "{1}"', p.GetName(), p.GetValueAsString())
 
     def OnPropGridSelect(self, event):
         pass

--- a/gui/resistsEditor.py
+++ b/gui/resistsEditor.py
@@ -22,6 +22,8 @@ from service.targetResists import TargetResists
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.clipboard import toClipboard, fromClipboard
 from gui.builtinViews.entityEditor import EntityEditor, BaseValidator
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class TargetResistsTextValidor(BaseValidator):
@@ -44,6 +46,7 @@ class TargetResistsTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
+            logger.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -227,10 +230,14 @@ class ResistsEditorDlg(wx.Dialog):
 
         except ValueError:
             editObj.SetForegroundColour(wx.RED)
-            self.stNotice.SetLabel("Incorrect Formatting (decimals only)")
+            msg = "Incorrect Formatting (decimals only)"
+            logger.warning(msg)
+            self.stNotice.SetLabel(msg)
         except AssertionError:
             editObj.SetForegroundColour(wx.RED)
-            self.stNotice.SetLabel("Incorrect Range (must be 0-100)")
+            msg = "Incorrect Range (must be 0-100)"
+            logger.warning(msg)
+            self.stNotice.SetLabel(msg)
         finally:  # Refresh for color changes to take effect immediately
             self.Refresh()
 
@@ -268,9 +275,12 @@ class ResistsEditorDlg(wx.Dialog):
                 sTR.importPatterns(text)
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
             except ImportError as e:
+                logger.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception:
-                self.stNotice.SetLabel("Could not import from clipboard: unknown errors")
+                msg = "Could not import from clipboard: unknown errors"
+                logger.warning(msg)
+                self.stNotice.SetLabel(msg)
             finally:
                 self.entityEditor.refreshEntityList()
         else:

--- a/gui/resistsEditor.py
+++ b/gui/resistsEditor.py
@@ -23,7 +23,7 @@ from gui.bitmapLoader import BitmapLoader
 from gui.utils.clipboard import toClipboard, fromClipboard
 from gui.builtinViews.entityEditor import EntityEditor, BaseValidator
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class TargetResistsTextValidor(BaseValidator):
@@ -46,7 +46,7 @@ class TargetResistsTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
-            logger.error(e)
+            logging.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -231,12 +231,12 @@ class ResistsEditorDlg(wx.Dialog):
         except ValueError:
             editObj.SetForegroundColour(wx.RED)
             msg = "Incorrect Formatting (decimals only)"
-            logger.warning(msg)
+            logging.warning(msg)
             self.stNotice.SetLabel(msg)
         except AssertionError:
             editObj.SetForegroundColour(wx.RED)
             msg = "Incorrect Range (must be 0-100)"
-            logger.warning(msg)
+            logging.warning(msg)
             self.stNotice.SetLabel(msg)
         finally:  # Refresh for color changes to take effect immediately
             self.Refresh()
@@ -275,11 +275,11 @@ class ResistsEditorDlg(wx.Dialog):
                 sTR.importPatterns(text)
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
             except ImportError as e:
-                logger.error(e)
+                logging.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception:
                 msg = "Could not import from clipboard: unknown errors"
-                logger.warning(msg)
+                logging.warning(msg)
                 self.stNotice.SetLabel(msg)
             finally:
                 self.entityEditor.refreshEntityList()

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -47,6 +47,7 @@ class ImplantTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
+            logger.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -196,9 +197,10 @@ class ImplantSetEditorDlg(wx.Dialog):
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
                 self.showInput(False)
             except ImportError as e:
+                logger.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception as e:
-                logging.exception("Unhandled Exception")
+                logger.error(e)
                 self.stNotice.SetLabel("Could not import from clipboard: unknown errors")
             finally:
                 self.updateChoices()

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -17,15 +17,14 @@
 # along with pyfa.    If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import wx
 
 from service.implantSet import ImplantSets
 from gui.builtinViews.implantEditor import BaseImplantEditorView
 from gui.utils.clipboard import toClipboard, fromClipboard
 from gui.builtinViews.entityEditor import EntityEditor, BaseValidator
-
-logger = logging.getLogger(__name__)
 
 
 class ImplantTextValidor(BaseValidator):

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -18,7 +18,7 @@
 # =============================================================================
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import wx
 
 from service.implantSet import ImplantSets
@@ -47,7 +47,7 @@ class ImplantTextValidor(BaseValidator):
 
             return True
         except ValueError as e:
-            logger.error(e)
+            logging.error(e)
             wx.MessageBox(u"{}".format(e), "Error")
             textCtrl.SetFocus()
             return False
@@ -197,10 +197,10 @@ class ImplantSetEditorDlg(wx.Dialog):
                 self.stNotice.SetLabel("Patterns successfully imported from clipboard")
                 self.showInput(False)
             except ImportError as e:
-                logger.error(e)
+                logging.error(e)
                 self.stNotice.SetLabel(str(e))
             except Exception as e:
-                logger.error(e)
+                logging.error(e)
                 self.stNotice.SetLabel("Could not import from clipboard: unknown errors")
             finally:
                 self.updateChoices()

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -19,6 +19,8 @@ import gui.utils.animEffects as animEffects
 from gui.PFListPane import PFListPane
 from gui.contextMenu import ContextMenu
 from gui.bitmapLoader import BitmapLoader
+from logbook import Logger
+logger = Logger(__name__)
 
 FitRenamed, EVT_FIT_RENAMED = wx.lib.newevent.NewEvent()
 FitSelected, EVT_FIT_SELECTED = wx.lib.newevent.NewEvent()
@@ -680,6 +682,7 @@ class ShipBrowser(wx.Panel):
         self.lpane.Freeze()
         self.lpane.RemoveAllChildren()
 
+        logger.debug("Populate ship category list.")
         if len(self.categoryList) == 0:
             # set cache of category list
             self.categoryList = list(sMkt.getShipRoot())

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -20,7 +20,7 @@ from gui.PFListPane import PFListPane
 from gui.contextMenu import ContextMenu
 from gui.bitmapLoader import BitmapLoader
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 FitRenamed, EVT_FIT_RENAMED = wx.lib.newevent.NewEvent()
 FitSelected, EVT_FIT_SELECTED = wx.lib.newevent.NewEvent()
@@ -682,7 +682,7 @@ class ShipBrowser(wx.Panel):
         self.lpane.Freeze()
         self.lpane.RemoveAllChildren()
 
-        logger.debug("Populate ship category list.")
+        logging.debug("Populate ship category list.")
         if len(self.categoryList) == 0:
             # set cache of category list
             self.categoryList = list(sMkt.getShipRoot())

--- a/gui/utils/compat.py
+++ b/gui/utils/compat.py
@@ -1,6 +1,9 @@
 # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
 # Passes Python2.7's test suite and incorporates all the latest updates.
 
+from logbook import Logger
+logger = Logger(__name__)
+
 try:
     from thread import get_ident as _get_ident
 except ImportError:
@@ -9,6 +12,7 @@ except ImportError:
 try:
     from _abcoll import KeysView, ValuesView, ItemsView
 except ImportError:
+    logger.warning("Failed to import from _abcoll")
     pass
 
 

--- a/gui/utils/compat.py
+++ b/gui/utils/compat.py
@@ -2,7 +2,7 @@
 # Passes Python2.7's test suite and incorporates all the latest updates.
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 try:
     from thread import get_ident as _get_ident
@@ -12,7 +12,7 @@ except ImportError:
 try:
     from _abcoll import KeysView, ValuesView, ItemsView
 except ImportError:
-    logger.warning("Failed to import from _abcoll")
+    logging.warning("Failed to import from _abcoll")
     pass
 
 

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -4,6 +4,8 @@ import wx
 from service.settings import HTMLExportSettings
 from service.fit import Fit
 from service.market import Market
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class exportHtml():
@@ -194,6 +196,7 @@ class exportHtmlThread(threading.Thread):
                             HTMLgroup += '        <li><a data-dna="' + dnaFit + '" target="_blank">' + ship.name + ": " + \
                                          fit[1] + '</a></li>\n'
                         except:
+                            logger.warning("Failed to export line")
                             pass
                         finally:
                             if self.callback:
@@ -216,6 +219,7 @@ class exportHtmlThread(threading.Thread):
                                 HTMLship += '          <li><a data-dna="' + dnaFit + '" target="_blank">' + fit[
                                     1] + '</a></li>\n'
                             except:
+                                logger.warning("Failed to export line")
                                 continue
                             finally:
                                 if self.callback:
@@ -268,6 +272,7 @@ class exportHtmlThread(threading.Thread):
                         HTML += '<a class="outOfGameBrowserLink" target="_blank" href="' + dnaUrl + dnaFit + '">' + ship.name + ': ' + \
                                 fit[1] + '</a><br> \n'
                     except:
+                        logger.error("Failed to export line")
                         continue
                     finally:
                         if self.callback:

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -5,7 +5,7 @@ from service.settings import HTMLExportSettings
 from service.fit import Fit
 from service.market import Market
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class exportHtml():
@@ -196,7 +196,7 @@ class exportHtmlThread(threading.Thread):
                             HTMLgroup += '        <li><a data-dna="' + dnaFit + '" target="_blank">' + ship.name + ": " + \
                                          fit[1] + '</a></li>\n'
                         except:
-                            logger.warning("Failed to export line")
+                            logging.warning("Failed to export line")
                             pass
                         finally:
                             if self.callback:
@@ -219,7 +219,7 @@ class exportHtmlThread(threading.Thread):
                                 HTMLship += '          <li><a data-dna="' + dnaFit + '" target="_blank">' + fit[
                                     1] + '</a></li>\n'
                             except:
-                                logger.warning("Failed to export line")
+                                logging.warning("Failed to export line")
                                 continue
                             finally:
                                 if self.callback:
@@ -272,7 +272,7 @@ class exportHtmlThread(threading.Thread):
                         HTML += '<a class="outOfGameBrowserLink" target="_blank" href="' + dnaUrl + dnaFit + '">' + ship.name + ': ' + \
                                 fit[1] + '</a><br> \n'
                     except:
-                        logger.error("Failed to export line")
+                        logging.error("Failed to export line")
                         continue
                     finally:
                         if self.callback:

--- a/pyfa.py
+++ b/pyfa.py
@@ -25,7 +25,7 @@ import config
 from optparse import OptionParser, BadOptionError, AmbiguousOptionError
 
 from logbook import RotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler
-log = Logger(__name__)
+logger = Logger(__name__)
 
 
 class PassThroughOptionParser(OptionParser):
@@ -187,33 +187,33 @@ if __name__ == "__main__":
 
     with logging_setup.threadbound():
         # Output all stdout (print) messages as warnings
-        sys.stdout = LoggerWriter(log.warning)
+        sys.stdout = LoggerWriter(logger.warning)
         # Output all stderr (stacktrace) messages as critical
-        sys.stderr = LoggerWriter(log.critical)
+        sys.stderr = LoggerWriter(logger.critical)
 
-        log.info("Starting Pyfa")
+        logger.info("Starting Pyfa")
 
         # Import everything
-        log.debug("Import wx")
+        logger.debug("Import wx")
         import wx
         import os
         import os.path
 
-        log.debug("Import eos.db")
+        logger.debug("Import eos.db")
         import eos.db
         import service.prefetch
         from gui.mainFrame import MainFrame
 
-        log.debug("Make sure the saveddata db exists")
+        logger.debug("Make sure the saveddata db exists")
         if not os.path.exists(config.savePath):
             os.mkdir(config.savePath)
 
         eos.db.saveddata_meta.create_all()
 
         pyfa = wx.App(False)
-        log.debug("Show GUI")
+        logger.debug("Show GUI")
         MainFrame(options.title)
 
         # run the gui mainloop
-        log.debug("Run MainLoop()")
+        logger.debug("Run MainLoop()")
         pyfa.MainLoop()

--- a/pyfa.py
+++ b/pyfa.py
@@ -19,6 +19,7 @@
 # ==============================================================================
 
 import sys
+import os
 import re
 import config
 
@@ -150,6 +151,53 @@ if __name__ == "__main__":
     '''
 
     if options.debug:
+        savePath_filename = "Pyfa_debug.log"
+    else:
+        savePath_filename = "Pyfa.log"
+
+    savePath_Destination = config.getSavePath(savePath_filename)
+
+    try:
+        if options.debug and savePath_Destination:
+            logging_mode = "Debug"
+            logging_setup = NestedSetup([
+                # make sure we never bubble up to the stderr handler
+                # if we run out of setup handling
+                NullHandler(),
+                StreamHandler(
+                    sys.stdout,
+                    bubble=False
+                ),
+                RotatingFileHandler(
+                    savePath_Destination,
+                    level=0,
+                    max_size=1048576,
+                    backup_count=5,
+                    bubble=True
+                )
+            ])
+        elif savePath_Destination:
+            logging_mode = "User"
+            logging_setup = NestedSetup([
+                # make sure we never bubble up to the stderr handler
+                # if we run out of setup handling
+                NullHandler(),
+                FingersCrossedHandler(
+                    RotatingFileHandler(
+                        savePath_Destination,
+                        level=0,
+                        max_size=1048576,
+                        backup_count=5,
+                        bubble=False
+                    ),
+                    # action_level=Warning,
+                    # buffer_size=1000,
+                    # pull_information=True,
+                    # reset=False,
+                )
+            ])
+    except:
+        logging_mode = "Console Only"
         logging_setup = NestedSetup([
             # make sure we never bubble up to the stderr handler
             # if we run out of setup handling
@@ -157,32 +205,6 @@ if __name__ == "__main__":
             StreamHandler(
                 sys.stdout,
                 bubble=False
-            ),
-            RotatingFileHandler(
-                config.getSavePath("Pyfa_debug.log"),
-                level=0,
-                max_size=1048576,
-                backup_count=5,
-                bubble=True
-            )
-        ])
-    else:
-        logging_setup = NestedSetup([
-            # make sure we never bubble up to the stderr handler
-            # if we run out of setup handling
-            NullHandler(),
-            FingersCrossedHandler(
-                RotatingFileHandler(
-                    config.getSavePath("Pyfa.log"),
-                    level=0,
-                    max_size=1048576,
-                    backup_count=5,
-                    bubble=False
-                ),
-                # action_level=Warning,
-                # buffer_size=1000,
-                # pull_information=True,
-                # reset=False,
             )
         ])
 
@@ -199,6 +221,7 @@ if __name__ == "__main__":
             logger.critical("Cannot access log file.  Continuing without writing stderr to log.")
 
         logger.info("Starting Pyfa")
+        logger.info("Running in logging mode: {0}", logging_mode)
 
         # Import everything
         logger.debug("Import wx")

--- a/pyfa.py
+++ b/pyfa.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     savePath_Destination = config.getSavePath(savePath_filename)
 
     try:
-        if options.debug and savePath_Destination:
+        if options.debug:
             logging_mode = "Debug"
             logging_setup = NestedSetup([
                 # make sure we never bubble up to the stderr handler
@@ -176,7 +176,7 @@ if __name__ == "__main__":
                     bubble=True
                 )
             ])
-        elif savePath_Destination:
+        else:
             logging_mode = "User"
             logging_setup = NestedSetup([
                 # make sure we never bubble up to the stderr handler

--- a/pyfa.py
+++ b/pyfa.py
@@ -39,6 +39,7 @@ class PassThroughOptionParser(OptionParser):
             try:
                 OptionParser._process_args(self, largs, rargs, values)
             except (BadOptionError, AmbiguousOptionError) as e:
+                logger.error("Bad startup option passed.")
                 largs.append(e.opt_str)
 
 

--- a/pyfa.py
+++ b/pyfa.py
@@ -188,9 +188,15 @@ if __name__ == "__main__":
 
     with logging_setup.threadbound():
         # Output all stdout (print) messages as warnings
-        sys.stdout = LoggerWriter(logger.warning)
+        try:
+            sys.stdout = LoggerWriter(logger.warning)
+        except ValueError:
+            logger.critical("Cannot access log file.  Continuing without writing stdout to log.")
         # Output all stderr (stacktrace) messages as critical
-        sys.stderr = LoggerWriter(logger.critical)
+        try:
+            sys.stderr = LoggerWriter(logger.critical)
+        except ValueError:
+            logger.critical("Cannot access log file.  Continuing without writing stderr to log.")
 
         logger.info("Starting Pyfa")
 

--- a/pyfa.py
+++ b/pyfa.py
@@ -25,7 +25,7 @@ import config
 
 from optparse import OptionParser, BadOptionError, AmbiguousOptionError
 
-from logbook import RotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler
+from logbook import TimedRotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler
 logger = Logger(__name__)
 
 
@@ -168,13 +168,13 @@ if __name__ == "__main__":
                     sys.stdout,
                     bubble=False
                 ),
-                RotatingFileHandler(
-                    savePath_Destination,
-                    level=0,
-                    max_size=1048576,
-                    backup_count=5,
-                    bubble=True
-                )
+                TimedRotatingFileHandler(
+                        savePath_Destination,
+                        level=0,
+                        backup_count=5,
+                        bubble=False,
+                        date_format='%Y-%m-%d',
+                ),
             ])
         else:
             logging_mode = "User"
@@ -183,12 +183,12 @@ if __name__ == "__main__":
                 # if we run out of setup handling
                 NullHandler(),
                 FingersCrossedHandler(
-                    RotatingFileHandler(
+                    TimedRotatingFileHandler(
                         savePath_Destination,
                         level=0,
-                        max_size=1048576,
                         backup_count=5,
-                        bubble=False
+                        bubble=False,
+                        date_format='%Y-%m-%d',
                     ),
                     # action_level=Warning,
                     # buffer_size=1000,

--- a/pyfa.py
+++ b/pyfa.py
@@ -206,8 +206,8 @@ if __name__ == "__main__":
                                 bubble=False,
                                 date_format='%Y-%m-%d',
                         ),
-                        # action_level=Warning,
-                        # buffer_size=1000,
+                        action_level=ERROR,
+                        buffer_size=1000,
                         # pull_information=True,
                         # reset=False,
                 )

--- a/pyfa.py
+++ b/pyfa.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
                         savePath_Destination,
                         level=0,
                         backup_count=3,
-                        bubble=False,
+                        bubble=True,
                         date_format='%Y-%m-%d',
                 ),
             ])

--- a/pyfa.py
+++ b/pyfa.py
@@ -25,7 +25,8 @@ import config
 
 from optparse import OptionParser, BadOptionError, AmbiguousOptionError
 
-from logbook import TimedRotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler
+from logbook import TimedRotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler, \
+    CRITICAL, ERROR, WARNING, DEBUG, INFO
 logging = Logger(__name__)
 
 
@@ -71,8 +72,22 @@ parser.add_option("-w", "--wx28", action="store_true", dest="force28", help="For
 parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set logger to debug level.", default=False)
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
+parser.add_option("-l", "--logginglevel", action="store", dest="logginglevel", help="Set the desired logging level (Critical, Error, Warning, Info, Debug)", default="Error")
 
 (options, args) = parser.parse_args()
+
+if options.logginglevel == "Critical":
+    options.logginglevel = CRITICAL
+elif options.logginglevel == "Error":
+    options.logginglevel = ERROR
+elif options.logginglevel == "Warning":
+    options.logginglevel = WARNING
+elif options.logginglevel == "Info":
+    options.logginglevel = INFO
+elif options.logginglevel == "Debug":
+    options.logginglevel = DEBUG
+else:
+    options.logginglevel = ERROR
 
 if not hasattr(sys, 'frozen'):
 
@@ -165,8 +180,9 @@ if __name__ == "__main__":
                 # if we run out of setup handling
                 NullHandler(),
                 StreamHandler(
-                    sys.stdout,
-                    bubble=False
+                        sys.stdout,
+                        bubble=False,
+                        level=options.logginglevel
                 ),
                 TimedRotatingFileHandler(
                         savePath_Destination,
@@ -183,17 +199,17 @@ if __name__ == "__main__":
                 # if we run out of setup handling
                 NullHandler(),
                 FingersCrossedHandler(
-                    TimedRotatingFileHandler(
-                        savePath_Destination,
-                        level=0,
-                        backup_count=3,
-                        bubble=False,
-                        date_format='%Y-%m-%d',
-                    ),
-                    # action_level=Warning,
-                    # buffer_size=1000,
-                    # pull_information=True,
-                    # reset=False,
+                        TimedRotatingFileHandler(
+                                savePath_Destination,
+                                level=0,
+                                backup_count=3,
+                                bubble=False,
+                                date_format='%Y-%m-%d',
+                        ),
+                        # action_level=Warning,
+                        # buffer_size=1000,
+                        # pull_information=True,
+                        # reset=False,
                 )
             ])
     except:
@@ -245,6 +261,8 @@ if __name__ == "__main__":
         pyfa = wx.App(False)
         logging.debug("Show GUI")
         MainFrame(options.title)
+
+        logging.critical("Force logging")
 
         # run the gui mainloop
         logging.debug("Run MainLoop()")

--- a/pyfa.py
+++ b/pyfa.py
@@ -209,16 +209,18 @@ if __name__ == "__main__":
         ])
 
     with logging_setup.threadbound():
-        # Output all stdout (print) messages as warnings
-        try:
-            sys.stdout = LoggerWriter(logger.warning)
-        except ValueError:
-            logger.critical("Cannot access log file.  Continuing without writing stdout to log.")
-        # Output all stderr (stacktrace) messages as critical
-        try:
-            sys.stderr = LoggerWriter(logger.critical)
-        except ValueError:
-            logger.critical("Cannot access log file.  Continuing without writing stderr to log.")
+        # Don't redirect if frozen
+        if not hasattr(sys, 'frozen'):
+            # Output all stdout (print) messages as warnings
+            try:
+                sys.stdout = LoggerWriter(logger.warning)
+            except ValueError:
+                logger.critical("Cannot access log file.  Continuing without writing stdout to log.")
+            # Output all stderr (stacktrace) messages as critical
+            try:
+                sys.stderr = LoggerWriter(logger.critical)
+            except ValueError:
+                logger.critical("Cannot access log file.  Continuing without writing stderr to log.")
 
         logger.info("Starting Pyfa")
         logger.info("Running in logging mode: {0}", logging_mode)

--- a/pyfa.py
+++ b/pyfa.py
@@ -26,7 +26,7 @@ import config
 from optparse import OptionParser, BadOptionError, AmbiguousOptionError
 
 from logbook import TimedRotatingFileHandler, Logger, StreamHandler, NestedSetup, FingersCrossedHandler, NullHandler
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class PassThroughOptionParser(OptionParser):
@@ -40,7 +40,7 @@ class PassThroughOptionParser(OptionParser):
             try:
                 OptionParser._process_args(self, largs, rargs, values)
             except (BadOptionError, AmbiguousOptionError) as e:
-                logger.error("Bad startup option passed.")
+                logging.error("Bad startup option passed.")
                 largs.append(e.opt_str)
 
 
@@ -213,39 +213,39 @@ if __name__ == "__main__":
         if not hasattr(sys, 'frozen'):
             # Output all stdout (print) messages as warnings
             try:
-                sys.stdout = LoggerWriter(logger.warning)
+                sys.stdout = LoggerWriter(logging.warning)
             except ValueError:
-                logger.critical("Cannot access log file.  Continuing without writing stdout to log.")
+                logging.critical("Cannot access log file.  Continuing without writing stdout to log.")
             # Output all stderr (stacktrace) messages as critical
             try:
-                sys.stderr = LoggerWriter(logger.critical)
+                sys.stderr = LoggerWriter(logging.critical)
             except ValueError:
-                logger.critical("Cannot access log file.  Continuing without writing stderr to log.")
+                logging.critical("Cannot access log file.  Continuing without writing stderr to log.")
 
-        logger.info("Starting Pyfa")
-        logger.info("Running in logging mode: {0}", logging_mode)
+        logging.info("Starting Pyfa")
+        logging.info("Running in logging mode: {0}", logging_mode)
 
         # Import everything
-        logger.debug("Import wx")
+        logging.debug("Import wx")
         import wx
         import os
         import os.path
 
-        logger.debug("Import eos.db")
+        logging.debug("Import eos.db")
         import eos.db
         import service.prefetch
         from gui.mainFrame import MainFrame
 
-        logger.debug("Make sure the saveddata db exists")
+        logging.debug("Make sure the saveddata db exists")
         if not os.path.exists(config.savePath):
             os.mkdir(config.savePath)
 
         eos.db.saveddata_meta.create_all()
 
         pyfa = wx.App(False)
-        logger.debug("Show GUI")
+        logging.debug("Show GUI")
         MainFrame(options.title)
 
         # run the gui mainloop
-        logger.debug("Run MainLoop()")
+        logging.debug("Run MainLoop()")
         pyfa.MainLoop()

--- a/pyfa.py
+++ b/pyfa.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
 
     with logging_setup.threadbound():
         # Don't redirect if frozen
-        if not hasattr(sys, 'frozen'):
+        if not hasattr(sys, 'frozen') and not options.debug:
             # Output all stdout (print) messages as warnings
             try:
                 sys.stdout = LoggerWriter(logging.warning)

--- a/pyfa.py
+++ b/pyfa.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                 TimedRotatingFileHandler(
                         savePath_Destination,
                         level=0,
-                        backup_count=5,
+                        backup_count=3,
                         bubble=False,
                         date_format='%Y-%m-%d',
                 ),
@@ -186,7 +186,7 @@ if __name__ == "__main__":
                     TimedRotatingFileHandler(
                         savePath_Destination,
                         level=0,
-                        backup_count=5,
+                        backup_count=3,
                         bubble=False,
                         date_format='%Y-%m-%d',
                     ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+logbook
 matplotlib
 PyYAML
 python-dateutil

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -248,12 +248,12 @@ if __name__ == "__main__":
             try:
                 shutil.rmtree(tmpDir)
             except:
-                logger.warning("Failed to remove: %s" % tmpDir)
+                logger.warning("Failed to remove: {0}", tmpDir)
                 pass
             try:
                 os.unlink(tmpFile)
             except:
-                logger.warning("Faileld to remove: %s" % tmpFile)
+                logger.warning("Faileld to remove: {0}", tmpFile)
                 pass
 
         sys.stdout = oldstd

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -35,6 +35,9 @@ import string
 import zipfile
 import errno
 from subprocess import call
+from logbook import Logger
+logger = Logger(__name__)
+
 
 class FileStub():
     def write(self, *args):
@@ -240,14 +243,17 @@ if __name__ == "__main__":
             try:
                 shutil.rmtree("dist") # Inno dir
             except:
+                logger.warning("Failed to remove dist")
                 pass
             try:
                 shutil.rmtree(tmpDir)
             except:
+                logger.warning("Failed to remove: %s" % tmpDir)
                 pass
             try:
                 os.unlink(tmpFile)
             except:
+                logger.warning("Faileld to remove: %s" % tmpFile)
                 pass
 
         sys.stdout = oldstd

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -36,7 +36,7 @@ import zipfile
 import errno
 from subprocess import call
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class FileStub():
@@ -243,17 +243,17 @@ if __name__ == "__main__":
             try:
                 shutil.rmtree("dist") # Inno dir
             except:
-                logger.warning("Failed to remove dist")
+                logging.warning("Failed to remove dist")
                 pass
             try:
                 shutil.rmtree(tmpDir)
             except:
-                logger.warning("Failed to remove: {0}", tmpDir)
+                logging.warning("Failed to remove: {0}", tmpDir)
                 pass
             try:
                 os.unlink(tmpFile)
             except:
-                logger.warning("Faileld to remove: {0}", tmpFile)
+                logging.warning("Faileld to remove: {0}", tmpFile)
                 pass
 
         sys.stdout = oldstd

--- a/scripts/itemDiff.py
+++ b/scripts/itemDiff.py
@@ -30,6 +30,8 @@ import os.path
 import re
 import sqlite3
 import sys
+from logbook import Logger
+logger = Logger(__name__)
 
 script_dir = os.path.dirname(__file__)
 default_old = os.path.join(script_dir, "..", "eve.db")
@@ -408,6 +410,7 @@ def main(old, new, groups=True, effects=True, attributes=True, renames=True):
         for row in new_cursor:
             new_meta[row[0]] = row[1]
     except:
+        logger.warning("Failed to get db metadata")
         pass
     # Print jobs
     print("Comparing databases:\n{0} -> {1}\n".format(old_meta.get("client_build"), new_meta.get("client_build")))

--- a/scripts/itemDiff.py
+++ b/scripts/itemDiff.py
@@ -31,7 +31,7 @@ import re
 import sqlite3
 import sys
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 script_dir = os.path.dirname(__file__)
 default_old = os.path.join(script_dir, "..", "eve.db")
@@ -410,7 +410,7 @@ def main(old, new, groups=True, effects=True, attributes=True, renames=True):
         for row in new_cursor:
             new_meta[row[0]] = row[1]
     except:
-        logger.warning("Failed to get db metadata")
+        logging.warning("Failed to get db metadata")
         pass
     # Print jobs
     print("Comparing databases:\n{0} -> {1}\n".format(old_meta.get("client_build"), new_meta.get("client_build")))

--- a/service/character.py
+++ b/service/character.py
@@ -20,7 +20,8 @@
 import copy
 import itertools
 import json
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import threading
 from codecs import open
 from xml.etree import ElementTree
@@ -37,8 +38,6 @@ from eos.saveddata.implant import Implant as es_Implant
 from eos.saveddata.character import Character as es_Character
 from eos.saveddata.module import Slot as es_Slot, Module as es_Module
 from eos.saveddata.fighter import Fighter as es_Fighter
-
-logger = logging.getLogger(__name__)
 
 
 class CharacterImportThread(threading.Thread):

--- a/service/character.py
+++ b/service/character.py
@@ -81,7 +81,7 @@ class CharacterImportThread(threading.Thread):
                                 "level": int(skill.getAttribute("level")),
                             })
                         else:
-                            logger.error("Attempted to import unknown skill %s (ID: %s) (Level: %s)",
+                            logger.error("Attempted to import unknown skill {0} (ID: {1}) (Level: {2})",
                                          skill.getAttribute("name"),
                                          skill.getAttribute("typeID"),
                                          skill.getAttribute("level"),

--- a/service/character.py
+++ b/service/character.py
@@ -21,7 +21,7 @@ import copy
 import itertools
 import json
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import threading
 from codecs import open
 from xml.etree import ElementTree
@@ -69,7 +69,7 @@ class CharacterImportThread(threading.Thread):
                     charFile = open(path, mode='r').read()
                     doc = minidom.parseString(charFile)
                     if doc.documentElement.tagName not in ("SerializableCCPCharacter", "SerializableUriCharacter"):
-                        logger.error("Incorrect EVEMon XML sheet")
+                        logging.error("Incorrect EVEMon XML sheet")
                         raise RuntimeError("Incorrect EVEMon XML sheet")
                     name = doc.getElementsByTagName("name")[0].firstChild.nodeValue
                     skill_els = doc.getElementsByTagName("skill")
@@ -81,7 +81,7 @@ class CharacterImportThread(threading.Thread):
                                 "level": int(skill.getAttribute("level")),
                             })
                         else:
-                            logger.error("Attempted to import unknown skill {0} (ID: {1}) (Level: {2})",
+                            logging.error("Attempted to import unknown skill {0} (ID: {1}) (Level: {2})",
                                          skill.getAttribute("name"),
                                          skill.getAttribute("typeID"),
                                          skill.getAttribute("level"),
@@ -89,8 +89,8 @@ class CharacterImportThread(threading.Thread):
                     char = sCharacter.new(name+" (EVEMon)")
                     sCharacter.apiUpdateCharSheet(char.ID, skills)
                 except Exception, e:
-                    logger.error("Exception on character import:")
-                    logger.error(e)
+                    logging.error("Exception on character import:")
+                    logging.error(e)
                     continue
 
         wx.CallAfter(self.callback)
@@ -281,7 +281,7 @@ class Character(object):
 
     def rename(self, char, newName):
         if char.name in ("All 0", "All 5"):
-            logger.info("Cannot rename built in characters.")
+            logging.info("Cannot rename built in characters.")
         else:
             char.name = newName
             eos.db.commit()
@@ -371,7 +371,7 @@ class Character(object):
     def addImplant(self, charID, itemID):
         char = eos.db.getCharacter(charID)
         if char.ro:
-            logger.error("Trying to add implant to read-only character")
+            logging.error("Trying to add implant to read-only character")
             return
 
         implant = es_Implant(eos.db.getItem(itemID))

--- a/service/crest.py
+++ b/service/crest.py
@@ -180,7 +180,7 @@ class Crest():
             logger.warn("OAUTH state mismatch")
             return
 
-        logger.debug("Handling CREST login with: %s" % message)
+        logger.debug("Handling CREST login with: {0}", message)
 
         if 'access_token' in message:  # implicit
             eve = copy.deepcopy(self.eve)
@@ -194,7 +194,7 @@ class Crest():
             eve()
             info = eve.whoami()
 
-            logger.debug("Got character info: %s" % info)
+            logger.debug("Got character info: {0}", info)
 
             self.implicitCharacter = CrestChar(info['CharacterID'], info['CharacterName'])
             self.implicitCharacter.eve = eve
@@ -207,7 +207,7 @@ class Crest():
             eve()
             info = eve.whoami()
 
-            logger.debug("Got character info: %s" % info)
+            logger.debug("Got character info: {0}", info)
 
             # check if we have character already. If so, simply replace refresh_token
             char = self.getCrestCharacter(int(info['CharacterID']))

--- a/service/crest.py
+++ b/service/crest.py
@@ -1,6 +1,7 @@
 import wx
 import thread
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import threading
 import copy
 import uuid
@@ -13,8 +14,6 @@ import gui.globalEvents as GE
 from service.settings import CRESTSettings
 from service.server import StoppableHTTPServer, AuthHandler
 from service.pycrest.eve import EVE
-
-logger = logging.getLogger(__name__)
 
 
 class Servers(Enum):

--- a/service/crest.py
+++ b/service/crest.py
@@ -1,7 +1,7 @@
 import wx
 import thread
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import threading
 import copy
 import uuid
@@ -177,10 +177,10 @@ class Crest():
             return
 
         if message['state'][0] != self.state:
-            logger.warn("OAUTH state mismatch")
+            logging.warn("OAUTH state mismatch")
             return
 
-        logger.debug("Handling CREST login with: {0}", message)
+        logging.debug("Handling CREST login with: {0}", message)
 
         if 'access_token' in message:  # implicit
             eve = copy.deepcopy(self.eve)
@@ -194,7 +194,7 @@ class Crest():
             eve()
             info = eve.whoami()
 
-            logger.debug("Got character info: {0}", info)
+            logging.debug("Got character info: {0}", info)
 
             self.implicitCharacter = CrestChar(info['CharacterID'], info['CharacterName'])
             self.implicitCharacter.eve = eve
@@ -207,7 +207,7 @@ class Crest():
             eve()
             info = eve.whoami()
 
-            logger.debug("Got character info: {0}", info)
+            logging.debug("Got character info: {0}", info)
 
             # check if we have character already. If so, simply replace refresh_token
             char = self.getCrestCharacter(int(info['CharacterID']))

--- a/service/fit.py
+++ b/service/fit.py
@@ -992,7 +992,7 @@ class Fit(object):
         self.recalc(fit)
 
     def recalc(self, fit, withBoosters=True):
-        logger.debug("=" * 10 + "recalc" + "=" * 10)
+        logger.info("=" * 10 + "recalc" + "=" * 10)
         if fit.factorReload is not self.serviceFittingOptions["useGlobalForceReload"]:
             fit.factorReload = self.serviceFittingOptions["useGlobalForceReload"]
         fit.clear()

--- a/service/fit.py
+++ b/service/fit.py
@@ -18,7 +18,8 @@
 # ===============================================================================
 
 import copy
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import eos.db
 from eos.saveddata.booster import Booster as es_Booster
@@ -36,8 +37,6 @@ from service.character import Character
 from service.damagePattern import DamagePattern
 from service.market import Market
 from service.settings import SettingsProvider
-
-logger = logging.getLogger(__name__)
 
 from logbook import Logger
 log = Logger(__name__)

--- a/service/fit.py
+++ b/service/fit.py
@@ -39,6 +39,9 @@ from service.settings import SettingsProvider
 
 logger = logging.getLogger(__name__)
 
+from logbook import Logger
+log = Logger(__name__)
+
 
 class Fit(object):
     instance = None
@@ -51,6 +54,7 @@ class Fit(object):
         return cls.instance
 
     def __init__(self):
+        log.debug("Initialize Fit class")
         self.pattern = DamagePattern.getInstance().getDamagePattern("Uniform")
         self.targetResists = None
         self.character = saveddata_Character.getAll5()

--- a/service/fit.py
+++ b/service/fit.py
@@ -19,7 +19,7 @@
 
 import copy
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import eos.db
 from eos.saveddata.booster import Booster as es_Booster
@@ -992,7 +992,7 @@ class Fit(object):
         self.recalc(fit)
 
     def recalc(self, fit, withBoosters=True):
-        logger.info("=" * 10 + "recalc" + "=" * 10)
+        logging.info("=" * 10 + "recalc" + "=" * 10)
         if fit.factorReload is not self.serviceFittingOptions["useGlobalForceReload"]:
             fit.factorReload = self.serviceFittingOptions["useGlobalForceReload"]
         fit.clear()

--- a/service/market.py
+++ b/service/market.py
@@ -19,7 +19,8 @@
 
 import re
 import threading
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import Queue
 
 import wx
@@ -41,8 +42,6 @@ try:
     from collections import OrderedDict
 except ImportError:
     from utils.compat import OrderedDict
-
-logger = logging.getLogger(__name__)
 
 # Event which tells threads dependent on Market that it's initialized
 mktRdy = threading.Event()

--- a/service/market.py
+++ b/service/market.py
@@ -70,11 +70,13 @@ class ShipBrowserWorkerThread(threading.Thread):
 
                 wx.CallAfter(callback, (id_, set_))
             except:
+                logger.debug("Callback failed.")
                 pass
             finally:
                 try:
                     queue.task_done()
                 except:
+                    logger.debug("Queue task done failed.")
                     pass
 
 
@@ -813,6 +815,7 @@ class Market():
             try:
                 callback(requests)
             except Exception:
+                logger.debug("Callback failed.")
                 pass
             eos.db.commit()
 
@@ -829,6 +832,7 @@ class Market():
             try:
                 callback(item)
             except:
+                logger.debug("Callback failed.")
                 pass
 
         self.priceWorkerThread.setToWait(item.ID, cb)

--- a/service/market.py
+++ b/service/market.py
@@ -82,9 +82,11 @@ class ShipBrowserWorkerThread(threading.Thread):
 
 class PriceWorkerThread(threading.Thread):
     def run(self):
+        logger.debug("Run start")
         self.queue = Queue.Queue()
         self.wait = {}
         self.processUpdates()
+        logger.debug("Run end")
 
     def processUpdates(self):
         queue = self.queue
@@ -425,7 +427,7 @@ class Market():
             else:
                 raise TypeError("Need Item object, integer, float or string as argument")
         except:
-            logger.error("Could not get item: %s", identity)
+            logger.error("Could not get item: {0}", identity)
             raise
 
         return item

--- a/service/market.py
+++ b/service/market.py
@@ -20,7 +20,7 @@
 import re
 import threading
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import Queue
 
 import wx
@@ -70,23 +70,23 @@ class ShipBrowserWorkerThread(threading.Thread):
 
                 wx.CallAfter(callback, (id_, set_))
             except:
-                logger.debug("Callback failed.")
+                logging.debug("Callback failed.")
                 pass
             finally:
                 try:
                     queue.task_done()
                 except:
-                    logger.debug("Queue task done failed.")
+                    logging.debug("Queue task done failed.")
                     pass
 
 
 class PriceWorkerThread(threading.Thread):
     def run(self):
-        logger.debug("Run start")
+        logging.debug("Run start")
         self.queue = Queue.Queue()
         self.wait = {}
         self.processUpdates()
-        logger.debug("Run end")
+        logging.debug("Run end")
 
     def processUpdates(self):
         queue = self.queue
@@ -427,7 +427,7 @@ class Market():
             else:
                 raise TypeError("Need Item object, integer, float or string as argument")
         except:
-            logger.error("Could not get item: {0}", identity)
+            logging.error("Could not get item: {0}", identity)
             raise
 
         return item
@@ -817,7 +817,7 @@ class Market():
             try:
                 callback(requests)
             except Exception:
-                logger.debug("Callback failed.")
+                logging.debug("Callback failed.")
                 pass
             eos.db.commit()
 
@@ -834,7 +834,7 @@ class Market():
             try:
                 callback(item)
             except:
-                logger.debug("Callback failed.")
+                logging.debug("Callback failed.")
                 pass
 
         self.priceWorkerThread.setToWait(item.ID, cb)

--- a/service/port.py
+++ b/service/port.py
@@ -121,21 +121,21 @@ class Port(object):
                         savebom = bom
 
                 if codec_found is None:
-                    logger.info("Unicode BOM not found in file %s.", path)
+                    logger.info("Unicode BOM not found in file {0}.", path)
                     attempt_codecs = (defcodepage, "utf-8", "utf-16", "cp1252")
 
                     for page in attempt_codecs:
                         try:
-                            logger.info("Attempting to decode file %s using %s page.", path, page)
+                            logger.info("Attempting to decode file {0} using {1} page.", path, page)
                             srcString = unicode(srcString, page)
                             codec_found = page
-                            logger.info("File %s decoded using %s page.", path, page)
+                            logger.info("File {0} decoded using {1} page.", path, page)
                         except UnicodeDecodeError:
-                            logger.info("Error unicode decoding %s from page %s, trying next codec", path, page)
+                            logger.info("Error unicode decoding {0} from page {1}, trying next codec", path, page)
                         else:
                             break
                 else:
-                    logger.info("Unicode BOM detected in %s, using %s page.", path, codec_found)
+                    logger.info("Unicode BOM detected in {0}, using {1} page.", path, codec_found)
                     srcString = unicode(srcString[len(savebom):], codec_found)
 
             else:
@@ -154,7 +154,7 @@ class Port(object):
             except xml.parsers.expat.ExpatError:
                 return False, "Malformed XML in %s" % path
             except Exception:
-                logger.exception("Unknown exception processing: %s", path)
+                logger.exception("Unknown exception processing: {0}", path)
                 return False, "Unknown Error while processing %s" % path
 
         IDs = []
@@ -412,7 +412,7 @@ class Port(object):
                     return s_[:10] + "..."
                 return s_
 
-            logger.exception("Couldn't import ship data %r", [logtransform(s) for s in info])
+            logger.exception("Couldn't import ship data {0}", [logtransform(s) for s in info])
             return None
 
         moduleList = []
@@ -556,7 +556,7 @@ class Port(object):
                 elif "boosterness" in item.attributes:
                     fit.boosters.append(Booster(item))
                 else:
-                    logger.error("Failed to import implant: %s", line)
+                    logger.error("Failed to import implant: {0}", line)
             # elif item.category.name == "Subsystem":
             #     try:
             #         subsystem = Module(item)
@@ -1175,7 +1175,7 @@ class FitImportThread(threading.Thread):
         success, result = sPort.importFitFromFiles(self.paths, self.callback)
 
         if not success:  # there was an error during processing
-            logger.error("Error while processing file import: %s", result)
+            logger.error("Error while processing file import: {0}", result)
             wx.CallAfter(self.callback, -2, result)
         else:  # Send done signal to GUI
             wx.CallAfter(self.callback, -1, result)

--- a/service/port.py
+++ b/service/port.py
@@ -326,6 +326,7 @@ class Port(object):
             except ValueError:
                 f.ship = Citadel(sMkt.getItem(fit['ship']['id']))
         except:
+            logger.warning("Caught exception in importCrest")
             return None
 
         items = fit['items']
@@ -351,6 +352,7 @@ class Port(object):
                         m = Module(item)
                     # When item can't be added to any slot (unknown item or just charge), ignore it
                     except ValueError:
+                        logger.debug("Item can't be added to any slot (unknown item or just charge)")
                         continue
                     # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                     if item.category.name == "Subsystem":
@@ -363,6 +365,7 @@ class Port(object):
                         moduleList.append(m)
 
             except:
+                logger.warning("Could not process module.")
                 continue
 
         # Recalc to get slot numbers correct for T3 cruisers
@@ -391,6 +394,7 @@ class Port(object):
                 string = string[string.index(str(id_)):]
                 break
             except:
+                logger.warning("Exception caught in importDna")
                 pass
         string = string[:string.index("::") + 2]
         info = string.split(":")
@@ -435,6 +439,7 @@ class Port(object):
                         try:
                             m = Module(item)
                         except:
+                            logger.warning("Exception caught in importDna")
                             continue
                         # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                         if item.category.name == "Subsystem":
@@ -483,6 +488,7 @@ class Port(object):
                 fit.ship = Citadel(ship)
             fit.name = fitName
         except:
+            logger.warning("Exception caught in importEft")
             return
 
         # maintain map of drones and their quantities
@@ -523,6 +529,7 @@ class Port(object):
                 item = sMkt.getItem(modName, eager="group.category")
             except:
                 # if no data can be found (old names)
+                logger.warning("no data can be found (old names)")
                 continue
 
             if item.category.name == "Drone":
@@ -675,6 +682,7 @@ class Port(object):
                             try:
                                 droneItem = sMkt.getItem(droneName, eager="group.category")
                             except:
+                                logger.warning("Cannot get item.")
                                 continue
                             if droneItem.category.name == "Drone":
                                 # Add drone to the fitting
@@ -696,6 +704,7 @@ class Port(object):
                             try:
                                 implantItem = sMkt.getItem(entityData, eager="group.category")
                             except:
+                                logger.warning("Cannot get item.")
                                 continue
                             if implantItem.category.name != "Implant":
                                 continue
@@ -711,6 +720,7 @@ class Port(object):
                             try:
                                 boosterItem = sMkt.getItem(entityData, eager="group.category")
                             except:
+                                logger.warning("Cannot get item.")
                                 continue
                             # All boosters have implant category
                             if boosterItem.category.name != "Implant":
@@ -731,6 +741,7 @@ class Port(object):
                         try:
                             item = sMkt.getItem(cargoName)
                         except:
+                            logger.warning("Cannot get item.")
                             continue
                         # Add Cargo to the fitting
                         c = Cargo(item)
@@ -744,6 +755,7 @@ class Port(object):
                         try:
                             modItem = sMkt.getItem(modName)
                         except:
+                            logger.warning("Cannot get item.")
                             continue
 
                         # Create module
@@ -765,6 +777,7 @@ class Port(object):
                                     if chargeItem.category.name == "Charge":
                                         m.charge = chargeItem
                                 except:
+                                    logger.warning("Cannot get item.")
                                     pass
                             # Append module to fit
                             moduleList.append(m)
@@ -783,6 +796,7 @@ class Port(object):
                     wx.CallAfter(callback, None)
             # Skip fit silently if we get an exception
             except Exception:
+                logger.error("Caught exception on fit.")
                 pass
 
         return fits
@@ -807,6 +821,7 @@ class Port(object):
                 except ValueError:
                     f.ship = Citadel(sMkt.getItem(shipType))
             except:
+                logger.warning("Caught exception on importXml")
                 continue
             hardwares = fitting.getElementsByTagName("hardware")
             moduleList = []
@@ -816,6 +831,7 @@ class Port(object):
                     try:
                         item = sMkt.getItem(moduleName, eager="group.category")
                     except:
+                        logger.warning("Caught exception on importXml")
                         continue
                     if item:
                         if item.category.name == "Drone":
@@ -838,6 +854,7 @@ class Port(object):
                                 m = Module(item)
                             # When item can't be added to any slot (unknown item or just charge), ignore it
                             except ValueError:
+                                logger.warning("item can't be added to any slot (unknown item or just charge), ignore it")
                                 continue
                             # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                             if item.category.name == "Subsystem":
@@ -851,6 +868,7 @@ class Port(object):
                                 moduleList.append(m)
 
                 except KeyboardInterrupt:
+                    logger.warning("Keyboard Interrupt")
                     continue
 
             # Recalc to get slot numbers correct for T3 cruisers

--- a/service/port.py
+++ b/service/port.py
@@ -20,7 +20,8 @@
 import re
 import os
 import xml.dom
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import collections
 import json
 import threading
@@ -42,7 +43,6 @@ if 'wxMac' not in wx.PlatformInfo or ('wxMac' in wx.PlatformInfo and wx.VERSION 
 
 from service.market import Market
 
-logger = logging.getLogger("pyfa.service.port")
 
 try:
     from collections import OrderedDict

--- a/service/port.py
+++ b/service/port.py
@@ -21,7 +21,7 @@ import re
 import os
 import xml.dom
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import collections
 import json
 import threading
@@ -121,21 +121,21 @@ class Port(object):
                         savebom = bom
 
                 if codec_found is None:
-                    logger.info("Unicode BOM not found in file {0}.", path)
+                    logging.info("Unicode BOM not found in file {0}.", path)
                     attempt_codecs = (defcodepage, "utf-8", "utf-16", "cp1252")
 
                     for page in attempt_codecs:
                         try:
-                            logger.info("Attempting to decode file {0} using {1} page.", path, page)
+                            logging.info("Attempting to decode file {0} using {1} page.", path, page)
                             srcString = unicode(srcString, page)
                             codec_found = page
-                            logger.info("File {0} decoded using {1} page.", path, page)
+                            logging.info("File {0} decoded using {1} page.", path, page)
                         except UnicodeDecodeError:
-                            logger.info("Error unicode decoding {0} from page {1}, trying next codec", path, page)
+                            logging.info("Error unicode decoding {0} from page {1}, trying next codec", path, page)
                         else:
                             break
                 else:
-                    logger.info("Unicode BOM detected in {0}, using {1} page.", path, codec_found)
+                    logging.info("Unicode BOM detected in {0}, using {1} page.", path, codec_found)
                     srcString = unicode(srcString[len(savebom):], codec_found)
 
             else:
@@ -154,7 +154,7 @@ class Port(object):
             except xml.parsers.expat.ExpatError:
                 return False, "Malformed XML in %s" % path
             except Exception:
-                logger.exception("Unknown exception processing: {0}", path)
+                logging.exception("Unknown exception processing: {0}", path)
                 return False, "Unknown Error while processing %s" % path
 
         IDs = []
@@ -326,7 +326,7 @@ class Port(object):
             except ValueError:
                 f.ship = Citadel(sMkt.getItem(fit['ship']['id']))
         except:
-            logger.warning("Caught exception in importCrest")
+            logging.warning("Caught exception in importCrest")
             return None
 
         items = fit['items']
@@ -352,7 +352,7 @@ class Port(object):
                         m = Module(item)
                     # When item can't be added to any slot (unknown item or just charge), ignore it
                     except ValueError:
-                        logger.debug("Item can't be added to any slot (unknown item or just charge)")
+                        logging.debug("Item can't be added to any slot (unknown item or just charge)")
                         continue
                     # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                     if item.category.name == "Subsystem":
@@ -365,7 +365,7 @@ class Port(object):
                         moduleList.append(m)
 
             except:
-                logger.warning("Could not process module.")
+                logging.warning("Could not process module.")
                 continue
 
         # Recalc to get slot numbers correct for T3 cruisers
@@ -394,7 +394,7 @@ class Port(object):
                 string = string[string.index(str(id_)):]
                 break
             except:
-                logger.warning("Exception caught in importDna")
+                logging.warning("Exception caught in importDna")
                 pass
         string = string[:string.index("::") + 2]
         info = string.split(":")
@@ -412,7 +412,7 @@ class Port(object):
                     return s_[:10] + "..."
                 return s_
 
-            logger.exception("Couldn't import ship data {0}", [logtransform(s) for s in info])
+            logging.exception("Couldn't import ship data {0}", [logtransform(s) for s in info])
             return None
 
         moduleList = []
@@ -439,7 +439,7 @@ class Port(object):
                         try:
                             m = Module(item)
                         except:
-                            logger.warning("Exception caught in importDna")
+                            logging.warning("Exception caught in importDna")
                             continue
                         # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                         if item.category.name == "Subsystem":
@@ -488,7 +488,7 @@ class Port(object):
                 fit.ship = Citadel(ship)
             fit.name = fitName
         except:
-            logger.warning("Exception caught in importEft")
+            logging.warning("Exception caught in importEft")
             return
 
         # maintain map of drones and their quantities
@@ -529,7 +529,7 @@ class Port(object):
                 item = sMkt.getItem(modName, eager="group.category")
             except:
                 # if no data can be found (old names)
-                logger.warning("no data can be found (old names)")
+                logging.warning("no data can be found (old names)")
                 continue
 
             if item.category.name == "Drone":
@@ -556,7 +556,7 @@ class Port(object):
                 elif "boosterness" in item.attributes:
                     fit.boosters.append(Booster(item))
                 else:
-                    logger.error("Failed to import implant: {0}", line)
+                    logging.error("Failed to import implant: {0}", line)
             # elif item.category.name == "Subsystem":
             #     try:
             #         subsystem = Module(item)
@@ -682,7 +682,7 @@ class Port(object):
                             try:
                                 droneItem = sMkt.getItem(droneName, eager="group.category")
                             except:
-                                logger.warning("Cannot get item.")
+                                logging.warning("Cannot get item.")
                                 continue
                             if droneItem.category.name == "Drone":
                                 # Add drone to the fitting
@@ -704,7 +704,7 @@ class Port(object):
                             try:
                                 implantItem = sMkt.getItem(entityData, eager="group.category")
                             except:
-                                logger.warning("Cannot get item.")
+                                logging.warning("Cannot get item.")
                                 continue
                             if implantItem.category.name != "Implant":
                                 continue
@@ -720,7 +720,7 @@ class Port(object):
                             try:
                                 boosterItem = sMkt.getItem(entityData, eager="group.category")
                             except:
-                                logger.warning("Cannot get item.")
+                                logging.warning("Cannot get item.")
                                 continue
                             # All boosters have implant category
                             if boosterItem.category.name != "Implant":
@@ -741,7 +741,7 @@ class Port(object):
                         try:
                             item = sMkt.getItem(cargoName)
                         except:
-                            logger.warning("Cannot get item.")
+                            logging.warning("Cannot get item.")
                             continue
                         # Add Cargo to the fitting
                         c = Cargo(item)
@@ -755,7 +755,7 @@ class Port(object):
                         try:
                             modItem = sMkt.getItem(modName)
                         except:
-                            logger.warning("Cannot get item.")
+                            logging.warning("Cannot get item.")
                             continue
 
                         # Create module
@@ -777,7 +777,7 @@ class Port(object):
                                     if chargeItem.category.name == "Charge":
                                         m.charge = chargeItem
                                 except:
-                                    logger.warning("Cannot get item.")
+                                    logging.warning("Cannot get item.")
                                     pass
                             # Append module to fit
                             moduleList.append(m)
@@ -796,7 +796,7 @@ class Port(object):
                     wx.CallAfter(callback, None)
             # Skip fit silently if we get an exception
             except Exception:
-                logger.error("Caught exception on fit.")
+                logging.error("Caught exception on fit.")
                 pass
 
         return fits
@@ -821,7 +821,7 @@ class Port(object):
                 except ValueError:
                     f.ship = Citadel(sMkt.getItem(shipType))
             except:
-                logger.warning("Caught exception on importXml")
+                logging.warning("Caught exception on importXml")
                 continue
             hardwares = fitting.getElementsByTagName("hardware")
             moduleList = []
@@ -831,7 +831,7 @@ class Port(object):
                     try:
                         item = sMkt.getItem(moduleName, eager="group.category")
                     except:
-                        logger.warning("Caught exception on importXml")
+                        logging.warning("Caught exception on importXml")
                         continue
                     if item:
                         if item.category.name == "Drone":
@@ -854,7 +854,7 @@ class Port(object):
                                 m = Module(item)
                             # When item can't be added to any slot (unknown item or just charge), ignore it
                             except ValueError:
-                                logger.warning("item can't be added to any slot (unknown item or just charge), ignore it")
+                                logging.warning("item can't be added to any slot (unknown item or just charge), ignore it")
                                 continue
                             # Add subsystems before modules to make sure T3 cruisers have subsystems installed
                             if item.category.name == "Subsystem":
@@ -868,7 +868,7 @@ class Port(object):
                                 moduleList.append(m)
 
                 except KeyboardInterrupt:
-                    logger.warning("Keyboard Interrupt")
+                    logging.warning("Keyboard Interrupt")
                     continue
 
             # Recalc to get slot numbers correct for T3 cruisers
@@ -1175,7 +1175,7 @@ class FitImportThread(threading.Thread):
         success, result = sPort.importFitFromFiles(self.paths, self.callback)
 
         if not success:  # there was an error during processing
-            logger.error("Error while processing file import: {0}", result)
+            logging.error("Error while processing file import: {0}", result)
             wx.CallAfter(self.callback, -2, result)
         else:  # Send done signal to GUI
             wx.CallAfter(self.callback, -1, result)

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -27,10 +27,8 @@ from eos.db.saveddata.loadDefaultDatabaseValues import DefaultDatabaseValues
 from eos.db.saveddata.databaseRepair import DatabaseCleanup
 from eos.saveddata.character import Character as es_Character
 
-import logging
-
-logger = logging.getLogger(__name__)
-
+from logbook import Logger
+logger = Logger(__name__)
 
 class PrefetchThread(threading.Thread):
     def run(self):
@@ -66,12 +64,12 @@ if config.saveDB and os.path.isfile(config.saveDB):
     # Import values that must exist otherwise Pyfa breaks
     DefaultDatabaseValues.importRequiredDefaults()
 
-    logging.debug("Starting database validation.")
+    logger.debug("Starting database validation.")
     database_cleanup_instance = DatabaseCleanup()
     database_cleanup_instance.OrphanedCharacterSkills(db.saveddata_engine)
     database_cleanup_instance.OrphanedFitCharacterIDs(db.saveddata_engine)
     database_cleanup_instance.OrphanedFitDamagePatterns(db.saveddata_engine)
-    logging.debug("Completed database validation.")
+    logger.debug("Completed database validation.")
 
 else:
     # If database does not exist, do not worry about migration. Simply

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -58,10 +58,12 @@ if config.savePath and not os.path.exists(config.savePath):
 
 if config.saveDB and os.path.isfile(config.saveDB):
     # If database exists, run migration after init'd database
+    logger.debug("Run database migration.")
     db.saveddata_meta.create_all()
     migration.update(db.saveddata_engine)
     # Import default database values
     # Import values that must exist otherwise Pyfa breaks
+    logger.debug("Import Required Database Values.")
     DefaultDatabaseValues.importRequiredDefaults()
 
     logger.debug("Starting database validation.")

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -28,7 +28,7 @@ from eos.db.saveddata.databaseRepair import DatabaseCleanup
 from eos.saveddata.character import Character as es_Character
 
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 class PrefetchThread(threading.Thread):
     def run(self):
@@ -58,20 +58,20 @@ if config.savePath and not os.path.exists(config.savePath):
 
 if config.saveDB and os.path.isfile(config.saveDB):
     # If database exists, run migration after init'd database
-    logger.debug("Run database migration.")
+    logging.debug("Run database migration.")
     db.saveddata_meta.create_all()
     migration.update(db.saveddata_engine)
     # Import default database values
     # Import values that must exist otherwise Pyfa breaks
-    logger.debug("Import Required Database Values.")
+    logging.debug("Import Required Database Values.")
     DefaultDatabaseValues.importRequiredDefaults()
 
-    logger.debug("Starting database validation.")
+    logging.debug("Starting database validation.")
     database_cleanup_instance = DatabaseCleanup()
     database_cleanup_instance.OrphanedCharacterSkills(db.saveddata_engine)
     database_cleanup_instance.OrphanedFitCharacterIDs(db.saveddata_engine)
     database_cleanup_instance.OrphanedFitDamagePatterns(db.saveddata_engine)
-    logger.debug("Completed database validation.")
+    logging.debug("Completed database validation.")
 
 else:
     # If database does not exist, do not worry about migration. Simply

--- a/service/price.py
+++ b/service/price.py
@@ -23,6 +23,8 @@ from xml.dom import minidom
 
 from eos import db
 from service.network import Network, TimeoutError
+from logbook import Logger
+logger = Logger(__name__)
 
 VALIDITY = 24 * 60 * 60  # Price validity period, 24 hours
 REREQUEST = 4 * 60 * 60  # Re-request delay for failed fetches, 4 hours
@@ -99,6 +101,7 @@ class Price(object):
         # If getting or processing data returned any errors
         except TimeoutError:
             # Timeout error deserves special treatment
+            logger.warning("Price fetch timout")
             for typeID in priceMap.keys():
                 priceobj = priceMap[typeID]
                 priceobj.time = time.time() + TIMEOUT
@@ -106,6 +109,7 @@ class Price(object):
                 del priceMap[typeID]
         except:
             # all other errors will pass and continue onward to the REREQUEST delay
+            logger.warning("Caught exception in fetchPrices")
             pass
 
         # if we get to this point, then we've got an error. Set to REREQUEST delay

--- a/service/price.py
+++ b/service/price.py
@@ -24,7 +24,7 @@ from xml.dom import minidom
 from eos import db
 from service.network import Network, TimeoutError
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 VALIDITY = 24 * 60 * 60  # Price validity period, 24 hours
 REREQUEST = 4 * 60 * 60  # Re-request delay for failed fetches, 4 hours
@@ -101,7 +101,7 @@ class Price(object):
         # If getting or processing data returned any errors
         except TimeoutError:
             # Timeout error deserves special treatment
-            logger.warning("Price fetch timout")
+            logging.warning("Price fetch timout")
             for typeID in priceMap.keys():
                 priceobj = priceMap[typeID]
                 priceobj.time = time.time() + TIMEOUT
@@ -109,7 +109,7 @@ class Price(object):
                 del priceMap[typeID]
         except:
             # all other errors will pass and continue onward to the REREQUEST delay
-            logger.warning("Caught exception in fetchPrices")
+            logging.warning("Caught exception in fetchPrices")
             pass
 
         # if we get to this point, then we've got an error. Set to REREQUEST delay

--- a/service/pycrest/__init__.py
+++ b/service/pycrest/__init__.py
@@ -1,12 +1,1 @@
-import logging
-
-
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-
-
-logger = logging.getLogger('pycrest')
-logger.addHandler(NullHandler())
-
 version = "0.0.1"

--- a/service/pycrest/eve.py
+++ b/service/pycrest/eve.py
@@ -67,6 +67,7 @@ class FileCache(APICache):
             with open(self._getpath(key), 'rb') as f:
                 return pickle.loads(zlib.decompress(f.read()))
         except IOError as ex:
+            logger.debug("IO error opening zip file. (May not exist yet.")
             if ex.errno == 2:  # file does not exist (yet)
                 return None
             else:
@@ -78,6 +79,7 @@ class FileCache(APICache):
         try:
             os.unlink(self._getpath(key))
         except OSError as ex:
+            logger.debug("Caught exception in invalidate")
             if ex.errno == 2:  # does not exist
                 pass
             else:

--- a/service/pycrest/eve.py
+++ b/service/pycrest/eve.py
@@ -127,7 +127,7 @@ class APIConnection(object):
             self.cache = DictCache()
 
     def get(self, resource, params=None):
-        logger.debug('Getting resource %s', resource)
+        logger.debug('Getting resource {0}', resource)
         if params is None:
             params = {}
 
@@ -147,15 +147,15 @@ class APIConnection(object):
         key = (resource, frozenset(self._session.headers.items()), frozenset(prms.items()))
         cached = self.cache.get(key)
         if cached and cached['cached_until'] > time.time():
-            logger.debug('Cache hit for resource %s (params=%s)', resource, prms)
+            logger.debug('Cache hit for resource {0} (params={1})', resource, prms)
             return cached
         elif cached:
-            logger.debug('Cache stale for resource %s (params=%s)', resource, prms)
+            logger.debug('Cache stale for resource {0} (params={1})', resource, prms)
             self.cache.invalidate(key)
         else:
-            logger.debug('Cache miss for resource %s (params=%s', resource, prms)
+            logger.debug('Cache miss for resource {0} (params={1}', resource, prms)
 
-        logger.debug('Getting resource %s (params=%s)', resource, prms)
+        logger.debug('Getting resource {0} (params={1})', resource, prms)
         res = self._session.get(resource, params=prms)
         if res.status_code != 200:
             raise APIException("Got unexpected status code from server: %i" % res.status_code)

--- a/service/pycrest/eve.py
+++ b/service/pycrest/eve.py
@@ -1,5 +1,6 @@
 import base64
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 import os
 import re
 import time
@@ -26,11 +27,9 @@ try:
     from urllib.parse import quote
 except ImportError:  # pragma: no cover
     from urllib import quote
-import logging
 import re
 import config
 
-logger = logging.getLogger("pycrest.eve")
 cache_re = re.compile(r'max-age=([0-9]+)')
 
 

--- a/service/pycrest/eve.py
+++ b/service/pycrest/eve.py
@@ -1,6 +1,6 @@
 import base64
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 import os
 import re
 import time
@@ -67,7 +67,7 @@ class FileCache(APICache):
             with open(self._getpath(key), 'rb') as f:
                 return pickle.loads(zlib.decompress(f.read()))
         except IOError as ex:
-            logger.debug("IO error opening zip file. (May not exist yet.")
+            logging.debug("IO error opening zip file. (May not exist yet.")
             if ex.errno == 2:  # file does not exist (yet)
                 return None
             else:
@@ -79,7 +79,7 @@ class FileCache(APICache):
         try:
             os.unlink(self._getpath(key))
         except OSError as ex:
-            logger.debug("Caught exception in invalidate")
+            logging.debug("Caught exception in invalidate")
             if ex.errno == 2:  # does not exist
                 pass
             else:
@@ -127,7 +127,7 @@ class APIConnection(object):
             self.cache = DictCache()
 
     def get(self, resource, params=None):
-        logger.debug('Getting resource {0}', resource)
+        logging.debug('Getting resource {0}', resource)
         if params is None:
             params = {}
 
@@ -147,15 +147,15 @@ class APIConnection(object):
         key = (resource, frozenset(self._session.headers.items()), frozenset(prms.items()))
         cached = self.cache.get(key)
         if cached and cached['cached_until'] > time.time():
-            logger.debug('Cache hit for resource {0} (params={1})', resource, prms)
+            logging.debug('Cache hit for resource {0} (params={1})', resource, prms)
             return cached
         elif cached:
-            logger.debug('Cache stale for resource {0} (params={1})', resource, prms)
+            logging.debug('Cache stale for resource {0} (params={1})', resource, prms)
             self.cache.invalidate(key)
         else:
-            logger.debug('Cache miss for resource {0} (params={1}', resource, prms)
+            logging.debug('Cache miss for resource {0} (params={1}', resource, prms)
 
-        logger.debug('Getting resource {0} (params={1})', resource, prms)
+        logging.debug('Getting resource {0} (params={1})', resource, prms)
         res = self._session.get(resource, params=prms)
         if res.status_code != 200:
             raise APIException("Got unexpected status code from server: %i" % res.status_code)

--- a/service/server.py
+++ b/service/server.py
@@ -2,13 +2,12 @@ import BaseHTTPServer
 import urlparse
 import socket
 import thread
-import logging
+from logbook import Logger
+logger = Logger(__name__)
 
 import wx
 
 from service.settings import CRESTSettings
-
-logger = logging.getLogger(__name__)
 
 # noinspection PyPep8
 HTML = '''

--- a/service/server.py
+++ b/service/server.py
@@ -97,6 +97,7 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
                 sock.settimeout(None)
                 return (sock, addr)
             except socket.timeout:
+                logger.warning("Server timed out waiting for connection")
                 pass
 
     def stop(self):
@@ -115,6 +116,7 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
             try:
                 self.handle_request()
             except TypeError:
+                logger.debug("Caught exception in serve")
                 pass
         self.server_close()
 

--- a/service/server.py
+++ b/service/server.py
@@ -83,7 +83,7 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
 
         # Allow listening for x seconds
         sec = self.settings.get('timeout')
-        logger.debug("Running server for %d seconds", sec)
+        logger.debug("Running server for {0} seconds", sec)
 
         self.socket.settimeout(0.5)
         self.max_tries = sec / self.socket.gettimeout()

--- a/service/server.py
+++ b/service/server.py
@@ -3,7 +3,7 @@ import urlparse
 import socket
 import thread
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 import wx
 
@@ -83,7 +83,7 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
 
         # Allow listening for x seconds
         sec = self.settings.get('timeout')
-        logger.debug("Running server for {0} seconds", sec)
+        logging.debug("Running server for {0} seconds", sec)
 
         self.socket.settimeout(0.5)
         self.max_tries = sec / self.socket.gettimeout()
@@ -97,17 +97,17 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
                 sock.settimeout(None)
                 return (sock, addr)
             except socket.timeout:
-                logger.warning("Server timed out waiting for connection")
+                logging.warning("Server timed out waiting for connection")
                 pass
 
     def stop(self):
         self.run = False
 
     def handle_timeout(self):
-        # logger.debug("Number of tries: %d"%self.tries)
+        # logging.debug("Number of tries: %d"%self.tries)
         self.tries += 1
         if self.tries == self.max_tries:
-            logger.debug("Server timed out waiting for connection")
+            logging.debug("Server timed out waiting for connection")
             self.stop()
 
     def serve(self, callback):
@@ -116,7 +116,7 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
             try:
                 self.handle_request()
             except TypeError:
-                logger.debug("Caught exception in serve")
+                logging.debug("Caught exception in serve")
                 pass
         self.server_close()
 

--- a/service/update.py
+++ b/service/update.py
@@ -27,6 +27,8 @@ import dateutil.parser
 import config
 from service.network import Network
 from service.settings import UpdateSettings
+from logbook import Logger
+logger = Logger(__name__)
 
 
 class CheckUpdateThread(threading.Thread):
@@ -80,6 +82,7 @@ class CheckUpdateThread(threading.Thread):
                         wx.CallAfter(self.callback, release)  # Singularity -> Singularity
                 break
         except:
+            logger.warning("Caught exception in run")
             pass
 
     def versiontuple(self, v):

--- a/service/update.py
+++ b/service/update.py
@@ -28,7 +28,7 @@ import config
 from service.network import Network
 from service.settings import UpdateSettings
 from logbook import Logger
-logger = Logger(__name__)
+logging = Logger(__name__)
 
 
 class CheckUpdateThread(threading.Thread):
@@ -82,7 +82,7 @@ class CheckUpdateThread(threading.Thread):
                         wx.CallAfter(self.callback, release)  # Singularity -> Singularity
                 break
         except:
-            logger.warning("Caught exception in run")
+            logging.warning("Caught exception in run")
             pass
 
     def versiontuple(self, v):


### PR DESCRIPTION
This is a PR to explore improving logging in Pyfa, as currently our logging doesn't have very good coverage.

Logging in general isn't very friendly toward keeping the application fast and light weight.  Currently our logging solution is the built in `logging`, which is relatively slow as a solution.

To test this, I created a simple scenario where I looped 1 million times and spat out the time elapsed.  Essentially each test will write a message to sysout, or the log file, or both.

+ *Write to log*
1.9 seconds
+ *Printing to Console*
10.6 seconds
+ *logging* (prints to console and writes to log)
430 seconds
+ *logbook*  (prints to console and writes to log)
366.8 seconds

Clearly if we want speed our best solution is to write our own and keep it as simple as possible.  Both built in `logging` and `logbook` are very slow in comparison, even though `logbook` is about 15% faster.

However, @blitzmann made some good points about everything surrounding logging, and not reinventing wheels.

Here's a quick rundown of the advantages to `logbook` over `logging`.

You can configure logbook to completely ignore debug messages.  Even if debugging isn't turned out, with logging the debug statement is still ran.  This means debug messages will have a heavier impact in logging than logbook.

Logbook allows you to "bubble up" messages, so we can handle them at different levels.  Writing the log to memory is very light weight, writing to disk less so, and writing to the system console is very painful (see how printing took 10 times as long as a file write).  In addition to being able to handle different log levels differently, such as always sending debug to log while printing other levels, logbook has two handlers that we can explore. 

`TestHandler` will keep logs in memory (not write to disk).  This could be super useful if we wanted to write a GUI pane that exposed the log (without having to go to the actual log file).

`FingersCrossedHandler` is even more interesting, it wraps another handler and will log everything in memory until a certain level (action_level, defaults to ERROR) is exceeded. When that happens the fingers crossed handler will activate forever and log all buffered records as well as records yet to come into another handler which was passed to the constructor.  So for non-debugging use, we could operate in this mode, and then when we hit an error, all the debug messages get flushed to disk.

Between handling different logging levels differently (keeping debug from printing to sysout), and being able to cache to memory, we can _seriously_ lighten the load that logging currently is.

While I don't think that logging is a terribly heavy load on Pyfa, right now it's barely used.  We currently only importing logging in 33 files, which means that there's huge swaths of Pyfa that have no logging.

While I don't think we need to go to an extreme (logging wouldn't be particularly useful in most effects, for example), more through logging would give us a lot more info and help us debug scenarios where we have weirdness.  If we use the built in logging function, we're stuck with pretty much having it on or off, on with a performance hit or off and lose the data.

I think by using the `FingersCrossedHandler` we can have the best of both worlds. 

Right now I'm simply working on implementing like for like, so we don't have any of the extra benefits yet.  But the nice thing is once we have logging replaced, we can easily modify our logging setup in `pyfa.py` to point to the other handlers.