### PR TITLE
Bug/1147

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,8 +19,8 @@ debug = False
 saveInRoot = False
 
 # Version data
-version = "1.29.0"
-tag = "Stable"
+version = "1.29.1"
+tag = "git"
 expansionName = "YC119.5"
 expansionVersion = "1.0"
 evemonMinVersion = "4081"

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -2001,7 +2001,7 @@ class FitItem(SFItem.SFBrowserItem):
 
     def Refresh(self):
         activeFit = self.mainFrame.getActiveFit()
-        if activeFit == self.fitID:
+        if activeFit == self.fitID and not self.deleted:
             sFit = Fit.getInstance()
             fit = sFit.getFit(activeFit)
             self.timestamp = fit.modifiedCoalesce

--- a/service/fit.py
+++ b/service/fit.py
@@ -198,8 +198,9 @@ class Fit(object):
     @staticmethod
     def editNotes(fitID, notes):
         fit = eos.db.getFit(fitID)
-        fit.notes = notes
-        eos.db.commit()
+        if fit:
+            fit.notes = notes
+            eos.db.commit()
 
     def toggleFactorReload(self, fitID):
         pyfalog.debug("Toggling factor reload for fit ID: {0}", fitID)


### PR DESCRIPTION
Fixes issue which caused exceptions when deleting fits. Two issues at hand: trying to read fit information after deletion of fit to refresh the FitItem for the fit (since that is triggered on fit changed event), and the notes view trying to save the notes for a deleted fit (since that is triggered when the tab switches / closes)

Fixes #1147 