### PR TITLE
Refactor Pricing

### DIFF
--- a/eos/saveddata/price.py
+++ b/eos/saveddata/price.py
@@ -21,6 +21,9 @@
 import time
 
 from sqlalchemy.orm import reconstructor
+from logbook import Logger
+
+pyfalog = Logger(__name__)
 
 
 class Price(object):
@@ -29,7 +32,6 @@ class Price(object):
         self.time = 0
         self.price = 0
         self.failed = None
-        self.__item = None
 
     @reconstructor
     def init(self):

--- a/gui/boosterView.py
+++ b/gui/boosterView.py
@@ -43,9 +43,12 @@ class BoosterViewDrop(wx.PyDropTarget):
 
 
 class BoosterView(d.Display):
-    DEFAULT_COLS = ["State",
-                    "attr:boosterness",
-                    "Base Name"]
+    DEFAULT_COLS = [
+        "State",
+        "attr:boosterness",
+        "Base Name",
+        "Price",
+    ]
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, style=wx.LC_SINGLE_SEL | wx.BORDER_NONE)

--- a/gui/builtinContextMenus/priceClear.py
+++ b/gui/builtinContextMenus/priceClear.py
@@ -3,7 +3,6 @@ import gui.mainFrame
 # noinspection PyPackageRequirements
 import wx
 import gui.globalEvents as GE
-from service.market import Market
 from service.settings import ContextMenuSettings
 
 
@@ -22,8 +21,6 @@ class PriceClear(ContextMenu):
         return "Reset Price Cache"
 
     def activate(self, fullContext, selection, i):
-        sMkt = Market.getInstance()
-        sMkt.clearPriceCache()
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.mainFrame.getActiveFit()))
 
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -9,7 +9,6 @@ import gui.globalEvents as GE
 from service.settings import SettingsProvider
 from service.fit import Fit
 from service.price import Price
-from service.market import Market
 
 
 class PFGeneralPref(PreferenceView):
@@ -196,9 +195,6 @@ class PFGeneralPref(PreferenceView):
         self.sFit.serviceFittingOptions["priceSystem"] = system
 
         fitID = self.mainFrame.getActiveFit()
-
-        sMkt = Market.getInstance()
-        sMkt.clearPriceCache()
 
         self.sFit.refreshFit(fitID)
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))

--- a/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
@@ -91,8 +91,6 @@ class PFStatViewPref(PreferenceView):
         rbSizerRow3 = wx.BoxSizer(wx.HORIZONTAL)
 
         self.rbPrice = wx.RadioBox(panel, -1, "Price", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
-        # Disable minimal as we don't have a view for this yet
-        self.rbPrice.EnableItem(1, False)
         self.rbPrice.SetSelection(self.settings.get('price'))
         rbSizerRow3.Add(self.rbPrice, 1, wx.TOP | wx.RIGHT, 5)
         self.rbPrice.Bind(wx.EVT_RADIOBOX, self.OnPriceChange)

--- a/gui/builtinStatsViews/__init__.py
+++ b/gui/builtinStatsViews/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     "outgoingViewMinimal",
     "targetingMiscViewMinimal",
     "priceViewFull",
+    "priceViewMinimal",
 ]

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -25,8 +25,8 @@ from gui.utils.numberFormatter import formatAmount
 from service.price import Price
 
 
-class PriceViewFull(StatsView):
-    name = "priceViewFull"
+class PriceViewMinimal(StatsView):
+    name = "priceViewMinimal"
 
     def __init__(self, parent):
         StatsView.__init__(self)
@@ -47,16 +47,10 @@ class PriceViewFull(StatsView):
         headerContentSizer.Add(self.labelEMStatus)
         headerPanel.GetParent().AddToggleItem(self.labelEMStatus)
 
-        gridPrice = wx.GridSizer(2, 3)
+        gridPrice = wx.GridSizer(1, 3)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for _type in ("ship", "fittings", "drones", "cargoBay", "character", "total"):
-            if _type in "ship":
-                image = "ship_big"
-            elif _type in ("fittings", "total"):
-                image = "%sPrice_big" % _type
-            else:
-                image = "%s_big" % _type
-
+        for _type in ("ship", "fittings", "total"):
+            image = "%sPrice_big" % _type if _type != "ship" else "ship_big"
             box = wx.BoxSizer(wx.HORIZONTAL)
             gridPrice.Add(box, 0, wx.ALIGN_TOP)
 
@@ -131,17 +125,8 @@ class PriceViewFull(StatsView):
         self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))
         self.labelPriceShip.SetToolTip(wx.ToolTip('{:,.2f}'.format(ship_price)))
 
-        self.labelPriceFittings.SetLabel("%s ISK" % formatAmount(module_price, 3, 3, 9, currency=True))
-        self.labelPriceFittings.SetToolTip(wx.ToolTip('{:,.2f}'.format(module_price)))
-
-        self.labelPriceDrones.SetLabel("%s ISK" % formatAmount(drone_price + fighter_price, 3, 3, 9, currency=True))
-        self.labelPriceDrones.SetToolTip(wx.ToolTip('{:,.2f}'.format(drone_price + fighter_price)))
-
-        self.labelPriceCargobay.SetLabel("%s ISK" % formatAmount(cargo_price, 3, 3, 9, currency=True))
-        self.labelPriceCargobay.SetToolTip(wx.ToolTip('{:,.2f}'.format(cargo_price)))
-
-        self.labelPriceCharacter.SetLabel("%s ISK" % formatAmount(booster_price + implant_price, 3, 3, 9, currency=True))
-        self.labelPriceCharacter.SetToolTip(wx.ToolTip('{:,.2f}'.format(booster_price + implant_price)))
+        self.labelPriceFittings.SetLabel("%s ISK" % formatAmount(fitting_price, 3, 3, 9, currency=True))
+        self.labelPriceFittings.SetToolTip(wx.ToolTip('{:,.2f}'.format(fitting_price)))
 
         self.labelPriceTotal.SetLabel("%s ISK" % formatAmount(total_price, 3, 3, 9, currency=True))
         self.labelPriceTotal.SetToolTip(wx.ToolTip('{:,.2f}'.format(total_price)))
@@ -153,4 +138,4 @@ class PriceViewFull(StatsView):
         self.panel.Layout()
 
 
-PriceViewFull.register()
+PriceViewMinimal.register()

--- a/gui/builtinViewColumns/price.py
+++ b/gui/builtinViewColumns/price.py
@@ -22,7 +22,7 @@ import wx
 
 from eos.saveddata.cargo import Cargo
 from eos.saveddata.drone import Drone
-from service.market import Market
+from service.price import Price as ServicePrice
 from gui.viewColumn import ViewColumn
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -41,13 +41,15 @@ class Price(ViewColumn):
         if stuff.item is None or stuff.item.group.name == "Ship Modifiers":
             return ""
 
-        sMkt = Market.getInstance()
-        price = sMkt.getPriceNow(stuff.item.ID)
+        if hasattr(stuff, "isEmpty"):
+            if stuff.isEmpty:
+                return ""
 
-        if not price or not price.price or not price.isValid:
-            return False
+        sPrice = ServicePrice.getInstance()
+        price = sPrice.getPriceNow(stuff.item)
 
-        price = price.price  # Set new price variable with what we need
+        if not price:
+            return ""
 
         if isinstance(stuff, Drone) or isinstance(stuff, Cargo):
             price *= stuff.amount
@@ -55,10 +57,10 @@ class Price(ViewColumn):
         return formatAmount(price, 3, 3, 9, currency=True)
 
     def delayedText(self, mod, display, colItem):
-        sMkt = Market.getInstance()
+        sPrice = ServicePrice.getInstance()
 
         def callback(item):
-            price = sMkt.getPriceNow(item.ID)
+            price = sPrice.getPriceNow(item.ID)
             text = formatAmount(price.price, 3, 3, 9, currency=True) if price.price else ""
             if price.failed:
                 text += " (!)"
@@ -66,7 +68,7 @@ class Price(ViewColumn):
 
             display.SetItem(colItem)
 
-        sMkt.waitForPrice(mod.item, callback)
+        sPrice.getPrices([mod.item], callback, True)
 
     def getImageId(self, mod):
         return -1

--- a/gui/implantView.py
+++ b/gui/implantView.py
@@ -79,10 +79,13 @@ class ImplantView(wx.Panel):
 
 
 class ImplantDisplay(d.Display):
-    DEFAULT_COLS = ["State",
-                    "attr:implantness",
-                    "Base Icon",
-                    "Base Name"]
+    DEFAULT_COLS = [
+        "State",
+        "attr:implantness",
+        "Base Icon",
+        "Base Name",
+        "Price",
+    ]
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, style=wx.LC_SINGLE_SEL | wx.BORDER_NONE)

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -43,6 +43,7 @@ from eos.saveddata.citadel import Citadel
 from eos.saveddata.fit import Fit
 from service.market import Market
 from service.attribute import Attribute
+from service.price import Price as ServicePrice
 import gui.mainFrame
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
@@ -623,7 +624,7 @@ class ItemCompare(wx.Panel):
 
     def processPrices(self, prices):
         for i, price in enumerate(prices):
-            self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(price.price, 3, 3, 9, currency=True))
+            self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(price.value, 3, 3, 9, currency=True))
 
     def PopulateList(self, sort=None):
 
@@ -660,9 +661,6 @@ class ItemCompare(wx.Panel):
         self.paramList.InsertColumn(len(self.attrs) + 1, "Price")
         self.paramList.SetColumnWidth(len(self.attrs) + 1, 60)
 
-        sMkt = Market.getInstance()
-        sMkt.getPrices([x.ID for x in self.items], self.processPrices)
-
         for item in self.items:
             i = self.paramList.InsertStringItem(sys.maxint, item.name)
             for x, attr in enumerate(self.attrs.keys()):
@@ -677,6 +675,10 @@ class ItemCompare(wx.Panel):
                         valueUnit = formatAmount(value, 3, 0, 0)
 
                     self.paramList.SetStringItem(i, x + 1, valueUnit)
+
+                # Add prices
+                sPrice = ServicePrice.getInstance()
+                self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(sPrice.getPriceNow(item), 3, 3, 9, currency=True))
 
         self.paramList.RefreshRows()
         self.Layout()

--- a/gui/statsView.py
+++ b/gui/statsView.py
@@ -52,6 +52,7 @@ from gui.builtinStatsViews import (  # noqa: E402, F401
     rechargeViewFull,
     targetingMiscViewMinimal,
     priceViewFull,
+    priceViewMinimal,
     outgoingViewFull,
     outgoingViewMinimal,
 )

--- a/service/market.py
+++ b/service/market.py
@@ -30,11 +30,10 @@ import config
 import eos.db
 from service import conversions
 from service.settings import SettingsProvider
-from service.price import Price
 
 from eos.gamedata import Category as types_Category, Group as types_Group, Item as types_Item, MarketGroup as types_MarketGroup, \
     MetaGroup as types_MetaGroup, MetaType as types_MetaType
-from eos.saveddata.price import Price as types_Price
+
 
 try:
     from collections import OrderedDict
@@ -83,48 +82,6 @@ class ShipBrowserWorkerThread(threading.Thread):
                 except Exception as e:
                     pyfalog.critical("Queue task done failed.")
                     pyfalog.critical(e)
-
-
-class PriceWorkerThread(threading.Thread):
-    def __init__(self):
-        threading.Thread.__init__(self)
-        self.name = "PriceWorker"
-        pyfalog.debug("Initialize PriceWorkerThread.")
-
-    def run(self):
-        pyfalog.debug("Run start")
-        self.queue = Queue.Queue()
-        self.wait = {}
-        self.processUpdates()
-        pyfalog.debug("Run end")
-
-    def processUpdates(self):
-        queue = self.queue
-        while True:
-            # Grab our data
-            callback, requests = queue.get()
-
-            # Grab prices, this is the time-consuming part
-            if len(requests) > 0:
-                Price.fetchPrices(requests)
-
-            wx.CallAfter(callback)
-            queue.task_done()
-
-            # After we fetch prices, go through the list of waiting items and call their callbacks
-            for price in requests:
-                callbacks = self.wait.pop(price.typeID, None)
-                if callbacks:
-                    for callback in callbacks:
-                        wx.CallAfter(callback)
-
-    def trigger(self, prices, callbacks):
-        self.queue.put((callbacks, prices))
-
-    def setToWait(self, itemID, callback):
-        if itemID not in self.wait:
-            self.wait[itemID] = []
-        self.wait[itemID].append(callback)
 
 
 class SearchWorkerThread(threading.Thread):
@@ -180,18 +137,12 @@ class Market(object):
     instance = None
 
     def __init__(self):
-        self.priceCache = {}
 
         # Init recently used module storage
         serviceMarketRecentlyUsedModules = {"pyfaMarketRecentlyUsedModules": []}
 
         self.serviceMarketRecentlyUsedModules = SettingsProvider.getInstance().getSettings(
                 "pyfaMarketRecentlyUsedModules", serviceMarketRecentlyUsedModules)
-
-        # Start price fetcher
-        self.priceWorkerThread = PriceWorkerThread()
-        self.priceWorkerThread.daemon = True
-        self.priceWorkerThread.start()
 
         # Thread which handles search
         self.searchWorkerThread = SearchWorkerThread()
@@ -854,60 +805,6 @@ class Market(object):
         """Filter items by meta lvl"""
         filtered = set(filter(lambda item: self.getMetaGroupIdByItem(item) in metas, items))
         return filtered
-
-    def getPriceNow(self, typeID):
-        """Get price for provided typeID"""
-        price = self.priceCache.get(typeID)
-        if price is None:
-            price = eos.db.getPrice(typeID)
-            if price is None:
-                price = types_Price(typeID)
-                eos.db.add(price)
-
-            self.priceCache[typeID] = price
-
-        return price
-
-    def getPricesNow(self, typeIDs):
-        """Return map of calls to get price against list of typeIDs"""
-        return map(self.getPrice, typeIDs)
-
-    def getPrices(self, typeIDs, callback):
-        """Get prices for multiple typeIDs"""
-        requests = []
-        for typeID in typeIDs:
-            price = self.getPriceNow(typeID)
-            requests.append(price)
-
-        def cb():
-            try:
-                callback(requests)
-            except Exception as e:
-                pyfalog.critical("Callback failed.")
-                pyfalog.critical(e)
-            eos.db.commit()
-
-        self.priceWorkerThread.trigger(requests, cb)
-
-    def waitForPrice(self, item, callback):
-        """
-        Wait for prices to be fetched and callback when finished. This is used with the column prices for modules.
-        Instead of calling them individually, we set them to wait until the entire fit price is called and calculated
-        (see GH #290)
-        """
-
-        def cb():
-            try:
-                callback(item)
-            except Exception as e:
-                pyfalog.critical("Callback failed.")
-                pyfalog.critical(e)
-
-        self.priceWorkerThread.setToWait(item.ID, cb)
-
-    def clearPriceCache(self):
-        self.priceCache.clear()
-        eos.db.clearPrices()
 
     def getSystemWideEffects(self):
         """


### PR DESCRIPTION
The main highlights:
- Removes the market price cache, and instead we append our price object to all items.  Now the item itself is the cache.
- Move the price thread to the price service. Makes more sense.
- Clean up a bunch of the logic
- Remove unused functions, and merge functions where possible.
- Make a number of things more object oriented (no taking a list of objects to get a list of IDs just to convert back to objects).
- Adds a new full pricing pane that breaks down value more discretely.
https://puu.sh/uJ07t/5aabdf3e4a.png
- Move the old pricing pane to a minimal version, so folks can still use that if they so desire.
- Adds pricing column to implants/boosters, because why not? Fixes #678

Unlike the prior PR (#1038), this leaves the thread handling intact.  We rework it a little to better use the caching of pricing on items, but we're still using it to let our panel know that it needs an update.