### PR TITLE
Issue #1261 show variations menu for cargo items

### DIFF
--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -14,6 +14,7 @@ from eos.saveddata.module import Module
 from eos.saveddata.drone import Drone
 from eos.saveddata.fighter import Fighter
 from eos.saveddata.implant import Implant
+from eos.saveddata.cargo import Cargo
 
 
 class MetaSwap(ContextMenu):
@@ -31,6 +32,7 @@ class MetaSwap(ContextMenu):
                 "fighterItem",
                 "boosterItem",
                 "implantItem",
+                "cargoItem",
         ):
             return False
 
@@ -183,6 +185,13 @@ class MetaSwap(ContextMenu):
                     if implant_stack is selected_item:
                         sFit.removeImplant(fitID, idx, False)
                         sFit.addImplant(fitID, item.ID, True)
+                        break
+
+            elif isinstance(selected_item, Cargo):
+                for idx, cargo_stack in enumerate(fit.cargo):
+                    if cargo_stack is selected_item:
+                        sFit.removeCargo(fitID, idx)
+                        sFit.addCargo(fitID, item.ID, cargo_stack.amount, True)
                         break
 
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))


### PR DESCRIPTION
https://github.com/pyfa-org/Pyfa/issues/1261

Added logic to condition statement in metaSwap.py to accommodate cargoItem context. Will replace existing cargo item with selected item and retain the original stack amount.

Seems like a fairly useful feature and I didn't realize how much I wanted it until I read the ticket. Tested on Windows 7, unable to test on any other platforms.

Screenshot:

![cargo_metaswap](https://user-images.githubusercontent.com/6990224/28756795-7c2e1204-756d-11e7-93a5-991cac87ac70.png)