### PR TITLE
Rewrite handler for non-unicode paths.

### DIFF
--- a/config.py
+++ b/config.py
@@ -203,14 +203,20 @@ def parsePath(root, Append=None, Create=False):
             if codec_return and Create:
                 path_exists = parsePathCreateDir(codec_return)
 
-            if path_exists and os.path.exists(path_exists):
+            if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists)):
                 return codec_return
             else:
                 continue
 
-        return
+        return None
     else:
-        return root_path
+        if root_path and Create:
+            path_exists = parsePathCreateDir(root_path)
+
+        if root_path and (os.path.exists(root_path) or os.path.isfile(root_path)):
+            return root_path
+        else:
+            return None
 
 
 def parsePathApplyCodec(root_path, apply_codec):

--- a/config.py
+++ b/config.py
@@ -16,6 +16,9 @@ except ImportError:
 debug = False
 # Defines if our saveddata will be in pyfa root or not
 saveInRoot = False
+# Defines if we use a hard set codec or not
+# See https://docs.python.org/2/library/codecs.html#standard-encodings
+codec = None
 
 # Version data
 version = "1.27.0"
@@ -53,11 +56,6 @@ def isFrozen():
         return False
 
 
-def __createDirs(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-
 def defPaths(customSavePath):
     global debug
     global pyfaPath
@@ -72,16 +70,15 @@ def defPaths(customSavePath):
         logLevel = logging.WARN
 
     # The main pyfa directory which contains run.py
-    # Python 2.X uses ANSI by default, so we need to convert the character encoding
     pyfaPath = getattr(configforced, "pyfaPath", pyfaPath)
     if pyfaPath is None:
-        pyfaPath = getPyfaPath()
+        pyfaPath = getPyfaPath(None, True)
 
     # Where we store the saved fits etc, default is the current users home directory
     if saveInRoot is True:
         savePath = getattr(configforced, "savePath", None)
         if savePath is None:
-            savePath = getPyfaPath("saveddata")
+            savePath = getPyfaPath("saveddata", True)
     else:
         savePath = getattr(configforced, "savePath", None)
         if savePath is None:
@@ -90,7 +87,7 @@ def defPaths(customSavePath):
             else:
                 savePath = customSavePath
 
-    __createDirs(savePath)
+    savePath = getSavePath(None, True)
 
     if isFrozen():
         certName = "cacert.pem"
@@ -134,39 +131,101 @@ def defPaths(customSavePath):
     eos.config.gamedata_connectionstring = "sqlite:///" + gameDB + "?check_same_thread=False"
 
 
-def getPyfaPath(Append=None):
+def getPyfaPath(Append=None, Create=False):
     base = getattr(sys.modules['__main__'], "__file__", sys.executable) if isFrozen() else sys.argv[0]
     root = os.path.dirname(os.path.realpath(os.path.abspath(base)))
-
-    if Append:
-        path = parsePath(root, Append)
-    else:
-        path = parsePath(root)
+    path = parsePath(root, Append, Create)
 
     return path
 
 
-def getSavePath(Append=None):
+def getSavePath(Append=None, Create=False):
     root = savePath
-
-    if Append:
-        path = parsePath(root, Append)
-    else:
-        path = parsePath(root)
+    path = parsePath(root, Append, Create)
 
     return path
 
 
-def parsePath(root, Append=None):
+def parsePath(root, Append=None, Create=False):
+    global codec
+
     if Append:
-        path = os.path.join(root, Append)
+        root_path = os.path.join(root, Append)
     else:
-        path = root
+        root_path = root
 
-    if type(path) == str:  # leave unicode ones alone
-        try:
-            path = path.decode('utf8')
-        except UnicodeDecodeError:
-            path = path.decode('windows-1252')
+    codecs = [
+        # Most commonly used
+        "utf_8",  # Generic Linux/Mac
+        "cp1252",  # Standard Windows
+        "cp1251",  # Russian
+        # Windows
+        "cp037", "cp424", "cp437", "cp500", "cp720", "cp737", "cp775", "cp850", "cp852", "cp855", "cp856", "cp857", "cp858", "cp860", "cp861", "cp862", "cp863",
+        "cp864", "cp865", "cp866", "cp869", "cp874", "cp875", "cp932", "cp949", "cp950", "cp1006", "cp1026", "cp1140", "cp1250", "cp1253",
+        "cp1254", "cp1255", "cp1256", "cp1257", "cp1258",
+        # Mac
+        "mac_cyrillic", "mac_greek", "mac_iceland", "mac_latin2", "mac_roman", "mac_turkish",
+        # UTF (universal)
+        "utf_16", "utf_32", "utf_32_be", "utf_32_le", "utf_16_be", "utf_16_le", "utf_7", "utf_8_sig",
+        # Other (AKA the "weird ones")
+        "scii", "big5", "big5hkscs", "euc_jp", "euc_jis_2004", "euc_jisx0213", "euc_kr", "gb2312", "gbk", "gb18030", "hz", "iso2022_jp", "iso2022_jp_1",
+        "iso2022_jp_2", "iso2022_jp_2004", "iso2022_jp_3", "iso2022_jp_ext", "iso2022_kr", "latin_1", "iso8859_2", "iso8859_3", "iso8859_4", "iso8859_5",
+        "iso8859_6", "iso8859_7", "iso8859_8", "iso8859_9", "iso8859_10", "iso8859_11", "iso8859_13", "iso8859_14", "iso8859_15", "iso8859_16", "johab", "koi8_r",
+        "koi8_u", "ptcp154", "shift_jis", "shift_jis_2004", "shift_jisx0213"
+    ]
 
-    return path
+    if type(root_path) == str:  # leave unicode ones alone
+        path_exists = False
+
+        if codec:
+            codec_return = parsePathApplyCodec(root_path, codec)
+
+            if codec_return and Create:
+                path_exists = parsePathCreateDir(codec_return)
+
+            if path_exists:
+                return codec_return
+
+        for test_codec in codecs:
+            codec_return = parsePathApplyCodec(root_path, test_codec)
+
+            if not Create:
+                return codec_return
+
+            if codec_return and Create:
+                path_exists = parsePathCreateDir(codec_return)
+
+            if path_exists:
+                return codec_return
+            else:
+                continue
+
+        return
+    else:
+        return root_path
+
+
+def parsePathApplyCodec(root_path, apply_codec):
+    try:
+        codec_path = root_path.decode(apply_codec)
+    except (UnicodeDecodeError, UnicodeEncodeError, LookupError, UnicodeError, UnicodeTranslateError):
+        # TODO: Add logging when we have logbook in place
+        codec_path = None
+
+    return codec_path
+
+
+def parsePathCreateDir(create_path):
+    # noinspection PyBroadException
+    try:
+        if not os.path.exists(create_path):
+            os.mkdir(create_path)
+        path_exists = True
+    except WindowsError:
+        path_exists = False
+    except Exception:  # as e
+        # We got some other error.
+        # TODO: Add logging when we have logbook in place
+        path_exists = False
+
+    return path_exists

--- a/config.py
+++ b/config.py
@@ -136,14 +136,22 @@ def getPyfaPath(Append=None, Create=False):
     root = os.path.dirname(os.path.realpath(os.path.abspath(base)))
     path = parsePath(root, Append, Create)
 
-    return path
+    if path:
+        return path
+    else:
+        # TODO: add logging and handling when we fail to get a path correctly. Probably should bail and direct the user to how to force the codec.
+        return
 
 
 def getSavePath(Append=None, Create=False):
     root = savePath
     path = parsePath(root, Append, Create)
 
-    return path
+    if path:
+        return path
+    else:
+        # TODO: add logging and handling when we fail to get a path correctly. Probably should bail and direct the user to how to force the codec.
+        return
 
 
 def parsePath(root, Append=None, Create=False):

--- a/config.py
+++ b/config.py
@@ -183,7 +183,7 @@ def parsePath(root, Append=None, Create=False):
             if codec_return and Create:
                 path_exists = parsePathCreateDir(codec_return)
 
-            if path_exists:
+            if path_exists and os.path.exists(path_exists):
                 return codec_return
 
         for test_codec in codecs:
@@ -195,7 +195,7 @@ def parsePath(root, Append=None, Create=False):
             if codec_return and Create:
                 path_exists = parsePathCreateDir(codec_return)
 
-            if path_exists:
+            if path_exists and os.path.exists(path_exists):
                 return codec_return
             else:
                 continue

--- a/config.py
+++ b/config.py
@@ -144,8 +144,8 @@ def getPyfaPath(Append=None, Create=False):
 
 
 def getSavePath(Append=None, Create=False):
-    root = savePath
-    path = parsePath(root, Append, Create)
+    global savePath
+    path = parsePath(savePath, Append, Create)
 
     if path:
         return path
@@ -154,7 +154,7 @@ def getSavePath(Append=None, Create=False):
         return
 
 
-def parsePath(root, Append=None, Create=False):
+def parsePath(root, Append=None, Create=False, SkipValidation=False):
     global codec
 
     if Append:
@@ -191,7 +191,7 @@ def parsePath(root, Append=None, Create=False):
             if codec_return and Create:
                 path_exists = parsePathCreateDir(codec_return)
 
-            if path_exists and os.path.exists(path_exists):
+            if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists) or SkipValidation):
                 return codec_return
 
         for test_codec in codecs:
@@ -203,7 +203,7 @@ def parsePath(root, Append=None, Create=False):
             if codec_return and Create:
                 path_exists = parsePathCreateDir(codec_return)
 
-            if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists)):
+            if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists) or SkipValidation):
                 return codec_return
             else:
                 continue
@@ -215,7 +215,7 @@ def parsePath(root, Append=None, Create=False):
         else:
             path_exists = root_path
 
-        if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists)):
+        if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists) or SkipValidation):
             return path_exists
         else:
             return None

--- a/config.py
+++ b/config.py
@@ -212,9 +212,11 @@ def parsePath(root, Append=None, Create=False):
     else:
         if root_path and Create:
             path_exists = parsePathCreateDir(root_path)
+        else:
+            path_exists = root_path
 
-        if root_path and (os.path.exists(root_path) or os.path.isfile(root_path)):
-            return root_path
+        if path_exists and (os.path.exists(path_exists) or os.path.isfile(path_exists)):
+            return path_exists
         else:
             return None
 
@@ -234,7 +236,7 @@ def parsePathCreateDir(create_path):
     try:
         if not os.path.exists(create_path):
             os.mkdir(create_path)
-        path_exists = True
+        path_exists = create_path
     except WindowsError:
         path_exists = False
     except Exception:  # as e

--- a/pyfa.py
+++ b/pyfa.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: latin-1 -*-
 # ==============================================================================
 # Copyright (C) 2010 Diego Duclos
 #
@@ -47,8 +48,22 @@ parser.add_option("-w", "--wx28", action="store_true", dest="force28", help="For
 parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set logger to debug level.", default=False)
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
+parser.add_option("-c", "--codec", action="store", dest="codec", help="Forces use of a particular language codec to run", default=None)
 
 (options, args) = parser.parse_args()
+
+# Configure paths
+if options.rootsavedata is True:
+    config.saveInRoot = True
+
+# set title if it wasn't supplied by argument
+if options.title is None:
+    options.title = "pyfa %s%s - Python Fitting Assistant" % (config.version, "" if config.tag.lower() != 'git' else " (git)")
+
+config.debug = options.debug
+config.codec = options.codec
+config.defPaths(options.savepath)
+
 
 if not hasattr(sys, 'frozen'):
 
@@ -105,20 +120,6 @@ if not hasattr(sys, 'frozen'):
 
 
 if __name__ == "__main__":
-    # Configure paths
-    if options.rootsavedata is True:
-        config.saveInRoot = True
-
-    # set title if it wasn't supplied by argument
-    if options.title is None:
-        options.title = "pyfa %s%s - Python Fitting Assistant" % (config.version, "" if config.tag.lower() != 'git' else " (git)")
-
-    config.debug = options.debug
-    # convert to unicode if it is set
-    if options.savepath is not None:
-        options.savepath = unicode(options.savepath)
-    config.defPaths(options.savepath)
-
     # Basic logging initialization
     import logging
     logging.basicConfig()
@@ -126,17 +127,11 @@ if __name__ == "__main__":
     # Import everything
     # noinspection PyPackageRequirements
     import wx
-    import os
-    import os.path
 
     import eos.db
     # noinspection PyUnresolvedReferences
     import service.prefetch  # noqa: F401
     from gui.mainFrame import MainFrame
-
-    # Make sure the saveddata db exists
-    if not os.path.exists(config.savePath):
-        os.mkdir(config.savePath)
 
     eos.db.saveddata_meta.create_all()
 

--- a/service/prefetch.py
+++ b/service/prefetch.py
@@ -29,9 +29,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Make sure the saveddata db exists
-if config.savePath and not os.path.exists(config.savePath):
-    os.mkdir(config.savePath)
+# Make sure the saveddata folder exists
+config.getSavePath(None, True)
 
 if config.saveDB and os.path.isfile(config.saveDB):
     # If database exists, run migration after init'd database

--- a/service/settings.py
+++ b/service/settings.py
@@ -25,7 +25,7 @@ import config
 
 
 class SettingsProvider(object):
-    BASE_PATH = config.getSavePath("settings")
+    BASE_PATH = config.getSavePath("settings", True)
     settings = {}
     _instance = None
 
@@ -35,10 +35,6 @@ class SettingsProvider(object):
             cls._instance = SettingsProvider()
 
         return cls._instance
-
-    def __init__(self):
-        if not os.path.exists(self.BASE_PATH):
-            os.mkdir(self.BASE_PATH)
 
     def getSettings(self, area, defaults=None):
 

--- a/tests/test_modules/_readme.md
+++ b/tests/test_modules/_readme.md
@@ -1,0 +1,3 @@
+Eventually this should contain a rough mirror of the folder structure of Pyfa.  Each file is used to test a matching file in Pyfa.
+
+For some files (notably `config.py`), we will need to test file formatting that will require a separate file.  Simply name the file to match, and append a brief description (example:  `test_config_cp1251.py` to test formatting using the `cp1251` codec.)

--- a/tests/test_modules/test_config.py
+++ b/tests/test_modules/test_config.py
@@ -24,4 +24,5 @@ def test_parsePath_with_append():
     assert create_result
     assert type(create_result) == unicode
     assert type(create_result) != str
-    assert create_result == "\\This\\Is\\A\\Fake\\Path\\file.py"
+    # On Linux this can show differently. Left side for Windows, right side for Linux.
+    assert (create_result == "\\This\\Is\\A\\Fake\\Path\\file.py" or create_result == "\This\Is\A\Fake\Path/file.py")

--- a/tests/test_modules/test_config.py
+++ b/tests/test_modules/test_config.py
@@ -3,24 +3,25 @@ import os
 
 
 def test_parsePath():
-    base = "C:\This\Is\A\Fake\Path"
-    base = os.path.realpath(os.path.abspath(base))
+    basepath = "\This\Is\A\Fake\Path"
+    base = os.path.normpath(basepath)
 
     create_result = parsePath(base)
 
     assert create_result
     assert type(create_result) == unicode
     assert type(create_result) != str
-    assert create_result == "C:\\This\\Is\\A\\Fake\\Path"
+    assert create_result == "\\This\\Is\\A\\Fake\\Path"
+
 
 def test_parsePath_with_append():
-    base = "C:\This\Is\A\Fake\Path"
+    basepath = "\This\Is\A\Fake\Path"
     append = "file.py"
-    base = os.path.realpath(os.path.abspath(base))
+    base = os.path.normpath(basepath)
 
     create_result = parsePath(base, append)
 
     assert create_result
     assert type(create_result) == unicode
     assert type(create_result) != str
-    assert create_result == "C:\\This\\Is\\A\\Fake\\Path\\file.py"
+    assert create_result == "\\This\\Is\\A\\Fake\\Path\\file.py"

--- a/tests/test_modules/test_config.py
+++ b/tests/test_modules/test_config.py
@@ -1,0 +1,26 @@
+from config import parsePath
+import os
+
+
+def test_parsePath():
+    base = "C:\This\Is\A\Fake\Path"
+    base = os.path.realpath(os.path.abspath(base))
+
+    create_result = parsePath(base)
+
+    assert create_result
+    assert type(create_result) == unicode
+    assert type(create_result) != str
+    assert create_result == "C:\\This\\Is\\A\\Fake\\Path"
+
+def test_parsePath_with_append():
+    base = "C:\This\Is\A\Fake\Path"
+    append = "file.py"
+    base = os.path.realpath(os.path.abspath(base))
+
+    create_result = parsePath(base, append)
+
+    assert create_result
+    assert type(create_result) == unicode
+    assert type(create_result) != str
+    assert create_result == "C:\\This\\Is\\A\\Fake\\Path\\file.py"

--- a/tests/test_modules/test_config_cp1251.py
+++ b/tests/test_modules/test_config_cp1251.py
@@ -3,10 +3,11 @@
 import config
 import os
 
+
 def test_parsePath_with_codec():
     config.codec = "cp1251"
-    base = "C:\Users\Гоша Егорян\.pyfa"
-    base = os.path.realpath(os.path.abspath(base))
+    basepath = "\Users\Гоша Егорян\.pyfa"
+    base = os.path.normpath(basepath)
 
     create_result = config.parsePath(base, None, "Skip")
 
@@ -14,21 +15,26 @@ def test_parsePath_with_codec():
     assert type(create_result) == unicode
     assert type(create_result) != str
 
-    assert create_result == ("C:\\Users\\Гоша Егорян\\.pyfa").decode(config.codec)
-    assert create_result != "C:\\Users\\Гоша Егорян\\.pyfa"
-    assert create_result != "C:\\Users\\???? ??????\\.pyfa"
-    assert create_result != "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+    assert create_result == "\\Users\\Гоша Егорян\\.pyfa".decode(config.codec)
+    assert create_result != "\\Users\\Гоша Егорян\\.pyfa"
+    assert create_result != "\\Users\\???? ??????\\.pyfa"
+    assert create_result != "\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
 
-    assert base != ("C:\\Users\\Гоша Егорян\\.pyfa").decode(config.codec)
-    assert base == "C:\\Users\\Гоша Егорян\\.pyfa"
-    assert base != "C:\\Users\\???? ??????\\.pyfa"
-    assert base == "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+    assert base != "\\Users\\Гоша Егорян\\.pyfa".decode(config.codec)
+    assert base == "\\Users\\Гоша Егорян\\.pyfa"
+    assert base != "\\Users\\???? ??????\\.pyfa"
+    assert base == "\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+
+    assert basepath != "\Users\Гоша Егорян\.pyfa".decode(config.codec)
+    assert basepath == "\Users\Гоша Егорян\.pyfa"
+    assert basepath != "\Users\???? ??????\.pyfa"
+    assert basepath == "\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\.pyfa"
 
 
 def test_parsePath_without_codec():
     codec = "cp1251"
-    base = "C:\Users\Гоша Егорян\.pyfa"
-    base = os.path.realpath(os.path.abspath(base))
+    basepath = "\Users\Гоша Егорян\.pyfa"
+    base = os.path.normpath(basepath)
 
     create_result = config.parsePath(base, None, "Skip")
 
@@ -36,12 +42,17 @@ def test_parsePath_without_codec():
     assert type(create_result) == unicode
     assert type(create_result) != str
 
-    assert create_result == ("C:\\Users\\Гоша Егорян\\.pyfa").decode(codec)
-    assert create_result != "C:\\Users\\Гоша Егорян\\.pyfa"
-    assert create_result != "C:\\Users\\???? ??????\\.pyfa"
-    assert create_result != "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+    assert create_result == "\\Users\\Гоша Егорян\\.pyfa".decode(codec)
+    assert create_result != "\\Users\\Гоша Егорян\\.pyfa"
+    assert create_result != "\\Users\\???? ??????\\.pyfa"
+    assert create_result != "\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
 
-    assert base != ("C:\\Users\\Гоша Егорян\\.pyfa").decode(codec)
-    assert base == "C:\\Users\\Гоша Егорян\\.pyfa"
-    assert base != "C:\\Users\\???? ??????\\.pyfa"
-    assert base == "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+    assert base != "\\Users\\Гоша Егорян\\.pyfa".decode(codec)
+    assert base == "\\Users\\Гоша Егорян\\.pyfa"
+    assert base != "\\Users\\???? ??????\\.pyfa"
+    assert base == "\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+
+    assert basepath != "\Users\Гоша Егорян\.pyfa".decode(codec)
+    assert basepath == "\Users\Гоша Егорян\.pyfa"
+    assert basepath != "\Users\???? ??????\.pyfa"
+    assert basepath == "\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\.pyfa"

--- a/tests/test_modules/test_config_cp1251.py
+++ b/tests/test_modules/test_config_cp1251.py
@@ -1,0 +1,47 @@
+# -*- coding: cp1251 -*-
+
+import config
+import os
+
+def test_parsePath_with_codec():
+    config.codec = "cp1251"
+    base = "C:\Users\Гоша Егорян\.pyfa"
+    base = os.path.realpath(os.path.abspath(base))
+
+    create_result = config.parsePath(base, None, "Skip")
+
+    assert create_result
+    assert type(create_result) == unicode
+    assert type(create_result) != str
+
+    assert create_result == ("C:\\Users\\Гоша Егорян\\.pyfa").decode(config.codec)
+    assert create_result != "C:\\Users\\Гоша Егорян\\.pyfa"
+    assert create_result != "C:\\Users\\???? ??????\\.pyfa"
+    assert create_result != "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+
+    assert base != ("C:\\Users\\Гоша Егорян\\.pyfa").decode(config.codec)
+    assert base == "C:\\Users\\Гоша Егорян\\.pyfa"
+    assert base != "C:\\Users\\???? ??????\\.pyfa"
+    assert base == "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+
+
+def test_parsePath_without_codec():
+    codec = "cp1251"
+    base = "C:\Users\Гоша Егорян\.pyfa"
+    base = os.path.realpath(os.path.abspath(base))
+
+    create_result = config.parsePath(base, None, "Skip")
+
+    assert create_result
+    assert type(create_result) == unicode
+    assert type(create_result) != str
+
+    assert create_result == ("C:\\Users\\Гоша Егорян\\.pyfa").decode(codec)
+    assert create_result != "C:\\Users\\Гоша Егорян\\.pyfa"
+    assert create_result != "C:\\Users\\???? ??????\\.pyfa"
+    assert create_result != "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"
+
+    assert base != ("C:\\Users\\Гоша Егорян\\.pyfa").decode(codec)
+    assert base == "C:\\Users\\Гоша Егорян\\.pyfa"
+    assert base != "C:\\Users\\???? ??????\\.pyfa"
+    assert base == "C:\\Users\\\xc3\xee\xf8\xe0 \xc5\xe3\xee\xf0\xff\xed\\.pyfa"


### PR DESCRIPTION
Rewrite handler for non-unicode paths.  Add option to force use of a particular codec. If the codec set via parameters fails, will auto fall back to trying every available codec.

@blitzmann can you test this and see about doing a new build?  Please note that this PR is pointed at Master and *NOT* Development.

Also, I did a thing! \o/
https://github.com/pyfa-org/Pyfa/wiki/Command-Line-Parameters-(Startup-Options)