### PR TITLE
Pricing pane 1158

### DIFF
--- a/gui/builtinContextMenus/priceOptions.py
+++ b/gui/builtinContextMenus/priceOptions.py
@@ -11,6 +11,7 @@ class PriceOptions(ContextMenu):
     def __init__(self):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.settings = PriceMenuSettings.getInstance()
+        self.optionList = ["Ship", "Modules", "Drones", "Cargo", "Character"]
 
     def display(self, srcContext, selection):
         return srcContext in ("priceViewFull", "priceViewMinimal")
@@ -33,16 +34,16 @@ class PriceOptions(ContextMenu):
 
         sub = wx.Menu()
 
-        for option in self.settings.PriceMenuDefaultSettings.info:
+        for option in self.optionList:
             menuItem = self.addOption(rootMenu if msw else sub, option)
             sub.AppendItem(menuItem)
-            menuItem.Check(self.settings.get(option))
+            menuItem.Check(self.settings.get(option.lower()))
 
         return sub
 
     def handleMode(self, event):
         option = self.optionIds[event.Id]
-        self.settings.set(option, event.Int)
+        self.settings.set(option.lower(), event.Int)
 
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.mainFrame.getActiveFit()))
 

--- a/gui/builtinContextMenus/priceOptions.py
+++ b/gui/builtinContextMenus/priceOptions.py
@@ -1,0 +1,49 @@
+from gui.contextMenu import ContextMenu
+import gui.mainFrame
+# noinspection PyPackageRequirements
+import wx
+import gui.globalEvents as GE
+from service.price import Price
+from service.settings import ContextMenuSettings, PriceMenuSettings
+
+
+class PriceOptions(ContextMenu):
+    def __init__(self):
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self.settings = PriceMenuSettings.getInstance()
+
+    def display(self, srcContext, selection):
+        return srcContext in ("priceViewFull", "priceViewMinimal")
+
+    def getText(self, itmContext, selection):
+        return "Include in total"
+
+    def addOption(self, menu, option):
+        label = option
+        id = ContextMenu.nextID()
+        self.optionIds[id] = option
+        menuItem = wx.MenuItem(menu, id, label, kind=wx.ITEM_CHECK)
+        menu.Bind(wx.EVT_MENU, self.handleMode, menuItem)
+        return menuItem
+
+    def getSubMenu(self, context, selection, rootMenu, i, pitem):
+        msw = True if "wxMSW" in wx.PlatformInfo else False
+        self.context = context
+        self.optionIds = {}
+
+        sub = wx.Menu()
+
+        for option in self.settings.PriceMenuDefaultSettings.info:
+            menuItem = self.addOption(rootMenu if msw else sub, option)
+            sub.AppendItem(menuItem)
+            menuItem.Check(self.settings.get(option))
+
+        return sub
+
+    def handleMode(self, event):
+        option = self.optionIds[event.Id]
+        self.settings.set(option, event.Int)
+
+        wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.mainFrame.getActiveFit()))
+
+PriceOptions.register()

--- a/gui/builtinContextMenus/priceOptions.py
+++ b/gui/builtinContextMenus/priceOptions.py
@@ -1,10 +1,9 @@
-from gui.contextMenu import ContextMenu
-import gui.mainFrame
-# noinspection PyPackageRequirements
 import wx
+
 import gui.globalEvents as GE
-from service.price import Price
-from service.settings import ContextMenuSettings, PriceMenuSettings
+import gui.mainFrame
+from gui.contextMenu import ContextMenu
+from service.settings import PriceMenuSettings
 
 
 class PriceOptions(ContextMenu):
@@ -46,5 +45,6 @@ class PriceOptions(ContextMenu):
         self.settings.set(option.lower(), event.Int)
 
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.mainFrame.getActiveFit()))
+
 
 PriceOptions.register()

--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -19,8 +19,9 @@
 
 # noinspection PyPackageRequirements
 import wx
-from gui.statsView import StatsView
+
 from gui.bitmapLoader import BitmapLoader
+from gui.statsView import StatsView
 from gui.utils.numberFormatter import formatAmount
 from service.price import Price
 from service.settings import PriceMenuSettings
@@ -131,13 +132,13 @@ class PriceViewFull(StatsView):
 
         if (self.settings.get("ship")):
             total_price += ship_price
-        if(self.settings.get("modules")):
+        if (self.settings.get("modules")):
             total_price += module_price
-        if(self.settings.get("drones")):
+        if (self.settings.get("drones")):
             total_price += drone_price + fighter_price
-        if(self.settings.get("cargo")):
+        if (self.settings.get("cargo")):
             total_price += cargo_price
-        if(self.settings.get("character")):
+        if (self.settings.get("character")):
             total_price += booster_price + implant_price
 
         self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))
@@ -155,10 +156,9 @@ class PriceViewFull(StatsView):
         self.labelPriceCargobay.SetLabel("%s ISK" % formatAmount(cargo_price, 3, 3, 9, currency=True))
         self.labelPriceCargobay.SetToolTip(wx.ToolTip('{:,.2f}'.format(cargo_price)))
 
-        self.labelPriceCharacter.SetLabel("%s ISK" % formatAmount(booster_price + implant_price, 3, 3, 9, currency=True))
+        self.labelPriceCharacter.SetLabel(
+            "%s ISK" % formatAmount(booster_price + implant_price, 3, 3, 9, currency=True))
         self.labelPriceCharacter.SetToolTip(wx.ToolTip('{:,.2f}'.format(booster_price + implant_price)))
-
-
 
     def processPrices(self, prices):
         self.refreshPanelPrices(self.fit)

--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -23,6 +23,7 @@ from gui.statsView import StatsView
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
 from service.price import Price
+from service.settings import PriceMenuSettings
 
 
 class PriceViewFull(StatsView):
@@ -31,6 +32,7 @@ class PriceViewFull(StatsView):
     def __init__(self, parent):
         StatsView.__init__(self)
         self.parent = parent
+        self.settings = PriceMenuSettings.getInstance()
 
     def getHeaderText(self, fit):
         return "Price"
@@ -49,7 +51,7 @@ class PriceViewFull(StatsView):
 
         gridPrice = wx.GridSizer(2, 3)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for _type in ("ship", "fittings", "drones", "cargoBay", "character", "total"):
+        for _type in ("ship", "fittings", "total", "drones", "cargoBay", "character"):
             if _type in "ship":
                 image = "ship_big"
             elif _type in ("fittings", "total"):
@@ -125,14 +127,27 @@ class PriceViewFull(StatsView):
                 for implant in fit.implants:
                     implant_price += implant.item.price.price
 
-        fitting_price = module_price + drone_price + fighter_price + cargo_price + booster_price + implant_price
-        total_price = ship_price + fitting_price
+        total_price = 0
+
+        if (self.settings.get("ship")):
+            total_price += ship_price
+        if(self.settings.get("modules")):
+            total_price += module_price
+        if(self.settings.get("drones")):
+            total_price += drone_price + fighter_price
+        if(self.settings.get("cargo")):
+            total_price += cargo_price
+        if(self.settings.get("character")):
+            total_price += booster_price + implant_price
 
         self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))
         self.labelPriceShip.SetToolTip(wx.ToolTip('{:,.2f}'.format(ship_price)))
 
         self.labelPriceFittings.SetLabel("%s ISK" % formatAmount(module_price, 3, 3, 9, currency=True))
         self.labelPriceFittings.SetToolTip(wx.ToolTip('{:,.2f}'.format(module_price)))
+
+        self.labelPriceTotal.SetLabel("%s ISK" % formatAmount(total_price, 3, 3, 9, currency=True))
+        self.labelPriceTotal.SetToolTip(wx.ToolTip('{:,.2f}'.format(total_price)))
 
         self.labelPriceDrones.SetLabel("%s ISK" % formatAmount(drone_price + fighter_price, 3, 3, 9, currency=True))
         self.labelPriceDrones.SetToolTip(wx.ToolTip('{:,.2f}'.format(drone_price + fighter_price)))
@@ -143,8 +158,7 @@ class PriceViewFull(StatsView):
         self.labelPriceCharacter.SetLabel("%s ISK" % formatAmount(booster_price + implant_price, 3, 3, 9, currency=True))
         self.labelPriceCharacter.SetToolTip(wx.ToolTip('{:,.2f}'.format(booster_price + implant_price)))
 
-        self.labelPriceTotal.SetLabel("%s ISK" % formatAmount(total_price, 3, 3, 9, currency=True))
-        self.labelPriceTotal.SetToolTip(wx.ToolTip('{:,.2f}'.format(total_price)))
+
 
     def processPrices(self, prices):
         self.refreshPanelPrices(self.fit)

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -127,19 +127,14 @@ class PriceViewMinimal(StatsView):
 
         if (self.settings.get("ship")):
             total_price += ship_price
-        if(self.settings.get("modules")):
+        if (self.settings.get("modules")):
             total_price += module_price
-        if(self.settings.get("drones")):
+        if (self.settings.get("drones")):
             total_price += drone_price + fighter_price
-        if(self.settings.get("cargo")):
+        if (self.settings.get("cargo")):
             total_price += cargo_price
-        if(self.settings.get("character")):
+        if (self.settings.get("character")):
             total_price += booster_price + implant_price
-
-
-
-
-        total_price = ship_price + fitting_price
 
         self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))
         self.labelPriceShip.SetToolTip(wx.ToolTip('{:,.2f}'.format(ship_price)))

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -23,6 +23,7 @@ from gui.statsView import StatsView
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
 from service.price import Price
+from service.settings import PriceMenuSettings
 
 
 class PriceViewMinimal(StatsView):
@@ -31,6 +32,7 @@ class PriceViewMinimal(StatsView):
     def __init__(self, parent):
         StatsView.__init__(self)
         self.parent = parent
+        self.settings = PriceMenuSettings.getInstance()
 
     def getHeaderText(self, fit):
         return "Price"
@@ -119,7 +121,24 @@ class PriceViewMinimal(StatsView):
                 for implant in fit.implants:
                     implant_price += implant.item.price.price
 
-        fitting_price = module_price + drone_price + fighter_price + cargo_price + booster_price + implant_price
+        fitting_price = module_price
+
+        total_price = 0
+
+        if (self.settings.get("ship")):
+            total_price += ship_price
+        if(self.settings.get("modules")):
+            total_price += module_price
+        if(self.settings.get("drones")):
+            total_price += drone_price + fighter_price
+        if(self.settings.get("cargo")):
+            total_price += cargo_price
+        if(self.settings.get("character")):
+            total_price += booster_price + implant_price
+
+
+
+
         total_price = ship_price + fitting_price
 
         self.labelPriceShip.SetLabel("%s ISK" % formatAmount(ship_price, 3, 3, 9, currency=True))

--- a/gui/contextMenu.py
+++ b/gui/contextMenu.py
@@ -199,6 +199,7 @@ from gui.builtinContextMenus import (  # noqa: E402,F401
     tacticalMode,
     targetResists,
     priceClear,
+    priceOptions,
     amount,
     cargoAmmo,
     droneStack,

--- a/service/settings.py
+++ b/service/settings.py
@@ -421,6 +421,38 @@ class StatViewSettings(object):
         self.serviceStatViewDefaultSettings[type] = value
 
 
+class PriceMenuSettings(object):
+    _instance = None
+
+    @classmethod
+    def getInstance(cls):
+        if cls._instance is None:
+            cls._instance = PriceMenuSettings()
+
+        return cls._instance
+
+    def __init__(self):
+        # mode
+        # 0 - Do not add to total
+        # 1 - Add to total
+        PriceMenuDefaultSettings = {
+            "ship" : 1,
+            "modules" : 1,
+            "drones" : 0,
+            "cargo" : 0,
+            "character" : 0
+        }
+
+        self.PriceMenuDefaultSettings = SettingsProvider.getInstance().getSettings("pyfaPriceMenuSettings",
+                                                                                     PriceMenuDefaultSettings)
+
+    def get(self, type):
+        return self.PriceMenuDefaultSettings[type]
+
+    def set(self, type, value):
+        self.PriceMenuDefaultSettings[type] = value
+
+
 class ContextMenuSettings(object):
     _instance = None
 


### PR DESCRIPTION
I have gone with the context menu solution to set options.
I have a list of labels in the ContextMenu definition, but I'm not sure this is the right way/right place. I put it there to always have the list in the same order.

I haven't used the bitmask thing yet but I could, as you wish.

The full pane looks self-explaining to me, but the minimal could benefit from a breakdown in a tooltip.
I also grouped price options as they were grouped in the pane (implants are grouped with boosters).