### PR TITLE
Fix a bunch of item swapping mechanisms

### DIFF
--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -233,7 +233,7 @@ class FittingView(d.Display):
     def startDrag(self, event):
         row = event.GetIndex()
 
-        if row != -1 and row not in self.blanks:
+        if row != -1 and row not in self.blanks and isinstance(self.mods[row], Module) and not self.mods[row].isEmpty:
             data = wx.PyTextDataObject()
             data.SetText("fitting:" + str(self.mods[row].modPosition))
 
@@ -330,11 +330,14 @@ class FittingView(d.Display):
                     modules = []
                     sel = self.GetFirstSelected()
                     while sel != -1 and sel not in self.blanks:
-                        modules.append(self.mods[self.GetItemData(sel)])
+                        mod = self.mods[self.GetItemData(sel)]
+                        if isinstance(mod, Module) and not mod.isEmpty:
+                            modules.append(self.mods[self.GetItemData(sel)])
                         sel = self.GetNextSelected(sel)
 
-                    sFit.setAmmo(fitID, itemID, modules)
-                    wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
+                    if len(modules) > 0:
+                        sFit.setAmmo(fitID, itemID, modules)
+                        wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
                 else:
                     populate = sFit.appendModule(fitID, itemID)
                     if populate is not None:
@@ -375,6 +378,10 @@ class FittingView(d.Display):
         if dstRow != -1 and dstRow not in self.blanks:
             sFit = Fit.getInstance()
             fitID = self.mainFrame.getActiveFit()
+            mod = self.mods[dstRow]
+            if not isinstance(mod, Module):  # make sure we're not adding something to a T3D Mode
+                return
+
             moduleChanged = sFit.changeModule(fitID, self.mods[dstRow].modPosition, srcIdx)
             if moduleChanged is None:
                 # the new module doesn't fit in specified slot, try to simply append it
@@ -389,6 +396,9 @@ class FittingView(d.Display):
         dstRow, _ = self.HitTest((x, y))
         if dstRow != -1 and dstRow not in self.blanks:
             module = self.mods[dstRow]
+
+            if not isinstance(module, Module):
+                return
 
             sFit = Fit.getInstance()
             fit = sFit.getFit(self.activeFitID)
@@ -416,6 +426,9 @@ class FittingView(d.Display):
 
             mod1 = fit.modules[srcIdx]
             mod2 = self.mods[dstRow]
+
+            if not isinstance(mod2, Module):
+                return
 
             # can't swap modules to different racks
             if mod1.slot != mod2.slot:

--- a/service/fit.py
+++ b/service/fit.py
@@ -567,13 +567,22 @@ class Fit(object):
         return numSlots != len(fit.modules)
 
     def changeModule(self, fitID, position, newItemID):
-        pyfalog.debug("Changing position of module from position ({0}) for fit ID: {1}", position, fitID)
         fit = eos.db.getFit(fitID)
+
+        # We're trying to add a charge to a slot, which won't work. Instead, try to add the charge to the module in that slot.
+        if self.isAmmo(newItemID):
+            module = fit.modules[position]
+            if not module.isEmpty:
+                self.setAmmo(fitID, newItemID, [module])
+            return True
+
+        pyfalog.debug("Changing position of module from position ({0}) for fit ID: {1}", position, fitID)
+
+        item = eos.db.getItem(newItemID, eager=("attributes", "group.category"))
 
         # Dummy it out in case the next bit fails
         fit.modules.toDummy(position)
 
-        item = eos.db.getItem(newItemID, eager=("attributes", "group.category"))
         try:
             m = es_Module(item)
         except ValueError:
@@ -606,11 +615,19 @@ class Fit(object):
         sanity checks as opposed to the GUI View. This is different than how the
         normal .swapModules() does things, which is mostly a blind swap.
         """
-        pyfalog.debug("Moving cargo item to module for fit ID: {1}", fitID)
-        fit = eos.db.getFit(fitID)
 
+        fit = eos.db.getFit(fitID)
         module = fit.modules[moduleIdx]
         cargo = fit.cargo[cargoIdx]
+
+        # We're trying to move a charge from cargo to a slot - try to add charge to dst module. Don't do anything with
+        # the charge in the cargo (don't respect move vs copy)
+        if self.isAmmo(cargo.item.ID):
+            if not module.isEmpty:
+                self.setAmmo(fitID, cargo.item.ID, [module])
+            return
+
+        pyfalog.debug("Moving cargo item to module for fit ID: {1}", fitID)
 
         # Gather modules and convert Cargo item to Module, silently return if not a module
         try:


### PR DESCRIPTION
Lots of little issues that have built up over the years that were previously hidden due to silent errors (dragging blank module somewhere, dragging module from market to T3D Mode, dragging charge from cargo to module not working, etc). Tested as many combinations as I could think of, seems to work better now. Need to implement a better way to handle these things in the future, but for now this fixes things.

Possible fix for #1186