### PR TITLE
Add Properties Pane

### DIFF
--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -1365,8 +1365,6 @@ class ItemProperties(wx.Panel):
         self.paramList.SetColumnWidth(0, 110)
         self.paramList.SetColumnWidth(1, 1500)
         self.paramList.setResizeColumn(0)
-        #self.imageList = wx.ImageList(16, 16)
-        #self.paramList.SetImageList(self.imageList, wx.IMAGE_LIST_SMALL)
 
         if self.stuff:
             names = dir(self.stuff)
@@ -1374,7 +1372,6 @@ class ItemProperties(wx.Panel):
             names = dir(self.item)
 
         names = [a for a in names if not (a.startswith('__') and a.endswith('__'))]
-
 
         idNameMap = {}
         idCount = 0
@@ -1389,6 +1386,7 @@ class ItemProperties(wx.Panel):
             except Exception as e:
                 # TODO: Add logging to this.
                 # We couldn't get a property for some reason. Skip it for now.
+                print(e)
                 continue
 
             index = self.paramList.InsertStringItem(sys.maxint, attrName)

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -1357,26 +1357,39 @@ class ItemProperties(wx.Panel):
         self.paramList.ClearAll()
         self.PopulateList()
         self.Thaw()
-        self.paramList.resizeLastColumn(100)
+        self.paramList.resizeLastColumn(1500)
 
     def PopulateList(self):
         self.paramList.InsertColumn(0, "Attribute")
         self.paramList.InsertColumn(1, "Current Value")
         self.paramList.SetColumnWidth(0, 110)
-        self.paramList.SetColumnWidth(1, 400)
+        self.paramList.SetColumnWidth(1, 1500)
         self.paramList.setResizeColumn(0)
-        self.imageList = wx.ImageList(16, 16)
-        self.paramList.SetImageList(self.imageList, wx.IMAGE_LIST_SMALL)
+        #self.imageList = wx.ImageList(16, 16)
+        #self.paramList.SetImageList(self.imageList, wx.IMAGE_LIST_SMALL)
 
-        names = dir(self.item)
+        if self.stuff:
+            names = dir(self.stuff)
+        else:
+            names = dir(self.item)
+
         names = [a for a in names if not (a.startswith('__') and a.endswith('__'))]
-        # names = names.sort()
+
 
         idNameMap = {}
         idCount = 0
         for name in names:
-            attrName = name.title()
-            value = getattr(self.item, name)
+            try:
+                if self.stuff:
+                    attrName = name.title()
+                    value = getattr(self.stuff, name)
+                else:
+                    attrName = name.title()
+                    value = getattr(self.item, name)
+            except Exception as e:
+                # TODO: Add logging to this.
+                # We couldn't get a property for some reason. Skip it for now.
+                continue
 
             index = self.paramList.InsertStringItem(sys.maxint, attrName)
             # index = self.paramList.InsertImageStringItem(sys.maxint, attrName)

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -1352,13 +1352,6 @@ class ItemProperties(wx.Panel):
         else:
             return
 
-    def UpdateList(self):
-        self.Freeze()
-        self.paramList.ClearAll()
-        self.PopulateList()
-        self.Thaw()
-        self.paramList.resizeLastColumn(1500)
-
     def PopulateList(self):
         self.paramList.InsertColumn(0, "Attribute")
         self.paramList.InsertColumn(1, "Current Value")

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -62,13 +62,13 @@ class ItemStatsDialog(wx.Dialog):
     ):
 
         wx.Dialog.__init__(
-            self,
-            gui.mainFrame.MainFrame.getInstance(),
-            wx.ID_ANY,
-            title="Item stats",
-            pos=pos,
-            size=size,
-            style=wx.CAPTION | wx.CLOSE_BOX | wx.MINIMIZE_BOX | wx.MAXIMIZE_BOX | wx.RESIZE_BORDER | wx.SYSTEM_MENU
+                self,
+                gui.mainFrame.MainFrame.getInstance(),
+                wx.ID_ANY,
+                title="Item stats",
+                pos=pos,
+                size=size,
+                style=wx.CAPTION | wx.CLOSE_BOX | wx.MINIMIZE_BOX | wx.MAXIMIZE_BOX | wx.RESIZE_BORDER | wx.SYSTEM_MENU
         )
 
         empty = getattr(victim, "isEmpty", False)
@@ -197,6 +197,10 @@ class ItemStatsContainer(wx.Panel):
             self.affectedby = ItemAffectedBy(self.nbContainer, stuff, item)
             self.nbContainer.AddPage(self.affectedby, "Affected by")
 
+        if config.debug:
+            self.properties = ItemProperties(self.nbContainer, stuff, item, context)
+            self.nbContainer.AddPage(self.properties, "Properties")
+
         self.nbContainer.Bind(wx.EVT_LEFT_DOWN, self.mouseHit)
         self.SetSizer(mainSizer)
         self.Layout()
@@ -256,7 +260,7 @@ class ItemDescription(wx.Panel):
         # Strip URLs
         desc = re.sub("<( *)a(.*?)>(?P<inside>.*?)<( *)/( *)a( *)>", "\g<inside>", desc)
         desc = "<body bgcolor='" + bgcolor.GetAsString(wx.C2S_HTML_SYNTAX) + "' text='" + fgcolor.GetAsString(
-            wx.C2S_HTML_SYNTAX) + "' >" + desc + "</body>"
+                wx.C2S_HTML_SYNTAX) + "' >" + desc + "</body>"
 
         self.description.SetPage(desc)
 
@@ -358,13 +362,13 @@ class ItemParams(wx.Panel):
             writer = csv.writer(exportFile, delimiter=',')
 
             writer.writerow(
-                [
-                    "ID",
-                    "Internal Name",
-                    "Friendly Name",
-                    "Modified Value",
-                    "Base Value",
-                ]
+                    [
+                        "ID",
+                        "Internal Name",
+                        "Friendly Name",
+                        "Modified Value",
+                        "Base Value",
+                    ]
             )
 
             for attribute in self.attrValues:
@@ -395,13 +399,13 @@ class ItemParams(wx.Panel):
                     attribute_modified_value = self.attrValues[attribute]
 
                 writer.writerow(
-                    [
-                        attribute_id,
-                        attribute_name,
-                        attribute_displayname,
-                        attribute_modified_value,
-                        attribute_value,
-                    ]
+                        [
+                            attribute_id,
+                            attribute_name,
+                            attribute_displayname,
+                            attribute_modified_value,
+                            attribute_value,
+                        ]
                 )
 
     def PopulateList(self):
@@ -496,17 +500,19 @@ class ItemParams(wx.Panel):
             attribute = Attribute.getInstance().getAttributeInfo(value)
             return "%s (%d)" % (attribute.name.capitalize(), value)
 
-        trans = {"Inverse Absolute Percent": (lambda: (1 - value) * 100, unitName),
-                 "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
-                 "Modifier Percent": (
-                     lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
-                 "Volume": (lambda: value, u"m\u00B3"),
-                 "Sizeclass": (lambda: value, ""),
-                 "Absolute Percent": (lambda: (value * 100), unitName),
-                 "Milliseconds": (lambda: value / 1000.0, unitName),
-                 "typeID": (itemIDCallback, ""),
-                 "groupID": (groupIDCallback, ""),
-                 "attributeID": (attributeIDCallback, "")}
+        trans = {
+            "Inverse Absolute Percent" : (lambda: (1 - value) * 100, unitName),
+            "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
+            "Modifier Percent"         : (
+                lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
+            "Volume"                   : (lambda: value, u"m\u00B3"),
+            "Sizeclass"                : (lambda: value, ""),
+            "Absolute Percent"         : (lambda: (value * 100), unitName),
+            "Milliseconds"             : (lambda: value / 1000.0, unitName),
+            "typeID"                   : (itemIDCallback, ""),
+            "groupID"                  : (groupIDCallback, ""),
+            "attributeID"              : (attributeIDCallback, "")
+        }
 
         override = trans.get(unitDisplayName)
         if override is not None:
@@ -689,17 +695,18 @@ class ItemCompare(wx.Panel):
             attribute = Attribute.getInstance().getAttributeInfo(value)
             return "%s (%d)" % (attribute.name.capitalize(), value)
 
-        trans = {"Inverse Absolute Percent": (lambda: (1 - value) * 100, unitName),
-                 "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
-                 "Modifier Percent": (
-                     lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
-                 "Volume": (lambda: value, u"m\u00B3"),
-                 "Sizeclass": (lambda: value, ""),
-                 "Absolute Percent": (lambda: (value * 100), unitName),
-                 "Milliseconds": (lambda: value / 1000.0, unitName),
-                 "typeID": (itemIDCallback, ""),
-                 "groupID": (groupIDCallback, ""),
-                 "attributeID": (attributeIDCallback, "")}
+        trans = {
+            "Inverse Absolute Percent" : (lambda: (1 - value) * 100, unitName),
+            "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
+            "Modifier Percent"         : (lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
+            "Volume"                   : (lambda: value, u"m\u00B3"),
+            "Sizeclass"                : (lambda: value, ""),
+            "Absolute Percent"         : (lambda: (value * 100), unitName),
+            "Milliseconds"             : (lambda: value / 1000.0, unitName),
+            "typeID"                   : (itemIDCallback, ""),
+            "groupID"                  : (groupIDCallback, ""),
+            "attributeID"              : (attributeIDCallback, "")
+        }
 
         override = trans.get(unitDisplayName)
         if override is not None:
@@ -1067,7 +1074,7 @@ class ItemAffectedBy(wx.Panel):
                         item = afflictor.item
 
                     items[attrName].append(
-                        (type(afflictor), afflictor, item, modifier, amount, getattr(afflictor, "projected", False)))
+                            (type(afflictor), afflictor, item, modifier, amount, getattr(afflictor, "projected", False)))
 
         # Make sure projected fits are on top
         rootOrder = container.keys()
@@ -1295,3 +1302,93 @@ class ItemAffectedBy(wx.Panel):
                         treeitem = self.affectedBy.AppendItem(child, display, attrIcon)
                         self.affectedBy.SetPyData(treeitem, saved)
                         self.treeItems.append(treeitem)
+
+
+class ItemProperties(wx.Panel):
+    def __init__(self, parent, stuff, item, context=None):
+        wx.Panel.__init__(self, parent)
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.paramList = AutoListCtrl(self, wx.ID_ANY,
+                                      style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.LC_VRULES | wx.NO_BORDER)
+        mainSizer.Add(self.paramList, 1, wx.ALL | wx.EXPAND, 0)
+        self.SetSizer(mainSizer)
+
+        self.toggleView = 1
+        self.stuff = stuff
+        self.item = item
+        self.attrInfo = {}
+        self.attrValues = {}
+        self._fetchValues()
+
+        self.m_staticline = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
+        mainSizer.Add(self.m_staticline, 0, wx.EXPAND)
+        bSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.totalAttrsLabel = wx.StaticText(self, wx.ID_ANY, u" ", wx.DefaultPosition, wx.DefaultSize, 0)
+        bSizer.Add(self.totalAttrsLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT)
+
+        mainSizer.Add(bSizer, 0, wx.ALIGN_RIGHT)
+
+        self.PopulateList()
+
+    def _fetchValues(self):
+        if self.stuff is None:
+            self.attrInfo.clear()
+            self.attrValues.clear()
+            self.attrInfo.update(self.item.attributes)
+            self.attrValues.update(self.item.attributes)
+        elif self.stuff.item == self.item:
+            self.attrInfo.clear()
+            self.attrValues.clear()
+            self.attrInfo.update(self.stuff.item.attributes)
+            self.attrValues.update(self.stuff.itemModifiedAttributes)
+        elif self.stuff.charge == self.item:
+            self.attrInfo.clear()
+            self.attrValues.clear()
+            self.attrInfo.update(self.stuff.charge.attributes)
+            self.attrValues.update(self.stuff.chargeModifiedAttributes)
+        # When item for stats window no longer exists, don't change anything
+        else:
+            return
+
+    def UpdateList(self):
+        self.Freeze()
+        self.paramList.ClearAll()
+        self.PopulateList()
+        self.Thaw()
+        self.paramList.resizeLastColumn(100)
+
+    def PopulateList(self):
+        self.paramList.InsertColumn(0, "Attribute")
+        self.paramList.InsertColumn(1, "Current Value")
+        self.paramList.SetColumnWidth(0, 110)
+        self.paramList.SetColumnWidth(1, 400)
+        self.paramList.setResizeColumn(0)
+        self.imageList = wx.ImageList(16, 16)
+        self.paramList.SetImageList(self.imageList, wx.IMAGE_LIST_SMALL)
+
+        names = dir(self.item)
+        names = [a for a in names if not (a.startswith('__') and a.endswith('__'))]
+        # names = names.sort()
+
+        idNameMap = {}
+        idCount = 0
+        for name in names:
+            attrName = name.title()
+            value = getattr(self.item, name)
+
+            index = self.paramList.InsertStringItem(sys.maxint, attrName)
+            # index = self.paramList.InsertImageStringItem(sys.maxint, attrName)
+            idNameMap[idCount] = attrName
+            self.paramList.SetItemData(index, idCount)
+            idCount += 1
+
+            valueUnit = str(value)
+
+            self.paramList.SetStringItem(index, 1, valueUnit)
+
+        self.paramList.SortItems(lambda id1, id2: cmp(idNameMap[id1], idNameMap[id2]))
+        self.paramList.RefreshRows()
+        self.totalAttrsLabel.SetLabel("%d attributes. " % idCount)
+        self.Layout()


### PR DESCRIPTION
Just a quick little dev QoL.

Adds a pane that exposes properties on an item, so we don't have to set breakpoints just to see what that one @property from `modules.py` set.

Need to check where we're  pulling this from, I think there's a better spot.

https://puu.sh/uiAOR/a316d5a05f.png