### PR TITLE
Fix settings provider

### DIFF
--- a/service/settings.py
+++ b/service/settings.py
@@ -74,8 +74,6 @@ class SettingsProvider(object):
                             info[item] = defaults[item]
 
             self.settings[area] = s = Settings(p, info)
-        else:
-            s = None
 
         return s
 


### PR DESCRIPTION
There are times when `s` is not None with the `get()` (when the settings have already been accessed). Having an `else: s = None` at the end of that condition will cause errors (for example, ran into this when opening prefs window). Was introduced with the `pytest` merge.