### PR TITLE
Fix an exception caused by too few variables for string formatting

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -421,7 +421,7 @@ class Fit(object):
         self.recalc(fit)
 
     def changeActiveFighters(self, fitID, fighter, amount):
-        pyfalog.debug("Changing active fighters ({0}) for fit ({1}) to amount: {2}", fighter.itemID, amount)
+        pyfalog.debug("Changing active fighters ({0}) for fit ({1}) to amount: {2}", fighter.itemID, fitID, amount)
         fit = eos.db.getFit(fitID)
         fighter.amountActive = amount
 


### PR DESCRIPTION
Quick fix for an issue with a log statement when changing active fighter count