### PR TITLE
Merging Drone Stacks

### DIFF
--- a/gui/droneView.py
+++ b/gui/droneView.py
@@ -148,11 +148,6 @@ class DroneView(Display):
         sFit = Fit.getInstance()
         fitID = self.mainFrame.getActiveFit()
 
-        # If either stack has active drones, make them all active. Fixes #728
-        if (getattr(self.drones[src], "amountActive", 0) + getattr(self.drones[dst], "amountActive", 0)) > 0:
-            self.drones[src].amountActive = getattr(self.drones[src], "amount", 0)
-            self.drones[dst].amountActive = getattr(self.drones[dst], "amount", 0)
-
         if sFit.mergeDrones(fitID, self.drones[src], self.drones[dst]):
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
 

--- a/gui/droneView.py
+++ b/gui/droneView.py
@@ -147,6 +147,12 @@ class DroneView(Display):
     def _merge(self, src, dst):
         sFit = Fit.getInstance()
         fitID = self.mainFrame.getActiveFit()
+
+        # If either stack has active drones, make them all active. Fixes #728
+        if (getattr(self.drones[src], "amountActive", 0) + getattr(self.drones[dst], "amountActive", 0)) > 0:
+            self.drones[src].amountActive = getattr(self.drones[src], "amount", 0)
+            self.drones[dst].amountActive = getattr(self.drones[dst], "amount", 0)
+
         if sFit.mergeDrones(fitID, self.drones[src], self.drones[dst]):
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
 

--- a/service/fit.py
+++ b/service/fit.py
@@ -726,8 +726,14 @@ class Fit(object):
         else:
             fit.drones.remove(d1)
 
-        d2.amount += d1.amount
-        d2.amountActive += d1.amountActive if d1.amountActive > 0 else -d2.amountActive
+        d2.amount += getattr(d1, "amount", 0)
+        d2.amountActive += getattr(d1, "amountActive", 0)
+
+        # If we have less than the total number of drones active, make them all active. Fixes #728
+        # This could be removed if we ever add an enhancement to make drone stacks partially active.
+        if getattr(d2, "amount", 0) > getattr(d2, "amountActive", 0):
+            d2.amountActive = getattr(d2, "amount", 0)
+
         eos.db.commit()
         self.recalc(fit)
         return True

--- a/service/fit.py
+++ b/service/fit.py
@@ -731,8 +731,8 @@ class Fit(object):
 
         # If we have less than the total number of drones active, make them all active. Fixes #728
         # This could be removed if we ever add an enhancement to make drone stacks partially active.
-        if getattr(d2, "amount", 0) > getattr(d2, "amountActive", 0):
-            d2.amountActive = getattr(d2, "amount", 0)
+        if d2.amount  > d2.amountActive:
+            d2.amountActive = d2.amount
 
         eos.db.commit()
         self.recalc(fit)


### PR DESCRIPTION
Check if we have active drones when merging, if we do make them all active to avoid getting weird scenarios (like deactivating stacks, or only activating parts of stacks).  Fixes #728