### PR TITLE
Fix issue with fit deletion

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,8 +19,8 @@ debug = False
 saveInRoot = False
 
 # Version data
-version = "1.29.3"
-tag = "Stable"
+version = "1.29.4"
+tag = "git"
 expansionName = "YC119.5"
 expansionVersion = "1.0"
 evemonMinVersion = "4081"

--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -17,6 +17,8 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
+import sys
+
 from sqlalchemy.sql import and_
 from sqlalchemy import desc, select
 
@@ -539,5 +541,10 @@ def remove(stuff):
 
 def commit():
     with sd_lock:
-        saveddata_session.commit()
-        saveddata_session.flush()
+        try:
+            saveddata_session.commit()
+            saveddata_session.flush()
+        except Exception:
+            saveddata_session.rollback()
+            exc_info = sys.exc_info()
+            raise exc_info[0], exc_info[1], exc_info[2]

--- a/service/fit.py
+++ b/service/fit.py
@@ -185,7 +185,7 @@ class Fit(object):
             if booster.boosted_fit != fit and booster.boosted_fit in eos.db.saveddata_session:  # GH issue #359
                 refreshFits.add(booster.boosted_fit)
 
-        eos.db.saveddata_session.delete(fit)
+        eos.db.remove(fit)
 
         pyfalog.debug("    Need to refresh {} fits: {}", len(refreshFits), refreshFits)
         for fit in refreshFits:


### PR DESCRIPTION
Also includes a fix for our commits. When a commit dies for whatever reason, catch the exception, rollback the session, and then raise the exception again so that the user knows something happened. However, rolling back the session allows pyfa to continue on working for things that aren't broke (whereas if we didn't rollback, any session manipulation would be hindered by session errors)