### PR TITLE
Convert booster attribute to value before applying

### DIFF
--- a/eos/effects/boostermissilevelocitypenalty.py
+++ b/eos/effects/boostermissilevelocitypenalty.py
@@ -14,4 +14,4 @@ attr = "boosterMissileVelocityPenalty"
 
 def handler(fit, booster, context):
     fit.modules.filteredChargeBoost(lambda mod: mod.charge.requiresSkill("Missile Launcher Operation"),
-                                    "maxVelocity", attr)
+                                    "maxVelocity", booster.getModifiedItemAttr(attr))


### PR DESCRIPTION
Changes to boostermissilevelocitypenalty.py:
Get booster attribute value using booster.getModifiedItemAttr()
before attempting to apply it to avoid type error

---

#1280 

Previously we were not getting the booster attribute value and were instead attempting to apply to the attribute name as the value, which was causing a type error.

I have built and tested this fix on Windows 7 but don't have access to test on any other platforms.