### PR TITLE
System wide installation

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ expansionVersion = "1.0"
 evemonMinVersion = "4081"
 
 pyfaPath = None
+dataPath = None
 savePath = None
 saveDB = None
 gameDB = None
@@ -58,6 +59,7 @@ def getDefaultSave():
 def defPaths(customSavePath):
     global debug
     global pyfaPath
+    global dataPath
     global savePath
     global saveDB
     global gameDB
@@ -92,6 +94,14 @@ def defPaths(customSavePath):
 
     # The database where we store all the fits etc
     saveDB = os.path.join(savePath, "saveddata.db")
+
+    # pyfa shared data directory (used for Linux system-wide installation).
+    dataPath = getattr(configforced, "dataPath", dataPath)
+    if dataPath is None:
+        if "site-packages" in pyfaPath and sys.platform.startswith("linux"):
+            dataPath = os.path.join("/usr", "share", "pyfa")
+        else:
+            dataPath = pyfaPath
 
     # The database where the static EVE data from the datadump is kept.
     # This is not the standard sqlite datadump but a modified version created by eos

--- a/config.py
+++ b/config.py
@@ -96,7 +96,9 @@ def defPaths(customSavePath):
     # The database where the static EVE data from the datadump is kept.
     # This is not the standard sqlite datadump but a modified version created by eos
     # maintenance script
-    gameDB = os.path.join(pyfaPath, "eve.db")
+    gameDB = getattr(configforced, "gameDB", gameDB)
+    if not gameDB:
+        gameDB = os.path.join(pyfaPath, "eve.db")
 
     # DON'T MODIFY ANYTHING BELOW
     import eos.config

--- a/config.py
+++ b/config.py
@@ -108,7 +108,7 @@ def defPaths(customSavePath):
     # maintenance script
     gameDB = getattr(configforced, "gameDB", gameDB)
     if not gameDB:
-        gameDB = os.path.join(pyfaPath, "eve.db")
+        gameDB = os.path.join(dataPath, "eve.db")
 
     # DON'T MODIFY ANYTHING BELOW
     import eos.config

--- a/gui/bitmapLoader.py
+++ b/gui/bitmapLoader.py
@@ -93,7 +93,7 @@ class BitmapLoader(object):
             except KeyError:
                 print("Missing icon file from zip: {0}".format(path))
         else:
-            path = os.path.join(config.pyfaPath, 'imgs' + os.sep + location + os.sep + filename)
+            path = os.path.join(config.dataPath, 'imgs' + os.sep + location + os.sep + filename)
 
             if os.path.exists(path):
                 return wx.Image(path)

--- a/service/settings.py
+++ b/service/settings.py
@@ -264,7 +264,7 @@ class HTMLExportSettings(object):
     def __init__(self):
         serviceHTMLExportDefaultSettings = {
             "enabled": False,
-            "path"   : config.pyfaPath + os.sep + 'pyfaFits.html',
+            "path"   : os.path.join(config.savePath, 'pyfaFits.html'),
             "minimal": False
         }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings(


### PR DESCRIPTION
I've been working those last weeks on providing Gentoo ebuilds for Pyfa.
Pyfa would be installed in the `site-packages` directory of the local Python installation... which raises some issues...

Some files, such as `eve.db` or `iconsIDs.yaml` do not belong there and should be moved to more appropriate locations (e.g. `/usr/share/pyfa`).
In addition, default HTML export path would not be writeable for a user so HTML exports would fail.

This pull request addresses those two issues and would also probably help making other Linux distribution packages.
It uses a long time available feature of Pyfa, the `configforced.py` file which would specify another directory to look for `eve.db`.
And it changes the default HTML export path to `~/.pyfa/pyfaFits.html`.

The possibly most bothering change is the default export path: I'm open to proposals ! 😄 

*For now, I'm focusing on providing Gentoo ebuilds for every Pyfa release. This is still work in progress. I may try to build `.deb` and `.rpm` (and other...) later.*