### PR TITLE
Tests for Pyfa

### DIFF
--- a/eos/mathUtils.py
+++ b/eos/mathUtils.py
@@ -17,15 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-import decimal
+from math import floor
 
 
 def floorFloat(value):
-    """Round float down to integer"""
-    # We have to convert float to str to keep compatibility with
-    # decimal module in python 2.6
-    value = str(value)
-    # Do the conversions for proper rounding down, avoiding float
-    # representation errors
-    result = int(decimal.Decimal(value).to_integral_value(rounding=decimal.ROUND_DOWN))
+    result = int(floor(value))
     return result

--- a/tests/test_modules/eos/test_mathUtils.py
+++ b/tests/test_modules/eos/test_mathUtils.py
@@ -9,4 +9,4 @@ def test_floorFloat():
     assert floorFloat(1.1) == 1
     assert floorFloat(1.9) == 1
     assert floorFloat(1.5) == 1
-    assert floorFloat(-1.5) == -1
+    assert floorFloat(-1.5) == -2

--- a/tests/test_modules/eos/test_mathUtils.py
+++ b/tests/test_modules/eos/test_mathUtils.py
@@ -1,0 +1,12 @@
+from eos.mathUtils import floorFloat
+
+
+def test_floorFloat():
+    assert type(floorFloat(1)) is not float
+    assert type(floorFloat(1)) is int
+    assert type(floorFloat(1.1)) is not float
+    assert type(floorFloat(1.1)) is int
+    assert floorFloat(1.1) == 1
+    assert floorFloat(1.9) == 1
+    assert floorFloat(1.5) == 1
+    assert floorFloat(-1.5) == -1

--- a/tests/test_modules/gui/test_aboutData.py
+++ b/tests/test_modules/gui/test_aboutData.py
@@ -1,5 +1,6 @@
 from gui.aboutData import versionString, licenses, developers, credits, description
 
+
 def test_aboutData():
     assert versionString.__len__() > 0
     assert licenses.__len__() > 0

--- a/tests/test_modules/gui/test_aboutData.py
+++ b/tests/test_modules/gui/test_aboutData.py
@@ -1,0 +1,8 @@
+from gui.aboutData import versionString, licenses, developers, credits, description
+
+def test_aboutData():
+    assert versionString.__len__() > 0
+    assert licenses.__len__() > 0
+    assert developers.__len__() > 0
+    assert credits.__len__() > 0
+    assert description.__len__() > 0

--- a/tests/test_modules/service/test_attribute.py
+++ b/tests/test_modules/service/test_attribute.py
@@ -1,5 +1,6 @@
 from service.attribute import Attribute
 
+
 def test_attribute():
     """
     We don't really have much to test here, to throw a generic attribute at it and validate we get the expected results
@@ -19,13 +20,13 @@ def test_attribute():
     assert type(info.description) is unicode
     assert info.displayName == 'Optimal Range'
     assert type(info.displayName) is unicode
-    assert info.highIsGood == True
+    assert info.highIsGood is True
     assert type(info.highIsGood) is bool
     assert info.iconID == 1391
     assert type(info.iconID) is int
     assert info.name == 'maxRange'
     assert type(info.name) is unicode
-    assert info.published == True
+    assert info.published is True
     assert type(info.published) is bool
     assert info.unitID == 1
     assert type(info.unitID) is int

--- a/tests/test_modules/service/test_attribute.py
+++ b/tests/test_modules/service/test_attribute.py
@@ -1,0 +1,41 @@
+from service.attribute import Attribute
+
+def test_attribute():
+    """
+    We don't really have much to test here, to throw a generic attribute at it and validate we get the expected results
+
+    :return:
+    """
+    sAttr = Attribute.getInstance()
+    info = sAttr.getAttributeInfo("maxRange")
+
+    assert info.attributeID == 54
+    assert type(info.attributeID) is int
+    assert info.attributeName == 'maxRange'
+    assert type(info.attributeName) is unicode
+    assert info.defaultValue == 0.0
+    assert type(info.defaultValue) is float
+    assert info.description == 'Distance below which range does not affect the to-hit equation.'
+    assert type(info.description) is unicode
+    assert info.displayName == 'Optimal Range'
+    assert type(info.displayName) is unicode
+    assert info.highIsGood == True
+    assert type(info.highIsGood) is bool
+    assert info.iconID == 1391
+    assert type(info.iconID) is int
+    assert info.name == 'maxRange'
+    assert type(info.name) is unicode
+    assert info.published == True
+    assert type(info.published) is bool
+    assert info.unitID == 1
+    assert type(info.unitID) is int
+    assert info.unit.ID == 1
+    assert type(info.unit.ID) is int
+    assert info.unit.displayName == 'm'
+    assert type(info.unit.displayName) is unicode
+    assert info.unit.name == 'Length'
+    assert type(info.unit.name) is unicode
+    assert info.unit.unitID == 1
+    assert type(info.unit.unitID) is int
+    assert info.unit.unitName == 'Length'
+    assert type(info.unit.unitName) is unicode

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,10 +2,10 @@
 
 import os
 import sys
-import importlib
+# import importlib
 
 # noinspection PyPackageRequirements
-import pytest
+# import pytest
 
 
 script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Just a quick little PR to add a few tests for Pyfa.

Also, found a small bug in `floorFloat`.  We were handling it a bit hacky for 2.6 compataibility, and this meant we would round the wrong way for negative values (-1.1 rounded to -1, when it should round to -2).  Didn't see any use cases when we'd hit that, but rewrote it anyway to use `floor` since we're  not supporting 2.6 anymore, and it's MUCH simpler.