### PR TITLE
Issue #1241 Bind contextHandler to children of contentPanel

### DIFF
--- a/gui/builtinStatsViews/miningyieldViewFull.py
+++ b/gui/builtinStatsViews/miningyieldViewFull.py
@@ -122,6 +122,8 @@ class MiningYieldViewFull(StatsView):
         self.parent.views.append(view)
         # Get the TogglePanel
         tp = self.panel.GetParent()
+        # Bind the new panel's children to allow context menu access
+        self.parent.applyBinding(self.parent, tp.GetContentPane())        
         tp.SetLabel(view.getHeaderText(fit))
         view.refreshPanel(fit)
 

--- a/gui/statsPane.py
+++ b/gui/statsPane.py
@@ -113,7 +113,7 @@ class StatsPane(wx.Panel):
             view.populatePanel(contentPanel, headerPanel)
             tp.SetLabel(view.getHeaderText(None))
             view.refreshPanel(None)
-
+            
             contentPanel.Bind(wx.EVT_RIGHT_DOWN, self.contextHandler(contentPanel))
             for child in contentPanel.GetChildren():
                 child.Bind(wx.EVT_RIGHT_DOWN, self.contextHandler(contentPanel))
@@ -143,3 +143,10 @@ class StatsPane(wx.Panel):
             event.Skip()
 
         return handler
+
+    @staticmethod
+    def applyBinding(self, contentPanel):
+        pyfalog.debug("Attempt applyBinding to children of {0}", contentPanel.viewName)
+        for child in contentPanel.GetChildren():
+            child.Bind(wx.EVT_RIGHT_DOWN, self.contextHandler(contentPanel))        
+     


### PR DESCRIPTION
Changes to statsPane.py:
Added new method applyBinding which loops through all the children
of the contentPanel passed to it and binds contextHandler to each of them

Changes to miningyieldViewFull.py:
Call to new method applyBinding

---

#1241  

It looks like the child elements were never having any binding applied to them so I have created a new method to do this. 

There still appears to be an issue with the miningyieldViewFull panel displaying the context menu for firepowerViewFull but I believe that this is because binding occurs on the panel at load time when statsPane.py runs for all of the views. We would probably need something to remove the binding from this panel when it is toggled onto.

I'm not really an expert though, what do you think @blitzmann ?

I have built and tested this fix on Windows 7 but don't have access to test on any other platforms.