### PR TITLE
updated drag and drop behavior to not trigger a suspected wx bug on Mac

### DIFF
--- a/gui/boosterView.py
+++ b/gui/boosterView.py
@@ -37,7 +37,8 @@ class BoosterViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 

--- a/gui/boosterView.py
+++ b/gui/boosterView.py
@@ -24,6 +24,7 @@ import gui.globalEvents as GE
 import gui.marketBrowser as marketBrowser
 from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 
 

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -113,7 +113,7 @@ class FittingViewDrop(wx.PyDropTarget):
     def OnData(self, x, y, t):
         if self.GetData():
             dragged_data = DragDropHelper.data
-            #pyfalog.debug("fittingView: recieved drag: " + self.dropData.GetText())
+            # pyfalog.debug("fittingView: recieved drag: " + self.dropData.GetText())
             data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -38,6 +38,8 @@ from gui.chromeTabs import EVT_NOTEBOOK_PAGE_CHANGED
 from service.fit import Fit
 from service.market import Market
 
+from gui.utils.staticHelpers import DragDropHelper
+
 import gui.globalEvents as GE
 
 pyfalog = Logger(__name__)
@@ -110,8 +112,9 @@ class FittingViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            pyfalog.debug("fittingView: recieved drag: " + self.dropData.GetText())
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            #pyfalog.debug("fittingView: recieved drag: " + self.dropData.GetText())
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -235,10 +238,12 @@ class FittingView(d.Display):
 
         if row != -1 and row not in self.blanks and isinstance(self.mods[row], Module) and not self.mods[row].isEmpty:
             data = wx.PyTextDataObject()
-            data.SetText("fitting:" + str(self.mods[row].modPosition))
+            dataStr = "fitting:" + str(self.mods[row].modPosition)
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def getSelectedMods(self):

--- a/gui/cargoView.py
+++ b/gui/cargoView.py
@@ -23,6 +23,7 @@ import gui.display as d
 from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
 import globalEvents as GE
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from service.market import Market
 
@@ -37,7 +38,8 @@ class CargoViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -87,10 +89,12 @@ class CargoView(d.Display):
 
         if row != -1:
             data = wx.PyTextDataObject()
-            data.SetText("cargo:" + str(row))
+            dataStr = "cargo:" + str(row)
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def kbEvent(self, event):

--- a/gui/commandView.py
+++ b/gui/commandView.py
@@ -26,6 +26,7 @@ import gui.droneView
 from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
 from gui.builtinContextMenus.commandFits import CommandFits
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from eos.saveddata.drone import Drone as es_Drone
 
@@ -51,7 +52,8 @@ class CommandViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -116,10 +118,12 @@ class CommandView(d.Display):
         row = event.GetIndex()
         if row != -1 and isinstance(self.get(row), es_Drone):
             data = wx.PyTextDataObject()
-            data.SetText("command:" + str(self.GetItemData(row)))
+            dataStr = "command:" + str(self.GetItemData(row))
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     @staticmethod

--- a/gui/droneView.py
+++ b/gui/droneView.py
@@ -25,6 +25,7 @@ from gui.marketBrowser import ITEM_SELECTED, ItemSelected
 from gui.display import Display
 from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from service.market import Market
 
@@ -39,7 +40,8 @@ class DroneViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -122,10 +124,12 @@ class DroneView(Display):
         row = event.GetIndex()
         if row != -1:
             data = wx.PyTextDataObject()
-            data.SetText("drone:" + str(row))
+            dataStr = "drone:" + str(row)
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def handleDragDrop(self, x, y, data):

--- a/gui/fighterView.py
+++ b/gui/fighterView.py
@@ -27,6 +27,7 @@ import gui.display as d
 from gui.builtinViewColumns.state import State
 from eos.saveddata.module import Slot
 from gui.contextMenu import ContextMenu
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from service.market import Market
 
@@ -41,7 +42,8 @@ class FighterViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -184,10 +186,12 @@ class FighterDisplay(d.Display):
         row = event.GetIndex()
         if row != -1:
             data = wx.PyTextDataObject()
-            data.SetText("fighter:" + str(row))
+            dataStr = "fighter:" + str(row)
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def handleDragDrop(self, x, y, data):

--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -28,6 +28,7 @@ from gui.cachingImageList import CachingImageList
 from gui.contextMenu import ContextMenu
 from gui.bitmapLoader import BitmapLoader
 from logbook import Logger
+from utils.staticHelpers import DragDropHelper
 
 pyfalog = Logger(__name__)
 
@@ -285,6 +286,7 @@ class ItemView(Display):
             data.SetText(dataStr)
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def itemActivated(self, event=None):

--- a/gui/projectedView.py
+++ b/gui/projectedView.py
@@ -24,6 +24,7 @@ import gui.globalEvents as GE
 import gui.droneView
 from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
+from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from service.market import Market
 from eos.saveddata.drone import Drone as es_Drone
@@ -52,7 +53,8 @@ class ProjectedViewDrop(wx.PyDropTarget):
 
     def OnData(self, x, y, t):
         if self.GetData():
-            data = self.dropData.GetText().split(':')
+            dragged_data = DragDropHelper.data
+            data = dragged_data.split(':')
             self.dropFn(x, y, data)
         return t
 
@@ -127,10 +129,12 @@ class ProjectedView(d.Display):
         row = event.GetIndex()
         if row != -1 and isinstance(self.get(row), es_Drone):
             data = wx.PyTextDataObject()
-            data.SetText("projected:" + str(self.GetItemData(row)))
+            dataStr = "projected:" + str(self.GetItemData(row))
+            data.SetText(dataStr)
 
             dropSource = wx.DropSource(self)
             dropSource.SetData(data)
+            DragDropHelper.data = dataStr
             dropSource.DoDragDrop()
 
     def mergeDrones(self, x, y, itemID):

--- a/gui/utils/staticHelpers.py
+++ b/gui/utils/staticHelpers.py
@@ -1,0 +1,5 @@
+class DragDropHelper:
+    data = None
+
+    def __init__(self):
+        pass


### PR DESCRIPTION
This patch addresses #1149 

I believe that wx 3.x for newer Mac operating systems has a memory buffer error allowing garbage data to be passed around through wx gui event handlers, resulting in a critical error that makes the Mac client unusable without a restart

I shortcut this problem by avoiding the wx-provided event handler data variable by using a simple python static variable, and apply the fix where I could find similarly implemented DragAndDrop events

I will note that this implementation is both quick and dirty, as my goal here was to influence the code base as little as possible. So I even leave in a conditional check `if self.GetData():` which is a call to a inherited wx function, because I did not want to make any assumptions about what this code was actually doing.

Therefore, you will notice where I assign this static variable, I am still allowing the data to also be assigned to the wx object, as to avoid the chances of causing an unintentional regression in behavior.

I leave the task of studying the functionality of `GetData()` and determining if it, and the related code, should be replaced to the maintainers of Pyfa.

This patch has received limited testing on the latest public version of Mac OS as of the date of this PR, only to confirm that the issue in question no longer occurs. No other testing has been conducted.