### PR TITLE
Skip character stuff if there is no fit.

### DIFF
--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -164,17 +164,19 @@ class MainMenuBar(wx.MenuBar):
 
     def fitChanged(self, event):
         enable = event.fitID is not None
-        self.Enable(wx.ID_SAVEAS, enable)
-        self.Enable(wx.ID_COPY, enable)
-        self.Enable(self.exportSkillsNeededId, enable)
 
-        sChar = Character.getInstance()
-        charID = self.mainFrame.charSelection.getActiveCharacter()
-        char = sChar.getCharacter(charID)
+        if enable:
+            self.Enable(wx.ID_SAVEAS, enable)
+            self.Enable(wx.ID_COPY, enable)
+            self.Enable(self.exportSkillsNeededId, enable)
 
-        # enable/disable character saving stuff
-        self.Enable(self.saveCharId, not char.ro and char.isDirty)
-        self.Enable(self.saveCharAsId, char.isDirty)
-        self.Enable(self.revertCharId, char.isDirty)
+            sChar = Character.getInstance()
+            charID = self.mainFrame.charSelection.getActiveCharacter()
+            char = sChar.getCharacter(charID)
+
+            # enable/disable character saving stuff
+            self.Enable(self.saveCharId, not char.ro and char.isDirty)
+            self.Enable(self.saveCharAsId, char.isDirty)
+            self.Enable(self.revertCharId, char.isDirty)
 
         event.Skip()


### PR DESCRIPTION
@blitzmann you'll want to review this one and make sure it's not breaking anything.

On a normal fit calc (with a ship, char, etc) `fitChanged` takes about 100-200 ms to run (in full debugging potato mode).  On an _empty_ fit, it takes 1000-1500 ms. (Why we run a full recalc against empty fits is another issue....)

Seems there's no sense in doing a bunch of character stuff for a fit that doesn't exist.

_Should_ be ready to be merged, if you don't see any issues with it.