### PR TITLE
Stats Pane - Remote Reps

### DIFF
--- a/gui/builtinStatsViews/__init__.py
+++ b/gui/builtinStatsViews/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["resourcesViewFull", "resistancesViewFull",
            "rechargeViewFull", "firepowerViewFull", "capacitorViewFull",
-           "targetingMiscViewFull", "priceViewFull", "miningyieldViewFull"]
+           "targetingMiscViewFull", "priceViewFull", "miningyieldViewFull", "outgoingViewFull"]

--- a/gui/statsPane.py
+++ b/gui/statsPane.py
@@ -33,7 +33,7 @@ from gui.pyfatogglepanel import TogglePanel
 class StatsPane(wx.Panel):
     DEFAULT_VIEWS = ["resourcesViewFull", "resistancesViewFull", "rechargeViewFull", "firepowerViewFull",
                      "capacitorViewFull", "targetingmiscViewFull",
-                     "priceViewFull"]
+                     "priceViewFull", "outgoingViewFull"]
 
     def fitChanged(self, event):
         sFit = Fit.getInstance()

--- a/gui/statsView.py
+++ b/gui/statsView.py
@@ -52,4 +52,5 @@ from gui.builtinStatsViews import (  # noqa: E402, F401
     rechargeViewFull,
     targetingMiscViewFull,
     priceViewFull,
+    outgoingViewFull,
 )


### PR DESCRIPTION
Going through some old issues and turned up #235

It took a bit of work, and unfortunately I didn't see a PR or branch I could easily work off (largely in part due to the major changes over the last few months), but I took what @lunedis had and tweaked it a bit to make it fit.

Adds a very small (so hardly any space lost @blitmann) pane for remote shield, armor, hull, and capacitor.
https://puu.sh/u4So7/8d210d9e56.png

Should be fairly difficult to overflow the numbers since I rearranged it to free up some room.

This would be _extremely_ useful for Logi pilots.

@blitmann I need to add some tooltips, then this will be ready to merge.