### PR TITLE
Clean up fit service

### DIFF
--- a/gui/builtinContextMenus/factorReload.py
+++ b/gui/builtinContextMenus/factorReload.py
@@ -26,7 +26,8 @@ class FactorReload(ContextMenu):
         sFit = Fit.getInstance()
         sFit.serviceFittingOptions["useGlobalForceReload"] = not sFit.serviceFittingOptions["useGlobalForceReload"]
         fitID = self.mainFrame.getActiveFit()
-        sFit.refreshFit(fitID)
+        fit = sFit.getFit(fitID)
+        sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
 
     def getBitmap(self, context, selection):

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -133,7 +133,8 @@ class PFGeneralPref(PreferenceView):
     def onCBGlobalColorBySlot(self, event):
         self.sFit.serviceFittingOptions["colorFitBySlot"] = self.cbFitColorSlots.GetValue()
         fitID = self.mainFrame.getActiveFit()
-        self.sFit.refreshFit(fitID)
+        fit = self.sFit.getFit(fitID)
+        self.sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
         event.Skip()
 
@@ -141,14 +142,16 @@ class PFGeneralPref(PreferenceView):
         self.sFit.serviceFittingOptions["rackSlots"] = self.cbRackSlots.GetValue()
         self.cbRackLabels.Enable(self.cbRackSlots.GetValue())
         fitID = self.mainFrame.getActiveFit()
-        self.sFit.refreshFit(fitID)
+        fit = self.sFit.getFit(fitID)
+        self.sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
         event.Skip()
 
     def onCBGlobalRackLabels(self, event):
         self.sFit.serviceFittingOptions["rackLabels"] = self.cbRackLabels.GetValue()
         fitID = self.mainFrame.getActiveFit()
-        self.sFit.refreshFit(fitID)
+        fit = self.sFit.getFit(fitID)
+        self.sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
         event.Skip()
 
@@ -163,7 +166,8 @@ class PFGeneralPref(PreferenceView):
     def onCBCompactSkills(self, event):
         self.sFit.serviceFittingOptions["compactSkills"] = self.cbCompactSkills.GetValue()
         fitID = self.mainFrame.getActiveFit()
-        self.sFit.refreshFit(fitID)
+        fit = self.sFit.getFit(fitID)
+        self.sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
         event.Skip()
 
@@ -200,7 +204,8 @@ class PFGeneralPref(PreferenceView):
         sMkt = Market.getInstance()
         sMkt.clearPriceCache()
 
-        self.sFit.refreshFit(fitID)
+        fit = self.sFit.getFit(fitID)
+        self.sFit.recalc(fit)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
         event.Skip()
 

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -273,7 +273,8 @@ class FittingView(d.Display):
         try:
             # Sometimes there is no active page after deletion, hence the try block
             sFit = Fit.getInstance()
-            sFit.refreshFit(self.getActiveFit())
+            fit = sFit.getFit(self.getActiveFit())
+            sFit.recalc(fit)
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.activeFitID))
         except wx._core.PyDeadObjectError:
             pyfalog.error("Caught dead object")

--- a/service/fit.py
+++ b/service/fit.py
@@ -186,7 +186,6 @@ class Fit(object):
         if fitID is None:
             return None
 
-        force_recalc = False
         fit = self.getFit(fitID)
 
         if self.serviceFittingOptions["useGlobalCharacter"]:

--- a/service/fit.py
+++ b/service/fit.py
@@ -1062,6 +1062,6 @@ class Fit(object):
             fit.factorReload = self.serviceFittingOptions["useGlobalForceReload"]
         fit.clear()
 
-        fit.calculateModifiedAttributes(withBoosters=False)
+        fit.calculateModifiedAttributes(withBoosters=withBoosters)
 
         pyfalog.info("=" * 10 + "recalc time: " + str(time() - start_time) + "=" * 10)


### PR DESCRIPTION
Performs a bunch of cleanup.

1. Redirects everything to use `getFit` rather than rolling their own DB fetch.
2. Moves redundant code into a single location (mostly `db.commit()` into the recalc).
3. Removes `refreshFit` because very little used it, and what did could use `recalc` just fine.
4. Makes what's requesting a full recalc (fit + boosters + command bursts) vs what's requesting just a local recalc a bit more sane.
5. `recalc` defaults to a full recalc now.