### PR TITLE
Fix loki effects

### DIFF
--- a/eos/effects/subsystembonusminmatardefensive2localrepheat.py
+++ b/eos/effects/subsystembonusminmatardefensive2localrepheat.py
@@ -7,7 +7,9 @@ def handler(fit, src, context):
     fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Repair Systems") or mod.item.requiresSkill("Shield Operation"),
                                   "overloadSelfDurationBonus", src.getModifiedItemAttr("subsystemBonusMinmatarDefensive2"),
                                   skill="Minmatar Defensive Systems")
-    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Repair Systems") or mod.item.requiresSkill("Shield Operation"),
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Repair Systems"),
                                   "overloadArmorDamageAmount", src.getModifiedItemAttr("subsystemBonusMinmatarDefensive2"),
                                   skill="Minmatar Defensive Systems")
-
+    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Shield Operation"),
+                                  "overloadShieldBonus", src.getModifiedItemAttr("subsystemBonusMinmatarDefensive2"),
+                                  skill="Minmatar Defensive Systems")

--- a/eos/effects/subsystembonusminmataroffensive1hmlhamvelo.py
+++ b/eos/effects/subsystembonusminmataroffensive1hmlhamvelo.py
@@ -3,7 +3,7 @@
 # Used by:
 # Subsystem: Loki Offensive - Launcher Efficiency Configuration
 type = "passive"
-def handler(fit, src, context):
-    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Heavy Missiles") or mod.item.requiresSkill("Heavy Assault Missiles"),
-                                  "maxVelocity", src.getModifiedItemAttr("subsystemBonusMinmatarOffensive"),
+def handler(fit, container, context):
+    fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Heavy Missiles") or mod.charge.requiresSkill("Heavy Assault Missiles"),
+                                  "maxVelocity", container.getModifiedItemAttr("subsystemBonusMinmatarOffensive"),
                                   skill="Minmatar Offensive Systems")

--- a/eos/effects/subsystembonusminmataroffensive3missileexpvelo.py
+++ b/eos/effects/subsystembonusminmataroffensive3missileexpvelo.py
@@ -3,7 +3,7 @@
 # Used by:
 # Subsystem: Loki Offensive - Launcher Efficiency Configuration
 type = "passive"
-def handler(fit, src, context):
-    fit.modules.filteredItemBoost(lambda mod: mod.item.requiresSkill("Missile Launcher Operation"),
-                                  "aoeVelocity", src.getModifiedItemAttr("subsystemBonusMinmatarOffensive3"),
+def handler(fit, container, context):
+    fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Missile Launcher Operation"),
+                                  "aoeVelocity", container.getModifiedItemAttr("subsystemBonusMinmatarOffensive3"),
                                   skill="Minmatar Offensive Systems")


### PR DESCRIPTION
Fix effects for loki subsystems:

- defensive subsystem "Adaptive Defense Node" should apply overheat bonus to both shield and armor repair amount bonus
- offensive subsystem "Launcher Efficiency Configuration" should apply missile velocity and missile explosion velocity bonuses to charge instead of launcher.