### PR TITLE
Fix for #1090

### DIFF
--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -179,8 +179,8 @@ class MetaSwap(ContextMenu):
             elif isinstance(selected_item, Implant):
                 for idx, implant_stack in enumerate(fit.implants):
                     if implant_stack is selected_item:
-                        sFit.removeImplant(fitID, idx)
-                        sFit.addImplant(fitID, item.ID, False)
+                        sFit.removeImplant(fitID, idx, False)
+                        sFit.addImplant(fitID, item.ID, True)
                         break
 
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))

--- a/service/fit.py
+++ b/service/fit.py
@@ -254,14 +254,15 @@ class Fit(object):
             self.recalc(fit)
         return True
 
-    def removeImplant(self, fitID, position):
+    def removeImplant(self, fitID, position, recalc=True):
         if fitID is None:
             return False
 
         fit = eos.db.getFit(fitID)
         implant = fit.implants[position]
         fit.implants.remove(implant)
-        self.recalc(fit)
+        if recalc:
+            self.recalc(fit)
         return True
 
     def addBooster(self, fitID, itemID):


### PR DESCRIPTION
When using variations context menu, selecting an implant would remove it and then add the new one. The problem here was that `recalc=Fasle` was set when adding the new one, and thus the fit did not recalculate with the new implants.

This quick fix simply sets that recalc flag to `True`. To prevent double recalc, I added a `recalc` parameter to `removeImplant()` and set that to `False`.