### PR TITLE
Allow system wide installation

### DIFF
--- a/config.py
+++ b/config.py
@@ -96,7 +96,9 @@ def defPaths(customSavePath):
     # The database where the static EVE data from the datadump is kept.
     # This is not the standard sqlite datadump but a modified version created by eos
     # maintenance script
-    gameDB = os.path.join(pyfaPath, "eve.db")
+    gameDB = getattr(configforced, "gameDB", gameDB)
+    if not gameDB:
+        gameDB = os.path.join(pyfaPath, "eve.db")
 
     # DON'T MODIFY ANYTHING BELOW
     import eos.config

--- a/service/settings.py
+++ b/service/settings.py
@@ -263,7 +263,7 @@ class HTMLExportSettings(object):
 
     def __init__(self):
         serviceHTMLExportDefaultSettings = {
-            "path"   : config.pyfaPath + os.sep + 'pyfaFits.html',
+            "path"   : config.savePath + os.sep + 'pyfaFits.html',
             "minimal": False
         }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings(


### PR DESCRIPTION
Rewrite/continuation of #1080.

I made the requested changes. And there are more to come.

For instance, on Linux systems, applications user data should be stored in `$XDG_DATA_HOME` which should default to ` ~/.local/share/[app-name]` if the variable is not set. See [here for details](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

In addition, I would like to be able to move the `imgs` directory to `/usr/share` as well, `$XDG_DATA_DIRS` eventually. When I'm talking about moving, I mean being able to run Pyfa as it is meant to be now and add the possibility to run it with the `imgs` directory in this new path.

#### Unicode issue
I've been trying to reproduce the issue with `os.path.join` and unicode strings. And the only error I have is with this:
```python
os.path.join(unicode(os.path.expanduser("~"), sys.getfilesystemencoding()), "çÁè")
```

But, for instance:
```python
os.path.join(os.path.expanduser("~"), "Développement")
```
does work like a charm... In fact, I've got errors when I am encoding one or more of the strings given to `os.path.join` with `unicode` (or prefixing it with `u""`) and I also give a string with unicode chars in it but without "unicoding" it.

At least on Linux... Not tested yet on Windows.