### PR TITLE
Rework price fetching for items

### DIFF
--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -98,6 +98,11 @@ def getItem(lookfor, eager=None):
     return item
 
 
+def getAllItems():
+    items = gamedata_session.query(Item).all()
+    return items
+
+
 @cachedQuery(1, "lookfor")
 def getAlphaClone(lookfor, eager=None):
     if isinstance(lookfor, int):

--- a/gui/boosterView.py
+++ b/gui/boosterView.py
@@ -43,9 +43,12 @@ class BoosterViewDrop(wx.PyDropTarget):
 
 
 class BoosterView(d.Display):
-    DEFAULT_COLS = ["State",
-                    "attr:boosterness",
-                    "Base Name"]
+    DEFAULT_COLS = [
+        "State",
+        "attr:boosterness",
+        "Base Name",
+        "Price",
+    ]
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, style=wx.LC_SINGLE_SEL | wx.BORDER_NONE)

--- a/gui/builtinContextMenus/priceClear.py
+++ b/gui/builtinContextMenus/priceClear.py
@@ -3,7 +3,7 @@ import gui.mainFrame
 # noinspection PyPackageRequirements
 import wx
 import gui.globalEvents as GE
-from service.market import Market
+from service.price import Price
 from service.settings import ContextMenuSettings
 
 
@@ -22,8 +22,8 @@ class PriceClear(ContextMenu):
         return "Reset Price Cache"
 
     def activate(self, fullContext, selection, i):
-        sMkt = Market.getInstance()
-        sMkt.clearPriceCache()
+        sPrice = Price.getInstance()
+        sPrice.clearPriceCache()
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.mainFrame.getActiveFit()))
 
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -9,7 +9,6 @@ import gui.globalEvents as GE
 from service.settings import SettingsProvider
 from service.fit import Fit
 from service.price import Price
-from service.market import Market
 
 
 class PFGeneralPref(PreferenceView):
@@ -188,8 +187,8 @@ class PFGeneralPref(PreferenceView):
 
         fitID = self.mainFrame.getActiveFit()
 
-        sMkt = Market.getInstance()
-        sMkt.clearPriceCache()
+        sPrice = Price.getInstance()
+        sPrice.clearPriceCache()
 
         self.sFit.refreshFit(fitID)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))

--- a/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
@@ -91,8 +91,6 @@ class PFStatViewPref(PreferenceView):
         rbSizerRow3 = wx.BoxSizer(wx.HORIZONTAL)
 
         self.rbPrice = wx.RadioBox(panel, -1, "Price", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
-        # Disable minimal as we don't have a view for this yet
-        self.rbPrice.EnableItem(1, False)
         self.rbPrice.SetSelection(self.settings.get('price'))
         rbSizerRow3.Add(self.rbPrice, 1, wx.TOP | wx.RIGHT, 5)
         self.rbPrice.Bind(wx.EVT_RADIOBOX, self.OnPriceChange)

--- a/gui/builtinStatsViews/__init__.py
+++ b/gui/builtinStatsViews/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     "outgoingViewFull",
     "targetingMiscViewMinimal",
     "priceViewFull",
+    "priceViewMinimal",
 ]

--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -52,13 +52,13 @@ class PriceViewFull(StatsView):
 
         gridPrice = wx.GridSizer(2, 3)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for type in ("ship", "fittings", "drones", "cargoBay", "character", "total"):
-            if type in ("ship"):
+        for _type in ("ship", "fittings", "drones", "cargoBay", "character", "total"):
+            if _type in "ship":
                 image = "ship_big"
-            elif type in ("fittings", "total"):
-                image = "%sPrice_big" % type
+            elif _type in ("fittings", "total"):
+                image = "%sPrice_big" % _type
             else:
-                image = "%s_big" % type
+                image = "%s_big" % _type
 
             box = wx.BoxSizer(wx.HORIZONTAL)
             gridPrice.Add(box, 0, wx.ALIGN_TOP)
@@ -68,50 +68,51 @@ class PriceViewFull(StatsView):
             vbox = wx.BoxSizer(wx.VERTICAL)
             box.Add(vbox, 1, wx.EXPAND)
 
-            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, type.capitalize()), 0, wx.ALIGN_LEFT)
+            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, _type.capitalize()), 0, wx.ALIGN_LEFT)
 
             hbox = wx.BoxSizer(wx.HORIZONTAL)
             vbox.Add(hbox)
 
             lbl = wx.StaticText(contentPanel, wx.ID_ANY, "0.00 ISK")
-            setattr(self, "labelPrice%s" % type.capitalize(), lbl)
+            setattr(self, "labelPrice%s" % _type.capitalize(), lbl)
             hbox.Add(lbl, 0, wx.ALIGN_LEFT)
 
     def refreshPanel(self, fit):
         if fit is not None:
             self.labelEMStatus.SetLabel("Updating prices...")
-            ship_price = Price.fetchItemPrice(fit.ship.item)
+            sPrice = Price.getInstance()
+            ship_price = sPrice.fetchItemPrice(fit.ship.item)
 
             module_price = 0
             if fit.modules:
                 for module in fit.modules:
                     if not module.isEmpty:
-                        module_price += Price.fetchItemPrice(module.item)
+                        module_price += sPrice.fetchItemPrice(module.item)
 
             drone_price = 0
             if fit.drones:
                 for drone in fit.drones:
-                    drone_price += Price.fetchItemPrice(drone.item) * drone.amount
+                    drone_price += sPrice.fetchItemPrice(drone.item) * drone.amount
 
             fighter_price = 0
             if fit.fighters:
                 for fighter in fit.fighters:
-                    fighter_price += Price.fetchItemPrice(fighter.item) * fighter.amount
+                    fighter_price += sPrice.fetchItemPrice(fighter.item) * fighter.amount
 
             cargo_price = 0
             if fit.cargo:
                 for cargo in fit.cargo:
-                    cargo_price += Price.fetchItemPrice(cargo.item) * cargo.amount
+                    cargo_price += sPrice.fetchItemPrice(cargo.item) * cargo.amount
 
             booster_price = 0
             if fit.boosters:
                 for booster in fit.boosters:
-                    booster_price += Price.fetchItemPrice(booster.item)
+                    booster_price += sPrice.fetchItemPrice(booster.item)
 
             implant_price = 0
             if fit.implants:
                 for implant in fit.implants:
-                    implant_price += Price.fetchItemPrice(implant.item)
+                    implant_price += sPrice.fetchItemPrice(implant.item)
 
             fitting_price = module_price + drone_price + fighter_price + cargo_price + booster_price + implant_price
             total_price = ship_price + fitting_price

--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -91,27 +91,27 @@ class PriceViewFull(StatsView):
             drone_price = 0
             if fit.drones:
                 for drone in fit.drones:
-                    drone_price = Price.fetchItemPrice(drone.item) * drone.amount
+                    drone_price += Price.fetchItemPrice(drone.item) * drone.amount
 
             fighter_price = 0
             if fit.fighters:
                 for fighter in fit.fighters:
-                    fighter_price = Price.fetchItemPrice(fighter.item) * fighter.amount
+                    fighter_price += Price.fetchItemPrice(fighter.item) * fighter.amount
 
             cargo_price = 0
             if fit.cargo:
                 for cargo in fit.cargo:
-                    cargo_price = Price.fetchItemPrice(cargo.item) * cargo.amount
+                    cargo_price += Price.fetchItemPrice(cargo.item) * cargo.amount
 
             booster_price = 0
             if fit.boosters:
                 for booster in fit.boosters:
-                    booster_price = Price.fetchItemPrice(booster.item)
+                    booster_price += Price.fetchItemPrice(booster.item)
 
             implant_price = 0
             if fit.implants:
                 for implant in fit.implants:
-                    implant_price = Price.fetchItemPrice(implant.item)
+                    implant_price += Price.fetchItemPrice(implant.item)
 
             fitting_price = module_price + drone_price + fighter_price + cargo_price + booster_price + implant_price
             total_price = ship_price + fitting_price

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -52,8 +52,8 @@ class PriceViewMinimal(StatsView):
 
         gridPrice = wx.GridSizer(1, 3)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for type in ("ship", "fittings", "total"):
-            image = "%sPrice_big" % type if type != "ship" else "ship_big"
+        for _type in ("ship", "fittings", "total"):
+            image = "%sPrice_big" % _type if _type != "ship" else "ship_big"
             box = wx.BoxSizer(wx.HORIZONTAL)
             gridPrice.Add(box, 0, wx.ALIGN_TOP)
 
@@ -62,50 +62,51 @@ class PriceViewMinimal(StatsView):
             vbox = wx.BoxSizer(wx.VERTICAL)
             box.Add(vbox, 1, wx.EXPAND)
 
-            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, type.capitalize()), 0, wx.ALIGN_LEFT)
+            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, _type.capitalize()), 0, wx.ALIGN_LEFT)
 
             hbox = wx.BoxSizer(wx.HORIZONTAL)
             vbox.Add(hbox)
 
             lbl = wx.StaticText(contentPanel, wx.ID_ANY, "0.00 ISK")
-            setattr(self, "labelPrice%s" % type.capitalize(), lbl)
+            setattr(self, "labelPrice%s" % _type.capitalize(), lbl)
             hbox.Add(lbl, 0, wx.ALIGN_LEFT)
 
     def refreshPanel(self, fit):
         if fit is not None:
             self.labelEMStatus.SetLabel("Updating prices...")
-            ship_price = Price.fetchItemPrice(fit.ship.item)
+            sPrice = Price.getInstance()
+            ship_price = sPrice.fetchItemPrice(fit.ship.item)
 
             module_price = 0
             if fit.modules:
                 for module in fit.modules:
                     if not module.isEmpty:
-                        module_price += Price.fetchItemPrice(module.item)
+                        module_price += sPrice.fetchItemPrice(module.item)
 
             drone_price = 0
             if fit.drones:
                 for drone in fit.drones:
-                    drone_price = Price.fetchItemPrice(drone.item) * drone.amount
+                    drone_price = sPrice.fetchItemPrice(drone.item) * drone.amount
 
             fighter_price = 0
             if fit.fighters:
                 for fighter in fit.fighters:
-                    fighter_price = Price.fetchItemPrice(fighter.item) * fighter.amount
+                    fighter_price = sPrice.fetchItemPrice(fighter.item) * fighter.amount
 
             cargo_price = 0
             if fit.cargo:
                 for cargo in fit.cargo:
-                    cargo_price = Price.fetchItemPrice(cargo.item) * cargo.amount
+                    cargo_price = sPrice.fetchItemPrice(cargo.item) * cargo.amount
 
             booster_price = 0
             if fit.boosters:
                 for booster in fit.boosters:
-                    booster_price = Price.fetchItemPrice(booster.item)
+                    booster_price = sPrice.fetchItemPrice(booster.item)
 
             implant_price = 0
             if fit.implants:
                 for implant in fit.implants:
-                    implant_price = Price.fetchItemPrice(implant.item)
+                    implant_price = sPrice.fetchItemPrice(implant.item)
 
             fitting_price = module_price + drone_price + fighter_price + cargo_price + booster_price + implant_price
             total_price = ship_price + fitting_price

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -25,8 +25,8 @@ from gui.utils.numberFormatter import formatAmount
 from service.price import Price
 
 
-class PriceViewFull(StatsView):
-    name = "priceViewFull"
+class PriceViewMinimal(StatsView):
+    name = "priceViewMinimal"
 
     def __init__(self, parent):
         StatsView.__init__(self)
@@ -50,16 +50,10 @@ class PriceViewFull(StatsView):
         headerContentSizer.Add(self.labelEMStatus)
         headerPanel.GetParent().AddToggleItem(self.labelEMStatus)
 
-        gridPrice = wx.GridSizer(2, 3)
+        gridPrice = wx.GridSizer(1, 3)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for type in ("ship", "fittings", "drones", "cargoBay", "character", "total"):
-            if type in ("ship"):
-                image = "ship_big"
-            elif type in ("fittings", "total"):
-                image = "%sPrice_big" % type
-            else:
-                image = "%s_big" % type
-
+        for type in ("ship", "fittings", "total"):
+            image = "%sPrice_big" % type if type != "ship" else "ship_big"
             box = wx.BoxSizer(wx.HORIZONTAL)
             gridPrice.Add(box, 0, wx.ALIGN_TOP)
 
@@ -119,17 +113,8 @@ class PriceViewFull(StatsView):
             self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))
             self.labelPriceShip.SetToolTip(wx.ToolTip('{:,.2f}'.format(ship_price)))
 
-            self.labelPriceFittings.SetLabel("%s ISK" % formatAmount(module_price, 3, 3, 9, currency=True))
-            self.labelPriceFittings.SetToolTip(wx.ToolTip('{:,.2f}'.format(module_price)))
-
-            self.labelPriceDrones.SetLabel("%s ISK" % formatAmount(drone_price + fighter_price, 3, 3, 9, currency=True))
-            self.labelPriceDrones.SetToolTip(wx.ToolTip('{:,.2f}'.format(drone_price + fighter_price)))
-
-            self.labelPriceCargobay.SetLabel("%s ISK" % formatAmount(cargo_price, 3, 3, 9, currency=True))
-            self.labelPriceCargobay.SetToolTip(wx.ToolTip('{:,.2f}'.format(cargo_price)))
-
-            self.labelPriceCharacter.SetLabel("%s ISK" % formatAmount(booster_price + implant_price, 3, 3, 9, currency=True))
-            self.labelPriceCharacter.SetToolTip(wx.ToolTip('{:,.2f}'.format(booster_price + implant_price)))
+            self.labelPriceFittings.SetLabel("%s ISK" % formatAmount(fitting_price, 3, 3, 9, currency=True))
+            self.labelPriceFittings.SetToolTip(wx.ToolTip('{:,.2f}'.format(fitting_price)))
 
             self.labelPriceTotal.SetLabel("%s ISK" % formatAmount(total_price, 3, 3, 9, currency=True))
             self.labelPriceTotal.SetToolTip(wx.ToolTip('{:,.2f}'.format(total_price)))
@@ -145,4 +130,4 @@ class PriceViewFull(StatsView):
             self.panel.Layout()
 
 
-PriceViewFull.register()
+PriceViewMinimal.register()

--- a/gui/builtinViewColumns/price.py
+++ b/gui/builtinViewColumns/price.py
@@ -22,7 +22,7 @@ import wx
 
 from eos.saveddata.cargo import Cargo
 from eos.saveddata.drone import Drone
-from service.price import Price as sPrice
+from service.price import Price as ServicePrice
 from gui.viewColumn import ViewColumn
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -45,6 +45,7 @@ class Price(ViewColumn):
             if stuff.isEmpty:
                 return ""
 
+        sPrice = ServicePrice.getInstance()
         price = sPrice.fetchItemPrice(stuff.item)
 
         if not price:

--- a/gui/builtinViewColumns/price.py
+++ b/gui/builtinViewColumns/price.py
@@ -22,7 +22,7 @@ import wx
 
 from eos.saveddata.cargo import Cargo
 from eos.saveddata.drone import Drone
-from service.market import Market
+from service.price import Price as sPrice
 from gui.viewColumn import ViewColumn
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -41,32 +41,19 @@ class Price(ViewColumn):
         if stuff.item is None or stuff.item.group.name == "Ship Modifiers":
             return ""
 
-        sMkt = Market.getInstance()
-        price = sMkt.getPriceNow(stuff.item.ID)
+        if hasattr(stuff, "isEmpty"):
+            if stuff.isEmpty:
+                return ""
 
-        if not price or not price.price or not price.isValid:
-            return False
+        price = sPrice.fetchItemPrice(stuff.item)
 
-        price = price.price  # Set new price variable with what we need
+        if not price:
+            return ""
 
         if isinstance(stuff, Drone) or isinstance(stuff, Cargo):
             price *= stuff.amount
 
         return formatAmount(price, 3, 3, 9, currency=True)
-
-    def delayedText(self, mod, display, colItem):
-        sMkt = Market.getInstance()
-
-        def callback(item):
-            price = sMkt.getPriceNow(item.ID)
-            text = formatAmount(price.price, 3, 3, 9, currency=True) if price.price else ""
-            if price.failed:
-                text += " (!)"
-            colItem.SetText(text)
-
-            display.SetItem(colItem)
-
-        sMkt.waitForPrice(mod.item, callback)
 
     def getImageId(self, mod):
         return -1

--- a/gui/display.py
+++ b/gui/display.py
@@ -245,9 +245,6 @@ class Display(wx.ListCtrl):
                 oldText = colItem.GetText()
                 oldImageId = colItem.GetImage()
                 newText = col.getText(st)
-                if newText is False:
-                    col.delayedText(st, self, colItem)
-                    newText = u"\u21bb"
 
                 newImageId = col.getImageId(st)
 

--- a/gui/implantView.py
+++ b/gui/implantView.py
@@ -79,10 +79,13 @@ class ImplantView(wx.Panel):
 
 
 class ImplantDisplay(d.Display):
-    DEFAULT_COLS = ["State",
-                    "attr:implantness",
-                    "Base Icon",
-                    "Base Name"]
+    DEFAULT_COLS = [
+        "State",
+        "attr:implantness",
+        "Base Icon",
+        "Base Name",
+        "Price",
+    ]
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, style=wx.LC_SINGLE_SEL | wx.BORDER_NONE)

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -43,6 +43,7 @@ from eos.saveddata.citadel import Citadel
 from eos.saveddata.fit import Fit
 from service.market import Market
 from service.attribute import Attribute
+from service.price import Price as sPrice
 import gui.mainFrame
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -621,10 +622,6 @@ class ItemCompare(wx.Panel):
         self.UpdateList()
         event.Skip()
 
-    def processPrices(self, prices):
-        for i, price in enumerate(prices):
-            self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(price.price, 3, 3, 9, currency=True))
-
     def PopulateList(self, sort=None):
 
         if sort is not None and self.currentSort == sort:
@@ -660,9 +657,6 @@ class ItemCompare(wx.Panel):
         self.paramList.InsertColumn(len(self.attrs) + 1, "Price")
         self.paramList.SetColumnWidth(len(self.attrs) + 1, 60)
 
-        sMkt = Market.getInstance()
-        sMkt.getPrices([x.ID for x in self.items], self.processPrices)
-
         for item in self.items:
             i = self.paramList.InsertStringItem(sys.maxint, item.name)
             for x, attr in enumerate(self.attrs.keys()):
@@ -677,6 +671,9 @@ class ItemCompare(wx.Panel):
                         valueUnit = formatAmount(value, 3, 0, 0)
 
                     self.paramList.SetStringItem(i, x + 1, valueUnit)
+
+                # Add prices
+                self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(sPrice.fetchItemPrice(item), 3, 3, 9, currency=True))
 
         self.paramList.RefreshRows()
         self.Layout()

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -43,7 +43,7 @@ from eos.saveddata.citadel import Citadel
 from eos.saveddata.fit import Fit
 from service.market import Market
 from service.attribute import Attribute
-from service.price import Price as sPrice
+from service.price import Price as ServicePrice
 import gui.mainFrame
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -673,6 +673,7 @@ class ItemCompare(wx.Panel):
                     self.paramList.SetStringItem(i, x + 1, valueUnit)
 
                 # Add prices
+                sPrice = ServicePrice.getInstance()
                 self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(sPrice.fetchItemPrice(item), 3, 3, 9, currency=True))
 
         self.paramList.RefreshRows()

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -346,9 +346,20 @@ class MainFrame(wx.Frame):
 
         # save all teh settingz
         SettingsProvider.getInstance().saveAll()
+
+        from service.price import PriceWorkerThread
+
+        PriceWorkerThread.pause()
+        PriceWorkerThread.join()
+
         event.Skip()
 
     def ExitApp(self, event):
+        from service.price import PriceWorkerThread
+
+        PriceWorkerThread.pause()
+        PriceWorkerThread.join()
+
         self.Close()
         event.Skip()
 

--- a/gui/statsView.py
+++ b/gui/statsView.py
@@ -52,5 +52,6 @@ from gui.builtinStatsViews import (  # noqa: E402, F401
     rechargeViewFull,
     targetingMiscViewMinimal,
     priceViewFull,
+    priceViewMinimal,
     outgoingViewFull,
 )

--- a/gui/viewColumn.py
+++ b/gui/viewColumn.py
@@ -46,9 +46,6 @@ class ViewColumn(object):
     def getColumn(cls, name):
         return ViewColumn.columns[name]
 
-    def getRestrictions(self):
-        raise NotImplementedError()
-
     def getText(self, mod):
         return ""
 
@@ -61,9 +58,6 @@ class ViewColumn(object):
     @staticmethod
     def getParameters():
         return tuple()
-
-    def delayedText(self, display, colItem):
-        raise NotImplementedError()
 
 
 # noinspection PyUnresolvedReferences

--- a/pyfa.py
+++ b/pyfa.py
@@ -258,7 +258,7 @@ if __name__ == "__main__":
         pyfa = wx.App(False)
         ErrorFrame(e, tb)
         pyfa.MainLoop()
-        sys.exit()
+        raise
 
     with logging_setup.threadbound():
         # Don't redirect if frozen

--- a/service/market.py
+++ b/service/market.py
@@ -868,10 +868,6 @@ class Market(object):
 
         return price
 
-    def getPricesNow(self, typeIDs):
-        """Return map of calls to get price against list of typeIDs"""
-        return map(self.getPrice, typeIDs)
-
     def getPrices(self, typeIDs, callback):
         """Get prices for multiple typeIDs"""
         requests = []

--- a/service/market.py
+++ b/service/market.py
@@ -30,11 +30,9 @@ import config
 import eos.db
 from service import conversions
 from service.settings import SettingsProvider
-from service.price import Price
 
 from eos.gamedata import Category as types_Category, Group as types_Group, Item as types_Item, MarketGroup as types_MarketGroup, \
     MetaGroup as types_MetaGroup, MetaType as types_MetaType
-from eos.saveddata.price import Price as types_Price
 
 try:
     from collections import OrderedDict
@@ -83,48 +81,6 @@ class ShipBrowserWorkerThread(threading.Thread):
                 except Exception as e:
                     pyfalog.critical("Queue task done failed.")
                     pyfalog.critical(e)
-
-
-class PriceWorkerThread(threading.Thread):
-    def __init__(self):
-        threading.Thread.__init__(self)
-        self.name = "PriceWorker"
-        pyfalog.debug("Initialize PriceWorkerThread.")
-
-    def run(self):
-        pyfalog.debug("Run start")
-        self.queue = Queue.Queue()
-        self.wait = {}
-        self.processUpdates()
-        pyfalog.debug("Run end")
-
-    def processUpdates(self):
-        queue = self.queue
-        while True:
-            # Grab our data
-            callback, requests = queue.get()
-
-            # Grab prices, this is the time-consuming part
-            if len(requests) > 0:
-                Price.fetchPrices(requests)
-
-            wx.CallAfter(callback)
-            queue.task_done()
-
-            # After we fetch prices, go through the list of waiting items and call their callbacks
-            for price in requests:
-                callbacks = self.wait.pop(price.typeID, None)
-                if callbacks:
-                    for callback in callbacks:
-                        wx.CallAfter(callback)
-
-    def trigger(self, prices, callbacks):
-        self.queue.put((callbacks, prices))
-
-    def setToWait(self, itemID, callback):
-        if itemID not in self.wait:
-            self.wait[itemID] = []
-        self.wait[itemID].append(callback)
 
 
 class SearchWorkerThread(threading.Thread):
@@ -180,18 +136,11 @@ class Market(object):
     instance = None
 
     def __init__(self):
-        self.priceCache = {}
-
         # Init recently used module storage
         serviceMarketRecentlyUsedModules = {"pyfaMarketRecentlyUsedModules": []}
 
         self.serviceMarketRecentlyUsedModules = SettingsProvider.getInstance().getSettings(
                 "pyfaMarketRecentlyUsedModules", serviceMarketRecentlyUsedModules)
-
-        # Start price fetcher
-        self.priceWorkerThread = PriceWorkerThread()
-        self.priceWorkerThread.daemon = True
-        self.priceWorkerThread.start()
 
         # Thread which handles search
         self.searchWorkerThread = SearchWorkerThread()
@@ -854,56 +803,6 @@ class Market(object):
         """Filter items by meta lvl"""
         filtered = set(filter(lambda item: self.getMetaGroupIdByItem(item) in metas, items))
         return filtered
-
-    def getPriceNow(self, typeID):
-        """Get price for provided typeID"""
-        price = self.priceCache.get(typeID)
-        if price is None:
-            price = eos.db.getPrice(typeID)
-            if price is None:
-                price = types_Price(typeID)
-                eos.db.add(price)
-
-            self.priceCache[typeID] = price
-
-        return price
-
-    def getPrices(self, typeIDs, callback):
-        """Get prices for multiple typeIDs"""
-        requests = []
-        for typeID in typeIDs:
-            price = self.getPriceNow(typeID)
-            requests.append(price)
-
-        def cb():
-            try:
-                callback(requests)
-            except Exception as e:
-                pyfalog.critical("Callback failed.")
-                pyfalog.critical(e)
-            eos.db.commit()
-
-        self.priceWorkerThread.trigger(requests, cb)
-
-    def waitForPrice(self, item, callback):
-        """
-        Wait for prices to be fetched and callback when finished. This is used with the column prices for modules.
-        Instead of calling them individually, we set them to wait until the entire fit price is called and calculated
-        (see GH #290)
-        """
-
-        def cb():
-            try:
-                callback(item)
-            except Exception as e:
-                pyfalog.critical("Callback failed.")
-                pyfalog.critical(e)
-
-        self.priceWorkerThread.setToWait(item.ID, cb)
-
-    def clearPriceCache(self):
-        self.priceCache.clear()
-        eos.db.clearPrices()
 
     def getSystemWideEffects(self):
         """

--- a/service/price.py
+++ b/service/price.py
@@ -279,4 +279,5 @@ class PriceWorkerThread(threading.Thread):
             pyfalog.debug("Price run end")
 
             # Sleep for 60 seconds
+            # TODO: Add this as an option
             time.sleep(60)

--- a/service/price.py
+++ b/service/price.py
@@ -20,6 +20,7 @@
 
 import time
 from xml.dom import minidom
+import threading
 
 from eos import db
 from service.network import Network, TimeoutError
@@ -36,6 +37,8 @@ TIMEOUT = 15 * 60  # Network timeout delay for connection issues, 15 minutes
 
 
 class Price(object):
+    instance = None
+
     systemsList = {
         "Jita": 30000142,
         "Amarr": 30002187,
@@ -44,101 +47,41 @@ class Price(object):
         "Hek": 30002053
     }
 
-    @classmethod
-    def invalidPrices(cls, prices):
-        for price in prices:
-            price.time = 0
+    def __init__(self):
+        # Start price fetcher
+        self.priceWorkerThread = PriceWorkerThread()
+        self.priceWorkerThread.daemon = True
+        self.priceWorkerThread.start()
 
     @classmethod
-    def fetchPrices(cls, prices):
-        """Fetch all prices passed to this method"""
+    def getInstance(cls):
+        if cls.instance is None:
+            cls.instance = Price()
+        return cls.instance
 
-        # Dictionary for our price objects
-        priceMap = {}
-        # Check all provided price objects, and add invalid ones to dictionary
-        for price in prices:
-            if not price.isValid:
-                priceMap[price.typeID] = price
-
-        if len(priceMap) == 0:
-            return
-
-        # Set of items which are still to be requested from this service
-        toRequest = set()
-
-        # Compose list of items we're going to request
-        for typeID in priceMap:
-            # Get item object
-            item = db.getItem(typeID)
-            # We're not going to request items only with market group, as eve-central
-            # doesn't provide any data for items not on the market
-            if item is not None and item.marketGroupID:
-                toRequest.add(typeID)
-
-        # Do not waste our time if all items are not on the market
-        if len(toRequest) == 0:
-            return
-
-        # This will store POST data for eve-central
-        data = []
-
-        sFit = Fit.getInstance()
-        # Base request URL
-        baseurl = "https://eve-central.com/api/marketstat"
-        data.append(("usesystem", cls.systemsList[sFit.serviceFittingOptions["priceSystem"]]))  # Use Jita for market
-
-        for typeID in toRequest:  # Add all typeID arguments
-            data.append(("typeid", typeID))
-
-        # Attempt to send request and process it
-        try:
-            network = Network.getInstance()
-            data = network.request(baseurl, network.PRICES, data)
-            xml = minidom.parse(data)
-            types = xml.getElementsByTagName("marketstat").item(0).getElementsByTagName("type")
-            # Cycle through all types we've got from request
-            for type_ in types:
-                # Get data out of each typeID details tree
-                typeID = int(type_.getAttribute("id"))
-                sell = type_.getElementsByTagName("sell").item(0)
-                # If price data wasn't there, set price to zero
-                try:
-                    percprice = float(sell.getElementsByTagName("percentile").item(0).firstChild.data)
-                except (TypeError, ValueError):
-                    pyfalog.warning("Failed to get price for: {0}", type_)
-                    percprice = 0
-
-                # Fill price data
-                priceobj = priceMap[typeID]
-                priceobj.price = percprice
-                priceobj.time = time.time() + VALIDITY
-                priceobj.failed = None
-
-                # delete price from working dict
-                del priceMap[typeID]
-
-        # If getting or processing data returned any errors
-        except TimeoutError:
-            # Timeout error deserves special treatment
-            pyfalog.warning("Price fetch timout")
-            for typeID in priceMap.keys():
-                priceobj = priceMap[typeID]
-                priceobj.time = time.time() + TIMEOUT
-                priceobj.failed = True
-                del priceMap[typeID]
-        except:
-            # all other errors will pass and continue onward to the REREQUEST delay
-            pyfalog.warning("Caught exception in fetchPrices")
-            pass
-
-        # if we get to this point, then we've got an error. Set to REREQUEST delay
-        for typeID in priceMap.keys():
-            priceobj = priceMap[typeID]
-            priceobj.time = time.time() + REREQUEST
-            priceobj.failed = True
+    @staticmethod
+    def clearPriceCache():
+        db.clearPrices()
 
     @classmethod
     def fetchItemPrice(cls, item):
+        """Fetch price for a specific item"""
+
+        if not item:
+            return 0
+        # Check if price is valid (within the time frame) or failed.
+        elif item.price.isValid and item.price.failed is not True:
+            return item.price.price
+
+        try:
+            return_items = Price.getMarketData([item])
+            return return_items[0].price.price
+        except:
+            pyfalog.warning("Failed to get price for item: {0}", item.ID)
+            return 0
+
+    @classmethod
+    def fetchItemPriceOLD(cls, item):
         """Fetch all prices passed to this method"""
 
         # Check if price is valid (within the time frame) or failed.
@@ -216,3 +159,124 @@ class Price(object):
         priceobj.time = time.time() + REREQUEST
         priceobj.failed = True
         return 0
+
+    @classmethod
+    def getMarketData(cls, items=None):
+        if items is None:
+            # No items passed in, so nothing to return
+            # This is here to catch if we run out of items to update from our update price thread
+            return []
+
+        network = Network.getInstance()
+        settings = NetworkSettings.getInstance()
+
+        if not settings.isEnabled(network.PRICES):
+            # Network settings for fetching prices is disabled.
+                return None
+
+        # This will store POST data for eve-central
+        data = []
+
+        sFit = Fit.getInstance()
+        # Base request URL
+        baseurl = "https://eve-central.com/api/marketstat"
+        data.append(("usesystem", cls.systemsList[sFit.serviceFittingOptions["priceSystem"]]))
+
+        for item in items:  # Add all typeID arguments
+            data.append(("typeid", item.ID))
+
+        return_items = []
+
+        # Attempt to send request and process it
+        try:
+            data = network.request(baseurl, network.PRICES, data)
+            xml = minidom.parse(data)
+            types = xml.getElementsByTagName("marketstat").item(0).getElementsByTagName("type")
+
+            # Cycle through all types we've got from request
+            for type_ in types:
+                try:
+                    # Get data out of each typeID details tree
+                    sell = type_.getElementsByTagName("sell").item(0)
+                    typeID = int(type_.getAttribute("id"))
+
+                    # If price data wasn't there, set price to zero
+                    try:
+                        percprice = float(sell.getElementsByTagName("percentile").item(0).firstChild.data)
+                    except (TypeError, ValueError):
+                        pyfalog.warning("Failed to get price for: {0}", type_)
+                        percprice = 0
+
+                    # Fill price data
+                    priceobj = db.getItem(typeID)
+                    priceobj.price.price = percprice
+                    priceobj.price.time = time.time() + VALIDITY
+                    priceobj.price.failed = False
+
+                    # Append this item so we can return it and see what items were updated.
+                    return_items.append(priceobj)
+                except Exception as e:
+                    try:
+                        # if we get to this point, then we've got an error. Set to REREQUEST delay
+                        # Try and handle this neatly.
+                        typeID = int(type_.getAttribute("id"))
+                        priceobj = db.getItem(typeID)
+                        priceobj.time = time.time() + REREQUEST
+                        priceobj.failed = True
+                        pyfalog.warning("Failed to update price for item: {0}", typeID)
+                    except:
+                        # We critically failed, most likely a bad return or couldn't even get the item ID.
+                        pyfalog.error("Critical failure on updating price.")
+                        pyfalog.debug(type_)
+                        pyfalog.debug(e)
+
+        # If getting or processing data returned any errors
+        except TimeoutError:
+            # Timeout error deserves special treatment
+            pyfalog.warning("Price fetch timout")
+        except Exception as e:
+            # all other errors will pass and continue onward to the REREQUEST delay
+            pyfalog.warning("Caught exception in fetchPrices")
+            pyfalog.warning(e)
+
+        return return_items
+
+
+class PriceWorkerThread(threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.name = "PriceWorker"
+        pyfalog.debug("Initialize PriceWorkerThread.")
+
+    def run(self):
+        # Get all items
+        all_items = db.getAllItems()
+
+        # Filter out items that are:
+        # -Unpublished
+        # -Without a market group
+        # -Without skills
+        # This will filter out some valid items, but they'll be caught later if they're missing a price
+        # TODO: Move the filtering to SQL so it can be done faster.  Not a big deal, but would get the thread moving quicker.
+        all_items = [item for item in all_items if item.marketGroupID and item.published and item.requiredSkills]
+
+        while True:
+            pyfalog.debug("Price run start")
+
+            # Make a copy of our list so we can fiddle with it
+            # Filter out any items where they have a valid price, not marked as failed, and are still within our timeframe.
+            shopping_list = [item for item in all_items if item.price.isValid is not True or item.price.failed is True or not item.price.price]
+
+            # Truncate our list to 100.  This is an arbitrary number, but we don't want to try and grab _everything_ at once.
+            # TODO: Add this as an option
+            max_shopping_list = 333
+            if len(shopping_list) > max_shopping_list:
+                shopping_list = shopping_list[:max_shopping_list]
+
+            return_items = Price.getMarketData(shopping_list)
+            pyfalog.debug("Updated price on {0} items.", return_items.__len__())
+
+            pyfalog.debug("Price run end")
+
+            # Sleep for 60 seconds
+            time.sleep(60)


### PR DESCRIPTION
This significantly simplifies fetching prices for items.  

We add a @property named `price` on all items.  This fetches directly from the DB rather than caching it. Even a very complex fit (think full set of implants, cargo, etc) only takes around .1 seconds to full parse all the pricing.  A more standard/simple fit takes .05 seconds.  That's in full potato mode, so when compiled it should be basically nil time.

The `price` property is the full price object, so it has the timestamp, `isValid`, etc.
(This does make querying it slightly awkward, since it's `item.price.price` to get the value. Meh.)


Add new pricing full view (move existing into a minimal version).  The pricing view (both min and full) should now reflect all the tabs correctly, including amounts.
https://puu.sh/uJ07t/5aabdf3e4a.png

The minimal version looks essentially the same.  For the values, ship is the ship cost, and fitting is the cost of everything else (modules, drones/fighters, cargo, and implants/boosters).

For the full version, we're grouping drones and fighters together (under the "Drone" label"), and implants and boosters together (under the Character label).  I'm not terribly worried about the drone label including fighters, since half the carrier pilots I know call fighters "drones" anyway.  Character is _slightly_ more confusing, but since implants and boosters both apply to the character (rather than the ship) I think it's easy enough to figure out.

One final little thing I slipped in here, raising an error if we exception in `pyfa.py` rather than exiting, so we don't lose the stacktrace in the IDE.  `raise` will exit out so we're good either way.

.

Okay, so now for the "problem".  If we have prices cached, it's essentially the same time to load the fit as we have now.  If we _don't_ then we're blocking the process as we fetch the items, and since we're fetching one at a time it's not as fast at bulk operations (just a handful won't be a significant difference).

In testing, querying for 24 items (when none of them are cached in the DB) took just under 12 seconds.  Now that's in full potato mode so won't be what an end user will see, but still not great.

What I'd like to do is create a simple background service that updates prices in the background.  Simply put, loop through the items in the DB, and update them on a mass scale.  We can easily query for the price of dozens or hundreds of items in one shot, and it'd be trivial to loop through all the items and update them (if they're expired).

I think that this is ultimately a better solution than what we had previously, which was fairly complicated (requiring callbacks).  While ultimately this solution would be slightly slower in one particular use case than the current existing solution (since if a user loaded a fit with null/expired values very quickly, it'd take some time to update), once the application has been open for a while it would actually be quite a bit faster, because theoretically you'd never run into any items without a price.  It'd also help users like myself, where I'm using Pyfa fairly often in an offline mode.  You'd have the values for those items, where as currently you get bupkis.

There is the one drawback with this PR (once I add on the service to fetch prices), but I think that the huge amount of simplification and constantly background updating prices is worth the trade off.