### PR TITLE
Amounts window crashes pyfa if you paste with characters

### DIFF
--- a/gui/builtinContextMenus/amount.py
+++ b/gui/builtinContextMenus/amount.py
@@ -4,6 +4,7 @@ import gui.mainFrame
 import gui.globalEvents as GE
 # noinspection PyPackageRequirements
 import wx
+import re
 from service.fit import Fit
 from eos.saveddata.cargo import Cargo as es_Cargo
 from eos.saveddata.fighter import Fighter as es_Fighter
@@ -61,15 +62,16 @@ class AmountChanger(wx.Dialog):
             return
 
         sFit = Fit.getInstance()
+        cleanInput = re.sub(r'[^0-9]', '', self.input.GetLineText(0).strip())
         mainFrame = gui.mainFrame.MainFrame.getInstance()
         fitID = mainFrame.getActiveFit()
 
         if isinstance(self.thing, es_Cargo):
-            sFit.addCargo(fitID, self.thing.item.ID, int(float(self.input.GetLineText(0))), replace=True)
+            sFit.addCargo(fitID, self.thing.item.ID, int(float(cleanInput)), replace=True)
         elif isinstance(self.thing, es_Fit):
-            sFit.changeAmount(fitID, self.thing, int(float(self.input.GetLineText(0))))
+            sFit.changeAmount(fitID, self.thing, int(float(cleanInput)))
         elif isinstance(self.thing, es_Fighter):
-            sFit.changeActiveFighters(fitID, self.thing, int(float(self.input.GetLineText(0))))
+            sFit.changeActiveFighters(fitID, self.thing, int(float(cleanInput)))
 
         wx.PostEvent(mainFrame, GE.FitChanged(fitID=fitID))
 


### PR DESCRIPTION
- Most common case would be copying from calculator, which shows commas for formatting