### PR TITLE
Variation menu efficiencies 

### DIFF
--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -143,11 +143,11 @@ class MetaSwap(ContextMenu):
                 for idx, drone_stack in enumerate(fit.drones):
                     if drone_stack is selected_item:
                         drone_count = drone_stack.amount
-                        sFit.removeDrone(fitID, idx, drone_count)
+                        sFit.removeDrone(fitID, idx, drone_count, False)
                         break
 
                 if drone_count:
-                    sFit.addDrone(fitID, item.ID, drone_count)
+                    sFit.addDrone(fitID, item.ID, drone_count, True)
 
             elif isinstance(selected_item, Fighter):
                 fighter_count = None
@@ -164,16 +164,16 @@ class MetaSwap(ContextMenu):
                         else:
                             fighter_count.amount = 0
 
-                        sFit.removeFighter(fitID, idx)
+                        sFit.removeFighter(fitID, idx, False)
                         break
 
-                sFit.addFighter(fitID, item.ID)
+                sFit.addFighter(fitID, item.ID, True)
 
             elif isinstance(selected_item, Booster):
                 for idx, booster_stack in enumerate(fit.boosters):
                     if booster_stack is selected_item:
-                        sFit.removeBooster(fitID, idx)
-                        sFit.addBooster(fitID, item.ID)
+                        sFit.removeBooster(fitID, idx, False)
+                        sFit.addBooster(fitID, item.ID, True)
                         break
 
             elif isinstance(selected_item, Implant):

--- a/service/fit.py
+++ b/service/fit.py
@@ -278,7 +278,7 @@ class Fit(object):
         self.recalc(fit)
         return True
 
-    def addBooster(self, fitID, itemID):
+    def addBooster(self, fitID, itemID, recalc=True):
         pyfalog.debug("Adding booster ({0}) to fit ID: {1}", itemID, fitID)
         if fitID is None:
             return False
@@ -292,10 +292,11 @@ class Fit(object):
             return False
 
         fit.boosters.append(booster)
-        self.recalc(fit)
+        if recalc:
+            self.recalc(fit)
         return True
 
-    def removeBooster(self, fitID, position):
+    def removeBooster(self, fitID, position, recalc=True):
         pyfalog.debug("Removing booster from position ({0}) for fit ID: {1}", position, fitID)
         if fitID is None:
             return False
@@ -303,7 +304,8 @@ class Fit(object):
         fit = eos.db.getFit(fitID)
         booster = fit.boosters[position]
         fit.boosters.remove(booster)
-        self.recalc(fit)
+        if recalc:
+            self.recalc(fit)
         return True
 
     def project(self, fitID, thing):
@@ -670,7 +672,7 @@ class Fit(object):
         self.recalc(fit)
         return True
 
-    def addFighter(self, fitID, itemID):
+    def addFighter(self, fitID, itemID, recalc=True):
         pyfalog.debug("Adding fighters ({0}) to fit ID: {1}", itemID, fitID)
         if fitID is None:
             return False
@@ -712,22 +714,24 @@ class Fit(object):
                     return False
 
             eos.db.commit()
-            self.recalc(fit)
+            if recalc:
+                self.recalc(fit)
             return True
         else:
             return False
 
-    def removeFighter(self, fitID, i):
+    def removeFighter(self, fitID, i, recalc=True):
         pyfalog.debug("Removing fighters from fit ID: {0}", fitID)
         fit = eos.db.getFit(fitID)
         f = fit.fighters[i]
         fit.fighters.remove(f)
 
         eos.db.commit()
-        self.recalc(fit)
+        if recalc:
+            self.recalc(fit)
         return True
 
-    def addDrone(self, fitID, itemID, numDronesToAdd=1):
+    def addDrone(self, fitID, itemID, numDronesToAdd=1, recalc=True):
         pyfalog.debug("Adding {0} drones ({1}) to fit ID: {2}", numDronesToAdd, itemID, fitID)
         if fitID is None:
             return False
@@ -749,7 +753,8 @@ class Fit(object):
                     return False
             drone.amount += numDronesToAdd
             eos.db.commit()
-            self.recalc(fit)
+            if recalc:
+                self.recalc(fit)
             return True
         else:
             return False
@@ -810,7 +815,7 @@ class Fit(object):
         fit = eos.db.getFit(fitID)
         self.splitDrones(fit, d, amount, fit.drones)
 
-    def removeDrone(self, fitID, i, numDronesToRemove=1):
+    def removeDrone(self, fitID, i, numDronesToRemove=1, recalc=True):
         pyfalog.debug("Removing {0} drones for fit ID: {1}", numDronesToRemove, fitID)
         fit = eos.db.getFit(fitID)
         d = fit.drones[i]
@@ -822,7 +827,8 @@ class Fit(object):
             del fit.drones[i]
 
         eos.db.commit()
-        self.recalc(fit)
+        if recalc:
+            self.recalc(fit)
         return True
 
     def toggleDrone(self, fitID, i):


### PR DESCRIPTION
This should be a quick QoL and performance improvement, easy win. In the same light as #1094, this adds recalc flags to the add/remove fit service functions for drones, fighters, and boosters to prevent a double recalc when switching the modules. This does not include #1094 (didn't merge master into dev yet, but it'll get in there eventually).



