### PR TITLE
Re-introduce Command Fit State

### DIFF
--- a/gui/builtinViewColumns/state.py
+++ b/gui/builtinViewColumns/state.py
@@ -68,11 +68,17 @@ class State(ViewColumn):
                                                                 "gui")
         elif isinstance(stuff, Fit):
             fitID = self.mainFrame.getActiveFit()
-            projectionInfo = stuff.getProjectionInfo(fitID)
 
-            if projectionInfo is None:
+            # can't use isinstance here due to being prevented from importing CommandView.
+            #  So we do the next best thing and compare Name of class.
+            if type(self.fittingView).__name__ == "CommandView":
+                info = stuff.getCommandInfo(fitID)
+            else:
+                info = stuff.getProjectionInfo(fitID)
+
+            if info is None:
                 return -1
-            if projectionInfo.active:
+            if info.active:
                 return generic_active
             return generic_inactive
         elif isinstance(stuff, Implant) and stuff.character:

--- a/gui/builtinViewColumns/state.py
+++ b/gui/builtinViewColumns/state.py
@@ -69,9 +69,9 @@ class State(ViewColumn):
         elif isinstance(stuff, Fit):
             fitID = self.mainFrame.getActiveFit()
 
-            # can't use isinstance here due to being prevented from importing CommandView.
-            #  So we do the next best thing and compare Name of class.
-            if type(self.fittingView).__name__ == "CommandView":
+            # Can't use isinstance here due to being prevented from importing CommandView.
+            # So we do the next best thing and compare Name of class.
+            if self.fittingView.__class__.__name__ == "CommandView":
                 info = stuff.getCommandInfo(fitID)
             else:
                 info = stuff.getProjectionInfo(fitID)

--- a/gui/commandView.py
+++ b/gui/commandView.py
@@ -57,7 +57,7 @@ class CommandViewDrop(wx.PyDropTarget):
 
 
 class CommandView(d.Display):
-    DEFAULT_COLS = ["Base Name"]
+    DEFAULT_COLS = ["State", "Base Name"]
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, style=wx.LC_SINGLE_SEL | wx.BORDER_NONE)


### PR DESCRIPTION
Simple QoL improvement / a fix for a regression dating back to November.

Bit of background: I disabled the state column for the Command / Fleet view when we made the change over to the new command burst mechanics. The reason behind this is because the State column, which controls which image is show to represent state of item, only received `stuff`. Normally we check what `stuff` is, and figure out what to do from there (eg: if `stuff` is a module, check the modules state and display an image that works).

The problem originally with command fits is that it shares the same `stuff` type as projected fits. So there wasn't a way to differentiate a projected fit from a command fit in the State class.

But holy shit, this was super easy after taking a look at it again tonight. We can't differentiate on `stuff`, but what we do have is access to the calling view. So to re-enable the State column for command view, we check to see if we're calling from command or projected, then get it's information, then display based on active flag.
