### PR TITLE
Issue #1264 Don't attempt PopupMenu if getMenu returned False

### DIFF
--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -659,7 +659,11 @@ class ImplantEditorView(BaseImplantEditorView):
         # fuck good coding practices, passing a pointer to the character editor here for [reasons] =D
         # (see implantSets context class for info)
         menu = ContextMenu.getMenu((self.Parent.Parent,), *context)
-        self.PopupMenu(menu)
+
+        if menu:
+            self.PopupMenu(menu)
+        else:
+            pyfalog.debug("ContextMenu.getMenu returned false do not attempt PopupMenu")
 
     def determineEnabled(self):
         char = self.Parent.Parent.entityEditor.getActiveEntity()


### PR DESCRIPTION
Change to characterEditor.py:
Added logic to prevent a crash when attempting to execute
self.PopupMenu(menu) when menu was False. This would occur in the
situation where there were no saved implant sets.

---

#1264 

Fixed a scenario where spawnMenu in characterEditor.py was attempting to create a list of implant sets even when the list of implant sets contained no items which resulted in a crash. 

The new behavior if there are no implant sets is to do nothing. I've put a trace in there but that might be unnecessary and could be removed.

I have built and tested this fix on Windows 7 but don't have access to test on any other platforms.