### PR TITLE
Tooltip for capacitor neut resistance

### DIFF
--- a/eos/config.py
+++ b/eos/config.py
@@ -16,4 +16,3 @@ settings = {
 
 # Autodetect path, only change if the autodetection bugs out.
 path = dirname(unicode(__file__, sys.getfilesystemencoding()))
-

--- a/eos/effects/tractorbeamcan.py
+++ b/eos/effects/tractorbeamcan.py
@@ -2,8 +2,9 @@
 #
 # Used by:
 # Modules from group: Tractor Beam (4 of 4)
-type = "active"
 from eos.config import settings
+type = "active"
+
 
 def handler(fit, module, context):
     print settings['setting1']

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -26,17 +26,23 @@ cappingAttrKeyCache = {}
 
 class ItemAttrShortcut(object):
     def getModifiedItemAttr(self, key, default=None):
-        if key in self.itemModifiedAttributes:
-            return self.itemModifiedAttributes[key]
-        else:
+        try:
+            if key in self.itemModifiedAttributes:
+                return self.itemModifiedAttributes[key]
+            else:
+                return default
+        except AttributeError:
             return default
 
 
 class ChargeAttrShortcut(object):
     def getModifiedChargeAttr(self, key, default=None):
-        if key in self.chargeModifiedAttributes:
-            return self.chargeModifiedAttributes[key]
-        else:
+        try:
+            if key in self.chargeModifiedAttributes:
+                return self.chargeModifiedAttributes[key]
+            else:
+                return default
+        except AttributeError:
             return default
 
 

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -283,7 +283,7 @@ class ModifiedAttributeDict(collections.MutableMapping):
         return skill.level
 
     def getAfflictions(self, key):
-        return self.__affectedBy[key] if key in self.__affectedBy else {}
+        return self.__affectedBy.get(key, {})
 
     def iterAfflictions(self):
         return self.__affectedBy.__iter__()

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -131,7 +131,7 @@ class ModifiedAttributeDict(collections.MutableMapping):
 
     def getOriginal(self, key, default=None):
 
-        if self.overrides:
+        if self.overrides_enabled and self.overrides:
             val = self.overrides.get(key, None)
         else:
             val = None

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -19,6 +19,7 @@
 
 import collections
 from math import exp
+from eos.db.gamedata.queries import getAttributeInfo
 
 defaultValuesCache = {}
 cappingAttrKeyCache = {}
@@ -172,7 +173,6 @@ class ModifiedAttributeDict(collections.MutableMapping):
         try:
             cappingKey = cappingAttrKeyCache[key]
         except KeyError:
-            from eos.db.gamedata.queries import getAttributeInfo
             attrInfo = getAttributeInfo(key)
             if attrInfo is None:
                 cappingId = cappingAttrKeyCache[key] = None
@@ -209,7 +209,6 @@ class ModifiedAttributeDict(collections.MutableMapping):
         try:
             default = defaultValuesCache[key]
         except KeyError:
-            from eos.db.gamedata.queries import getAttributeInfo
             attrInfo = getAttributeInfo(key)
             if attrInfo is None:
                 default = defaultValuesCache[key] = 0.0

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -19,6 +19,8 @@
 
 import collections
 from math import exp
+# TODO: This needs to be moved out, we shouldn't have *ANY* dependencies back to other modules/methods inside eos.
+# This also breaks writing any tests. :(
 from eos.db.gamedata.queries import getAttributeInfo
 
 defaultValuesCache = {}

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -110,20 +110,6 @@ class ModifiedAttributeDict(collections.MutableMapping):
         self.__modified = val
 
     def __getitem__(self, key):
-        '''
-        # Check if we have final calculated value
-        if key in self.modified:
-            if self.modified[key] == self.CalculationPlaceholder:
-                self.modified[key] = self.__calculateValue(key)
-            return self.modified[key]
-        # Then in values which are not yet calculated
-        elif key in self.__intermediary:
-            return self.__intermediary[key]
-        # Original value is the least priority
-        else:
-            return self.getOriginal(key)
-        '''
-
         # Check if we have final calculated value
         key_value = self.modified.get(key)
         if key_value is self.CalculationPlaceholder:

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -128,7 +128,7 @@ class ModifiedAttributeDict(collections.MutableMapping):
         if key in self.__intermediary:
             del self.__intermediary[key]
 
-    def getOriginal(self, key):
+    def getOriginal(self, key, default=None):
 
         if self.overrides:
             val = self.overrides.get(key, None)
@@ -138,6 +138,9 @@ class ModifiedAttributeDict(collections.MutableMapping):
         if val is None:
             if self.original:
                 val = self.original.get(key, None)
+
+        if val is None and val != default:
+            val = default
 
         return val.value if hasattr(val, "value") else val
 
@@ -216,7 +219,7 @@ class ModifiedAttributeDict(collections.MutableMapping):
 
         val = self.__intermediary.get(key,
                                       self.__preAssigns.get(key,
-                                                            self.getOriginal(key) if key in self.original else default
+                                                            self.getOriginal(key, default)
                                                             )
                                       )
 

--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -23,7 +23,6 @@ from eos.db.gamedata.queries import getAttributeInfo
 
 defaultValuesCache = {}
 cappingAttrKeyCache = {}
-calculate_value_time = 0
 
 
 class ItemAttrShortcut(object):
@@ -130,7 +129,6 @@ class ModifiedAttributeDict(collections.MutableMapping):
             del self.__intermediary[key]
 
     def getOriginal(self, key, default=None):
-
         if self.overrides_enabled and self.overrides:
             val = self.overrides.get(key, None)
         else:

--- a/gui/builtinStatsViews/capacitorViewFull.py
+++ b/gui/builtinStatsViews/capacitorViewFull.py
@@ -114,11 +114,10 @@ class CapacitorViewFull(StatsView):
             ("label%sCapacitorRecharge", lambda: fit.capRecharge, 3, 0, 0),
             ("label%sCapacitorDischarge", lambda: fit.capUsed, 3, 0, 0),
         )
-        if fit is None:
-            # Set default if fit is empty
-            neut_resist = 0
-        else:
+        if fit:
             neut_resist = fit.ship.getModifiedItemAttr("energyWarfareResistance", 0)
+        else:
+            neut_resist = 0
 
         panel = "Full"
         for labelName, value, prec, lowest, highest in stats:

--- a/gui/builtinStatsViews/capacitorViewFull.py
+++ b/gui/builtinStatsViews/capacitorViewFull.py
@@ -114,6 +114,11 @@ class CapacitorViewFull(StatsView):
             ("label%sCapacitorRecharge", lambda: fit.capRecharge, 3, 0, 0),
             ("label%sCapacitorDischarge", lambda: fit.capUsed, 3, 0, 0),
         )
+        if fit is None:
+            # Set default if fit is empty
+            neut_resist = 0
+        else:
+            neut_resist = fit.ship.getModifiedItemAttr("energyWarfareResistance", 0)
 
         panel = "Full"
         for labelName, value, prec, lowest, highest in stats:
@@ -126,6 +131,12 @@ class CapacitorViewFull(StatsView):
             else:
                 label.SetLabel(formatAmount(value, prec, lowest, highest))
                 label.SetToolTip(wx.ToolTip("%.1f" % value))
+
+            if labelName == "label%sCapacitorDischarge":
+                if neut_resist:
+                    neut_resist = 100 - (neut_resist * 100)
+                label_tooltip = "Neut Resistance: {0:.0f}%".format(neut_resist)
+                label.SetToolTip(wx.ToolTip(label_tooltip))
 
         capState = fit.capState if fit is not None else 0
         capStable = fit.capStable if fit is not None else False

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -1043,7 +1043,7 @@ class ItemAffectedBy(wx.Panel):
         container = {}
         for attrName in attributes.iterAfflictions():
             # if value is 0 or there has been no change from original to modified, return
-            if attributes[attrName] == (attributes.getOriginal(attrName) or 0):
+            if attributes[attrName] == (attributes.getOriginal(attrName, 0)):
                 continue
 
             for fit, afflictors in attributes.getAfflictions(attrName).iteritems():
@@ -1170,7 +1170,7 @@ class ItemAffectedBy(wx.Panel):
         container = {}
         for attrName in attributes.iterAfflictions():
             # if value is 0 or there has been no change from original to modified, return
-            if attributes[attrName] == (attributes.getOriginal(attrName) or 0):
+            if attributes[attrName] == (attributes.getOriginal(attrName, 0)):
                 continue
 
             for fit, afflictors in attributes.getAfflictions(attrName).iteritems():

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -651,11 +651,11 @@ class MainFrame(wx.Frame):
         dlg.Show()
 
     def toggleOverrides(self, event):
-        ModifiedAttributeDict.OVERRIDES = not ModifiedAttributeDict.OVERRIDES
+        ModifiedAttributeDict.overrides_enabled = not ModifiedAttributeDict.overrides_enabled
         wx.PostEvent(self, GE.FitChanged(fitID=self.getActiveFit()))
         menu = self.GetMenuBar()
         menu.SetLabel(menu.toggleOverridesId,
-                      "Turn Overrides Off" if ModifiedAttributeDict.OVERRIDES else "Turn Overrides On")
+                      "Turn Overrides Off" if ModifiedAttributeDict.overrides_enabled else "Turn Overrides On")
 
     def saveChar(self, event):
         sChr = Character.getInstance()

--- a/service/fit.py
+++ b/service/fit.py
@@ -19,6 +19,7 @@
 
 import copy
 from logbook import Logger
+from time import time
 
 import eos.db
 from eos.saveddata.booster import Booster as es_Booster
@@ -1028,9 +1029,12 @@ class Fit(object):
         self.recalc(fit)
 
     def recalc(self, fit, withBoosters=True):
+        start_time = time()
         pyfalog.info("=" * 10 + "recalc" + "=" * 10)
         if fit.factorReload is not self.serviceFittingOptions["useGlobalForceReload"]:
             fit.factorReload = self.serviceFittingOptions["useGlobalForceReload"]
         fit.clear()
 
         fit.calculateModifiedAttributes(withBoosters=False)
+
+        pyfalog.info("=" * 10 + "recalc time: " + str(time() - start_time) + "=" * 10)

--- a/service/port.py
+++ b/service/port.py
@@ -816,7 +816,7 @@ class Port(object):
                 if callback:
                     wx.CallAfter(callback, None)
             # Skip fit silently if we get an exception
-            except Exception as  e:
+            except Exception as e:
                 pyfalog.error("Caught exception on fit.")
                 pyfalog.error(e)
                 pass

--- a/service/settings.py
+++ b/service/settings.py
@@ -437,6 +437,7 @@ class ContextMenuSettings(object):
     def set(self, type, value):
         self.ContextMenuDefaultSettings[type] = value
 
+
 class EOSSettings(object):
         _instance = None
 


### PR DESCRIPTION
Just a small add to have a tooltip for capacitor neut resistance.  A very useful stat, but one not exposed at all effectively.

https://puu.sh/uykft/0076290861.gif

Also prevents exceptions from modifiedAttributeDict when getting an attribute that doesn't exist (returns default).  (Ran into this when passing in an object that doesn't exist because we're on a blank tab.)

Bit of Tox cleanup.