### PR TITLE
Do not commit price objects to database from within thread

### DIFF
--- a/service/price.py
+++ b/service/price.py
@@ -151,7 +151,6 @@ class Price(object):
             priceobj.time = time.time() + REREQUEST
             priceobj.failed = True
 
-
     @classmethod
     def fitItemsList(cls, fit):
         # Compose a list of all the data we need & request it

--- a/service/price.py
+++ b/service/price.py
@@ -127,9 +127,6 @@ class Price(object):
                 priceobj.time = time.time() + VALIDITY
                 priceobj.failed = None
 
-                # Update the DB.
-                db.commit()
-
                 # delete price from working dict
                 del priceMap[typeID]
 
@@ -141,9 +138,6 @@ class Price(object):
                 priceobj = priceMap[typeID]
                 priceobj.time = time.time() + TIMEOUT
                 priceobj.failed = True
-
-                # Update the DB.
-                db.commit()
 
                 del priceMap[typeID]
         except:
@@ -157,8 +151,6 @@ class Price(object):
             priceobj.time = time.time() + REREQUEST
             priceobj.failed = True
 
-            # Update the DB.
-            db.commit()
 
     @classmethod
     def fitItemsList(cls, fit):
@@ -207,6 +199,7 @@ class Price(object):
             except Exception as e:
                 pyfalog.critical("Callback failed.")
                 pyfalog.critical(e)
+
             db.commit()
 
         if waitforthread:


### PR DESCRIPTION
Trying to manipulate and save objects from one thread in another will cause sqlalchemy session exceptions. This brings it back to the original method of modifying the price object in another thread, but committing it in the main thread, avoiding the issues.

Will have to look for a better way later (not really supposed to share session objects at all with other threads), but this should work in the interim. 

Should resolve #1151, #1148, #1146, #1145