### PR TITLE
Fix for #1193 - compounded bonuses during recursive command / projected fittings

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -425,7 +425,7 @@ class Fit(object):
         self.__capUsed = None
         self.__capRecharge = None
         self.ecmProjectedStr = 1
-        self.commandBonuses = {}
+        #self.commandBonuses = {}
 
         for remoterep_type in self.__remoteReps:
             self.__remoteReps[remoterep_type] = None
@@ -711,8 +711,6 @@ class Fit(object):
                 # apparently this is a thing that happens when removing a command fit from a fit and then switching to
                 # that command fit. Same as projected clears, figure out why.
                 if value.boosted_fit:
-                    if value.boosted_fit in self.commandFits: # recursion, need to clear manually
-                        value.boosted_fit.clear()
                     value.boosted_fit.__resetDependentCalcs()
 
         if targetFit and type == CalcType.PROJECTED:
@@ -754,6 +752,7 @@ class Fit(object):
 
         if not self.__calculated:
             pyfalog.info("Fit is not yet calculated; will be running local calcs for {}".format(repr(self)))
+            self.clear()
 
         # Loop through our run times here. These determine which effects are run in which order.
         for runTime in ("early", "normal", "late"):
@@ -808,7 +807,7 @@ class Fit(object):
                 self.__runProjectionEffects(runTime, targetFit, projectionInfo)
 
         # Recursive command ships (A <-> B) get marked as calculated, which means that they aren't recalced when changing
-        # tabs. See GH issue
+        # tabs. See GH issue 1193
         if type == CalcType.COMMAND and targetFit in self.commandFits:
             pyfalog.debug("{} is in the command listing for COMMAND ({}), do not mark self as calculated (recursive)".format(repr(targetFit), repr(self)))
         else:

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -403,11 +403,12 @@ class Fit(object):
         }
 
         if not map[key](val):
+
             raise ValueError(str(val) + " is not a valid value for " + key)
         else:
             return val
 
-    def clear(self, projected=False):
+    def clear(self, projected=False, command=False):
         self.__effectiveTank = None
         self.__weaponDPS = None
         self.__minerYield = None
@@ -454,10 +455,15 @@ class Fit(object):
         # If this is the active fit that we are clearing, not a projected fit,
         # then this will run and clear the projected ships and flag the next
         # iteration to skip this part to prevent recursion.
-        if not projected:
-            for stuff in self.projectedFits:
-                if stuff is not None and stuff != self:
-                    stuff.clear(projected=True)
+        # if not projected:
+        #     for stuff in self.projectedFits:
+        #         if stuff is not None and stuff != self:
+        #             stuff.clear(projected=True)
+        #
+        # if not command:
+        #     for stuff in self.commandFits:
+        #         if stuff is not None and stuff != self:
+        #             stuff.clear(command=True)
 
     # Methods to register and get the thing currently affecting the fit,
     # so we can correctly map "Affected By"
@@ -688,9 +694,10 @@ class Fit(object):
                 The type of calculation our current iteration is in. This helps us determine the interactions between
                 fits that rely on others for proper calculations
         """
-        pyfalog.debug("Starting fit calculation on: {0}, calc: {1}", repr(self), CalcType.getName(type))
+        pyfalog.warn("Starting fit calculation on: {0}, calc: {1}", repr(self), CalcType.getName(type))
 
         # If we are projecting this fit onto another one, collect the projection info for later use
+
         # We also deal with self-projection here by setting self as a copy (to get a new fit object) to apply onto original fit
         # First and foremost, if we're looking at a local calc, reset the calculated state of fits that this fit affects
         # Thankfully, due to the way projection mechanics currently work, we don't have to traverse down a projection
@@ -714,7 +721,7 @@ class Fit(object):
         # We run the command calculations first so that they can calculate fully and store the command effects on the
         # target fit to be used later on in the calculation. This does not apply when we're already calculating a
         # command fit.
-        if type != CalcType.COMMAND and self.commandFits:
+        if type != CalcType.COMMAND and self.commandFits and not self.__calculated:
             for fit in self.commandFits:
                 commandInfo = fit.getCommandInfo(self.ID)
                 # Continue loop if we're trying to apply ourselves or if this fit isn't active
@@ -742,6 +749,9 @@ class Fit(object):
         if self.__calculated and type == CalcType.LOCAL:
             pyfalog.debug("Fit has already been calculated and is local, returning: {0}", self)
             return
+
+        if not self.__calculated:
+            pyfalog.warn("Running local calcs for {}".format(repr(self)))
 
         # Loop through our run times here. These determine which effects are run in which order.
         for runTime in ("early", "normal", "late"):

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -425,7 +425,7 @@ class Fit(object):
         self.__capUsed = None
         self.__capRecharge = None
         self.ecmProjectedStr = 1
-        #self.commandBonuses = {}
+        # self.commandBonuses = {}
 
         for remoterep_type in self.__remoteReps:
             self.__remoteReps[remoterep_type] = None


### PR DESCRIPTION
The problem was the fact that pyfa didn't `clear()` previous results, so it calculated values on top of already calculated values. I have a feeling this was also broken in previous releases since command fits weren't included in the `clear()` like projected fits were (though I haven't tested that theory), and the new fit calculated flag probably made the problem more apparent.

Speaking of `clear()`, we no longer `clear()` projected and command fits in the base `clear()` for hopes of performance boosts. If Fit B projects onto Fit A, and we change Fit A, we shouldn't have to clear (and thus recalculate) Fit B - values under that fitting should remain static until either it has changed, or something that it depends on has changed (via `__resetDependentCalcs()`).

This seems to work in the tests that I've tried. Will try to write up actual automated tests for these situations soon. If pyfa continues to have problems such as this, we can always revert back to how things were handled (recalc everything all the time)