### PR TITLE
Create and Modify fields for most database tables

### DIFF
--- a/eos/db/migrations/upgrade22.py
+++ b/eos/db/migrations/upgrade22.py
@@ -1,0 +1,46 @@
+"""
+Migration 22
+
+- Adds the created and modified fields to most tables
+"""
+import sqlalchemy
+
+
+def upgrade(saveddata_engine):
+
+    # 1 = created only
+    # 2 = created and modified
+    tables = {
+        "boosters": 2,
+        "cargo": 2,
+        "characters": 2,
+        "crest": 1,
+        "damagePatterns": 2,
+        "drones": 2,
+        "fighters": 2,
+        "fits": 2,
+        "projectedFits": 2,
+        "commandFits": 2,
+        "implants": 2,
+        "implantSets": 2,
+        "modules": 2,
+        "overrides": 2,
+        "characterSkills": 2,
+        "targetResists": 2
+    }
+
+    for table in tables.keys():
+
+        # midnight brain, there's probably a much more simple way to do this, but fuck it
+        if tables[table] > 0:
+            try:
+                saveddata_engine.execute("SELECT created FROM {0} LIMIT 1;".format(table))
+            except sqlalchemy.exc.DatabaseError:
+                saveddata_engine.execute("ALTER TABLE {} ADD COLUMN created DATETIME;".format(table))
+
+        if tables[table] > 1:
+            try:
+                saveddata_engine.execute("SELECT modified FROM {0} LIMIT 1;".format(table))
+            except sqlalchemy.exc.DatabaseError:
+                saveddata_engine.execute("ALTER TABLE {} ADD COLUMN modified DATETIME;".format(table))
+

--- a/eos/db/migrations/upgrade22.py
+++ b/eos/db/migrations/upgrade22.py
@@ -43,4 +43,3 @@ def upgrade(saveddata_engine):
                 saveddata_engine.execute("SELECT modified FROM {0} LIMIT 1;".format(table))
             except sqlalchemy.exc.DatabaseError:
                 saveddata_engine.execute("ALTER TABLE {} ADD COLUMN modified DATETIME;".format(table))
-

--- a/eos/db/saveddata/booster.py
+++ b/eos/db/saveddata/booster.py
@@ -17,18 +17,21 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, ForeignKey, Integer, Boolean
+from sqlalchemy import Table, Column, ForeignKey, Integer, Boolean, DateTime
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import mapper, relation
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.booster import Booster
 
 boosters_table = Table("boosters", saveddata_meta,
-                       Column("ID", Integer, primary_key=True),
-                       Column("itemID", Integer),
-                       Column("fitID", Integer, ForeignKey("fits.ID"), nullable=False),
-                       Column("active", Boolean),
+                        Column("ID", Integer, primary_key=True),
+                        Column("itemID", Integer),
+                        Column("fitID", Integer, ForeignKey("fits.ID"), nullable=False),
+                        Column("active", Boolean),
+                        Column("created", DateTime, nullable=True, default=func.now()),
+                        Column("modified", DateTime, nullable=True, onupdate=func.now()),
                        )
 
 # Legacy booster side effect code, should disable but a mapper relies on it.

--- a/eos/db/saveddata/cargo.py
+++ b/eos/db/saveddata/cargo.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey
+from sqlalchemy import Table, Column, Integer, ForeignKey, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.cargo import Cargo
@@ -27,6 +28,9 @@ cargo_table = Table("cargo", saveddata_meta,
                     Column("ID", Integer, primary_key=True),
                     Column("fitID", Integer, ForeignKey("fits.ID"), nullable=False, index=True),
                     Column("itemID", Integer, nullable=False),
-                    Column("amount", Integer, nullable=False))
+                    Column("amount", Integer, nullable=False),
+                    Column("created", DateTime, nullable=True, default=func.now()),
+                    Column("modified", DateTime, nullable=True, onupdate=func.now()),
+                    )
 
 mapper(Cargo, cargo_table)

--- a/eos/db/saveddata/character.py
+++ b/eos/db/saveddata/character.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, String
+from sqlalchemy import Table, Column, Integer, ForeignKey, String, DateTime
 from sqlalchemy.orm import relation, mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.db.saveddata.implant import charImplants_table
@@ -36,7 +37,9 @@ characters_table = Table("characters", saveddata_meta,
                          Column("chars", String, nullable=True),
                          Column("defaultLevel", Integer, nullable=True),
                          Column("alphaCloneID", Integer, nullable=True),
-                         Column("ownerID", ForeignKey("users.ID"), nullable=True))
+                         Column("ownerID", ForeignKey("users.ID"), nullable=True),
+                         Column("created", DateTime, nullable=True, default=func.now()),
+                         Column("modified", DateTime, nullable=True, onupdate=func.now()))
 
 mapper(Character, characters_table,
        properties={

--- a/eos/db/saveddata/crest.py
+++ b/eos/db/saveddata/crest.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, String
+from sqlalchemy import Table, Column, Integer, String, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.crestchar import CrestChar
@@ -26,6 +27,8 @@ from eos.saveddata.crestchar import CrestChar
 crest_table = Table("crest", saveddata_meta,
                     Column("ID", Integer, primary_key=True),
                     Column("name", String, nullable=False, unique=True),
-                    Column("refresh_token", String, nullable=False))
+                    Column("refresh_token", String, nullable=False),
+                    # These records aren't updated. Instead, they are dropped and created, hence we don't have a modified field
+                    Column("created", DateTime, nullable=True, default=func.now()))
 
 mapper(CrestChar, crest_table)

--- a/eos/db/saveddata/damagePattern.py
+++ b/eos/db/saveddata/damagePattern.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, String
+from sqlalchemy import Table, Column, Integer, ForeignKey, String, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.damagePattern import DamagePattern
@@ -30,6 +31,9 @@ damagePatterns_table = Table("damagePatterns", saveddata_meta,
                              Column("thermalAmount", Integer),
                              Column("kineticAmount", Integer),
                              Column("explosiveAmount", Integer),
-                             Column("ownerID", ForeignKey("users.ID"), nullable=True))
+                             Column("ownerID", ForeignKey("users.ID"), nullable=True),
+                             Column("created", DateTime, nullable=True, default=func.now()),
+                             Column("modified", DateTime, nullable=True, onupdate=func.now())
+                             )
 
 mapper(DamagePattern, damagePatterns_table)

--- a/eos/db/saveddata/drone.py
+++ b/eos/db/saveddata/drone.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean
+from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.drone import Drone
@@ -29,6 +30,9 @@ drones_table = Table("drones", saveddata_meta,
                      Column("itemID", Integer, nullable=False),
                      Column("amount", Integer, nullable=False),
                      Column("amountActive", Integer, nullable=False),
-                     Column("projected", Boolean, default=False))
+                     Column("projected", Boolean, default=False),
+                     Column("created", DateTime, nullable=True, default=func.now()),
+                     Column("modified", DateTime, nullable=True, onupdate=func.now())
+                     )
 
 mapper(Drone, drones_table)

--- a/eos/db/saveddata/fighter.py
+++ b/eos/db/saveddata/fighter.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean
+from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import mapper, relation
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.fighterAbility import FighterAbility
@@ -31,7 +32,10 @@ fighters_table = Table("fighters", saveddata_meta,
                        Column("itemID", Integer, nullable=False),
                        Column("active", Boolean, nullable=True),
                        Column("amount", Integer, nullable=False),
-                       Column("projected", Boolean, default=False))
+                       Column("projected", Boolean, default=False),
+                       Column("created", DateTime, nullable=True, default=func.now()),
+                       Column("modified", DateTime, nullable=True, onupdate=func.now())
+                       )
 
 fighter_abilities_table = Table("fightersAbilities", saveddata_meta,
                                 Column("groupID", Integer, ForeignKey("fighters.groupID"), primary_key=True,

--- a/eos/db/saveddata/fit.py
+++ b/eos/db/saveddata/fit.py
@@ -21,7 +21,8 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from sqlalchemy.sql import and_
 from sqlalchemy.orm import relation, reconstructor, mapper, relationship
-from sqlalchemy import ForeignKey, Column, Integer, String, Table, Boolean
+from sqlalchemy import ForeignKey, Column, Integer, String, Table, Boolean, DateTime
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.db import saveddata_session
@@ -57,6 +58,8 @@ fits_table = Table("fits", saveddata_meta,
                    Column("modeID", Integer, nullable=True),
                    Column("implantLocation", Integer, nullable=False, default=ImplantLocation.FIT),
                    Column("notes", String, nullable=True),
+                   Column("created", DateTime, nullable=True, default=func.now()),
+                   Column("modified", DateTime, nullable=True, onupdate=func.now())
                    )
 
 projectedFits_table = Table("projectedFits", saveddata_meta,
@@ -64,12 +67,16 @@ projectedFits_table = Table("projectedFits", saveddata_meta,
                             Column("victimID", ForeignKey("fits.ID"), primary_key=True),
                             Column("amount", Integer, nullable=False, default=1),
                             Column("active", Boolean, nullable=False, default=1),
+                            Column("created", DateTime, nullable=True, default=func.now()),
+                            Column("modified", DateTime, nullable=True, onupdate=func.now())
                             )
 
 commandFits_table = Table("commandFits", saveddata_meta,
                           Column("boosterID", ForeignKey("fits.ID"), primary_key=True),
                           Column("boostedID", ForeignKey("fits.ID"), primary_key=True),
-                          Column("active", Boolean, nullable=False, default=1)
+                          Column("active", Boolean, nullable=False, default=1),
+                          Column("created", DateTime, nullable=True, default=func.now()),
+                          Column("modified", DateTime, nullable=True, onupdate=func.now())
                           )
 
 

--- a/eos/db/saveddata/implant.py
+++ b/eos/db/saveddata/implant.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean
+from sqlalchemy import Table, Column, Integer, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.implant import Implant
@@ -26,7 +27,10 @@ from eos.saveddata.implant import Implant
 implants_table = Table("implants", saveddata_meta,
                        Column("ID", Integer, primary_key=True),
                        Column("itemID", Integer),
-                       Column("active", Boolean))
+                       Column("active", Boolean),
+                       Column("created", DateTime, nullable=True, default=func.now()),
+                       Column("modified", DateTime, nullable=True, onupdate=func.now())
+                       )
 
 fitImplants_table = Table("fitImplants", saveddata_meta,
                           Column("fitID", ForeignKey("fits.ID"), index=True),

--- a/eos/db/saveddata/implantSet.py
+++ b/eos/db/saveddata/implantSet.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, String
+from sqlalchemy import Table, Column, Integer, String, DateTime
 from sqlalchemy.orm import relation, mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.db.saveddata.implant import implantsSetMap_table
@@ -29,6 +30,8 @@ from eos.saveddata.implantSet import ImplantSet
 implant_set_table = Table("implantSets", saveddata_meta,
                           Column("ID", Integer, primary_key=True),
                           Column("name", String, nullable=False),
+                          Column("created", DateTime, nullable=True, default=func.now()),
+                          Column("modified", DateTime, nullable=True, onupdate=func.now())
                           )
 
 mapper(ImplantSet, implant_set_table,

--- a/eos/db/saveddata/module.py
+++ b/eos/db/saveddata/module.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey, CheckConstraint, Boolean
+from sqlalchemy import Table, Column, Integer, ForeignKey, CheckConstraint, Boolean, DateTime
 from sqlalchemy.orm import relation, mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.module import Module
@@ -33,6 +34,8 @@ modules_table = Table("modules", saveddata_meta,
                       Column("state", Integer, CheckConstraint("state >= -1"), CheckConstraint("state <= 2")),
                       Column("projected", Boolean, default=False, nullable=False),
                       Column("position", Integer),
+                      Column("created", DateTime, nullable=True, default=func.now()),
+                      Column("modified", DateTime, nullable=True, onupdate=func.now()),
                       CheckConstraint('("dummySlot" = NULL OR "itemID" = NULL) AND "dummySlot" != "itemID"'))
 
 mapper(Module, modules_table,

--- a/eos/db/saveddata/override.py
+++ b/eos/db/saveddata/override.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, Float
+from sqlalchemy import Table, Column, Integer, Float, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.override import Override
@@ -26,6 +27,9 @@ from eos.saveddata.override import Override
 overrides_table = Table("overrides", saveddata_meta,
                         Column("itemID", Integer, primary_key=True, index=True),
                         Column("attrID", Integer, primary_key=True, index=True),
-                        Column("value", Float, nullable=False))
+                        Column("value", Float, nullable=False),
+                        Column("created", DateTime, nullable=True, default=func.now()),
+                        Column("modified", DateTime, nullable=True, onupdate=func.now())
+                        )
 
 mapper(Override, overrides_table)

--- a/eos/db/saveddata/skill.py
+++ b/eos/db/saveddata/skill.py
@@ -17,15 +17,20 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, ForeignKey
+from sqlalchemy import Table, Column, Integer, ForeignKey, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.character import Skill
 
+
 skills_table = Table("characterSkills", saveddata_meta,
                      Column("characterID", ForeignKey("characters.ID"), primary_key=True, index=True),
                      Column("itemID", Integer, primary_key=True),
-                     Column("_Skill__level", Integer, nullable=True))
+                     Column("_Skill__level", Integer, nullable=True),
+                     Column("created", DateTime, nullable=True, default=func.now()),
+                     Column("modified", DateTime, nullable=True, onupdate=func.now())
+                     )
 
 mapper(Skill, skills_table)

--- a/eos/db/saveddata/targetResists.py
+++ b/eos/db/saveddata/targetResists.py
@@ -17,8 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from sqlalchemy import Table, Column, Integer, Float, ForeignKey, String
+from sqlalchemy import Table, Column, Integer, Float, ForeignKey, String, DateTime
 from sqlalchemy.orm import mapper
+import sqlalchemy.sql.functions as func
 
 from eos.db import saveddata_meta
 from eos.saveddata.targetResists import TargetResists
@@ -30,6 +31,9 @@ targetResists_table = Table("targetResists", saveddata_meta,
                             Column("thermalAmount", Float),
                             Column("kineticAmount", Float),
                             Column("explosiveAmount", Float),
-                            Column("ownerID", ForeignKey("users.ID"), nullable=True))
+                            Column("ownerID", ForeignKey("users.ID"), nullable=True),
+                            Column("created", DateTime, nullable=True, default=func.now()),
+                            Column("modified", DateTime, nullable=True, onupdate=func.now())
+                            )
 
 mapper(TargetResists, targetResists_table)


### PR DESCRIPTION
As discussed in #961. Preliminary testing shows this works well for existing and new databases. It's completely transparent to the user, and not something that is exposed at the moment (but we could later on if deemed necessary).

The primary motivation for this addition was to help with troubleshooting. If a user sends us a database file, having the times in which modules are added / modified, it's one more data point available to us to help piece together what happened. It also allows for some nifty things in the future (recently modified fits, for instance).

Three things to note:
- DATETIME is apparently a data type in SQLite, even though I continuously read that it isn't. This is the way SQLAlchemy creates it with it's own `DateType` class, but creating a table or column with that as part of the schema works fine. ¯\_(ツ)_/¯
- `fits` still contains a timestap of when the fit was created. Eventually I want to change over to the `created` field (or even `modified`) and abolish the `timestamp` field, but that's for another rainy day.
- Again on `fits`, I originally wanted the modified field to reflect all changes associated with that fit (modules added / removed, drones added / removed, etc) so that it represents the fit being modified on the whole, instead of simply modifying the name, character, etc. But I didn't see an easy way off hand, so this can be added later if deemed necessary.

Additionally, this does not include support for `sqlite_autoincrement` as discussed in the issue. I will submit another PR for that once it's been developed and tested.