### PR TITLE
Register fit with pointer list

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -52,6 +52,7 @@ class Fit(object):
 
     def __init__(self):
         pyfalog.debug("Initialize Fit class")
+        self.fit_pointer_list = []
         self.pattern = DamagePattern.getInstance().getDamagePattern("Uniform")
         self.targetResists = None
         self.character = saveddata_Character.getAll5()
@@ -217,7 +218,14 @@ class Fit(object):
         pyfalog.debug("Getting fit for fit ID: {0}", fitID)
         if fitID is None:
             return None
-        fit = eos.db.getFit(fitID)
+
+        fit = next((x for x in self.fit_pointer_list if x.ID == fitID), None)
+
+        if fit is None:
+            fit = eos.db.getFit(fitID)
+
+        if fit not in self.fit_pointer_list:
+            self.fit_pointer_list.append(fit)
 
         if basic:
             return fit


### PR DESCRIPTION
All this does is simply create a new pointer back to the fit object.

Every time we fetch from the database cache, we're getting the _same object_ back.  By maintaining a pointer list of the objects, we can do two things.

1) Increase performance signifcantly (11% at the low end, 30% at the higher end).
2) Start moving toward maintianing a list we can garbage collect and handle.


From a previous PR:
--------------------------------------------------

Okay, boiled this down to the bare components and ran some tests.

Literally. I used our new test environment to only load the bare components we needed.

Here are the times reported by the tests (this includes some overhead of creating/destructing objects)
https://puu.sh/v82Zb/f2c3bc815c.png

And here are the times for just getting the fits (either from the local cache, or the DB cache).

1000000 of the Rifter fit (new): 9.21399998665
1000000 of the Rifter fit (old): 10.3989999294
1000000 of the four fits (new): 7.20000004768
1000000 of the four fits (old): 10.3380000591
In each case, we fetch one million fits. The first two simply loop a million times and grab the same fit repeatedly, you'll see that the times are pretty close, though grabbing it out of the local cache is still 11% faster. Significant increase in speed, but not game changing.

The second two only loop 250k times, but each loop grabs 4 different fits. There's much less overhead as we have a quarter of the time spent processing our for and xrange (250k loops vs 1M loops), so you want to be a little careful directly comparing the first two tests to the second two, but they are fairly comparable.

What's super interesting is that there is a 30% increase in speed for using the local cache over the DB cache.

This actually matches my tests that I ran in situ for the getFit function. If I forced it to load a single fit repeatedly from the DB cache, the times were fairly close to on par with loading from a local cache (similar to test above). If I forced it to load different fits in a row, the time nearly doubled for loading with the DB cache.

The DB cache can retrieve the same fit fairly quickly (almost, though not quite, as fast as a local cache). It is not very good at switching what it hands back.

It makes sense that I'd see 12-16% improvements "in the wild", because we mostly retrieve the same fit repeatedly (we run getFit a good 20-30 times), but the test I ran did include switching between fits a few times.

Regardless, even if we shove the "switching fits" scenario aside, I would still say that a 11% increase in speed is worth it. Not only that, but the ability to be able to garbage collect and cleanup down the road, because we have fits that have been opened registered, rather than discarding them and recreating repeatedly. I've noticed (as have others) that Pyfa becomes sluggish over time (if left running and used over several days), this would be a step toward being able to manage that.

@blitzmann if you want to run the code yourself:
https://gist.github.com/Ebag333/01c4d9821190ae8f26efbffb99bf9b95