### PR TITLE
Fix for #1081

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -732,8 +732,6 @@ class Fit(object):
                         self.register(item)
                         item.calculateModifiedAttributes(self, runTime, False)
 
-
-
                     if targetFit and withBoosters and item in self.modules:
                         # Apply the gang boosts to target fit
                         # targetFit.register(item, origin=self)

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -732,11 +732,7 @@ class Fit(object):
                         self.register(item)
                         item.calculateModifiedAttributes(self, runTime, False)
 
-                    if projected is True and projectionInfo and item not in chain.from_iterable(r):
-                        # apply effects onto target fit
-                        for _ in xrange(projectionInfo.amount):
-                            targetFit.register(item, origin=self)
-                            item.calculateModifiedAttributes(targetFit, runTime, True)
+
 
                     if targetFit and withBoosters and item in self.modules:
                         # Apply the gang boosts to target fit
@@ -749,6 +745,16 @@ class Fit(object):
 
             if not withBoosters and self.commandBonuses:
                 self.__runCommandBoosts(runTime)
+
+            # Projection effects have been broken out of the main loop, see GH issue #1081
+
+            if projected is True and projectionInfo:
+                for item in chain.from_iterable(u):
+                    if item is not None:
+                        # apply effects onto target fit
+                        for _ in xrange(projectionInfo.amount):
+                            targetFit.register(item, origin=self)
+                            item.calculateModifiedAttributes(targetFit, runTime, True)
 
             timer.checkpoint('Done with runtime: %s' % runTime)
 


### PR DESCRIPTION
Break project application code out of main item iteration, and apply it after command boosts have been applied to the fit.

I do want to take another peak at it in a few days to see if there's any fat we can trim with that code now being in it's own block (for example review the items that are chained to see if there's anything unnecessary that's currently being run for projections, such as character, that I didn't bother to put brain cycles towards tonight). But for now this seems to fix the issue and works well.