### PR TITLE
Restrict cap modules to only cap ships

### DIFF
--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -200,6 +200,10 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             return self.owner.modules.index(self)
 
     @property
+    def isCapitalSize(self):
+        return self.getModifiedItemAttr("volume", 0) >= 4000
+
+    @property
     def hpBeforeReload(self):
         """
         If item is some kind of repairer with charges, calculate
@@ -420,7 +424,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
 
         # EVE doesn't let capital modules be fit onto subcapital hulls. Confirmed by CCP Larrikin that this is dictated
         # by the modules volume. See GH issue #1096
-        if (fit.ship.getModifiedItemAttr("isCapitalSize", 0) != 1 and self.getModifiedItemAttr("volume", 0) >= 4000):
+        if (fit.ship.getModifiedItemAttr("isCapitalSize", 0) != 1 and self.isCapitalSize):
             return False
 
         # If the mod is a subsystem, don't let two subs in the same slot fit

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -418,6 +418,11 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if isinstance(fit.ship, Citadel) and len(fitsOnGroup) == 0 and len(fitsOnType) == 0:
             return False
 
+        # EVE doesn't let capital modules be fit onto subcapital hulls. This seems to be dictated by the modules volume
+        # See GH issue #1096
+        if (fit.ship.getModifiedItemAttr("isCapitalSize", 0) != 1 and self.getModifiedItemAttr("volume", 0) >= 4000):
+            return False
+
         # If the mod is a subsystem, don't let two subs in the same slot fit
         if self.slot == Slot.SUBSYSTEM:
             subSlot = self.getModifiedItemAttr("subSystemSlot")

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -418,8 +418,8 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if isinstance(fit.ship, Citadel) and len(fitsOnGroup) == 0 and len(fitsOnType) == 0:
             return False
 
-        # EVE doesn't let capital modules be fit onto subcapital hulls. This seems to be dictated by the modules volume
-        # See GH issue #1096
+        # EVE doesn't let capital modules be fit onto subcapital hulls. Confirmed by CCP Larrikin that this is dictated
+        # by the modules volume. See GH issue #1096
         if (fit.ship.getModifiedItemAttr("isCapitalSize", 0) != 1 and self.getModifiedItemAttr("volume", 0) >= 4000):
             return False
 


### PR DESCRIPTION
This is a quick fix for #1096 - adds a check in `Module.fits()` to make sure we aren't trying to put a cap module on a sub cap ship.
