### PR TITLE
Change how skillsMap is generated

### DIFF
--- a/gui/characterSelection.py
+++ b/gui/characterSelection.py
@@ -108,16 +108,10 @@ class CharacterSelection(wx.Panel):
         charID = self.getActiveCharacter()
         sChar = Character.getInstance()
 
-        skillsMap = {}
-        for item, stuff in self.reqs.iteritems():
-            for things in stuff.values():
-                if things[1] not in skillsMap:
-                    skillsMap[things[1]] = things[0]
-                elif things[0] > skillsMap[things[1]]:
-                    skillsMap[things[1]] = things[0]
+        skillsMap = self._buildSkillsTooltipCondensed(self.reqs, skillsMap={})
 
-        for skillID, level in skillsMap.iteritems():
-            sChar.changeLevel(charID, skillID, level, ifHigher=True)
+        for index in skillsMap:
+            sChar.changeLevel(charID, skillsMap[index][1], skillsMap[index][0], ifHigher=True)
 
         self.refreshCharacterList()
 
@@ -235,7 +229,7 @@ class CharacterSelection(wx.Panel):
                 if condensed:
                     dict_ = self._buildSkillsTooltipCondensed(self.reqs, skillsMap={})
                     for key in sorted(dict_):
-                        tip += "%s: %d\n" % (key, dict_[key])
+                        tip += "%s: %d\n" % (key, dict_[key][0])
                 else:
                     tip += self._buildSkillsTooltip(self.reqs)
                 self.skillReqsStaticBitmap.SetBitmap(self.redSkills)
@@ -257,7 +251,7 @@ class CharacterSelection(wx.Panel):
 
         list = ""
         for key in sorted(skillsMap):
-            list += "%s %d\n" % (key, skillsMap[key])
+            list += "%s %d\n" % (key, skillsMap[key][0])
 
         toClipboard(list)
 
@@ -307,9 +301,9 @@ class CharacterSelection(wx.Panel):
                 })
 
                 if name not in skillsMap:
-                    skillsMap[name] = level
-                elif skillsMap[name] < level:
-                    skillsMap[name] = level
+                    skillsMap[name] = level, ID
+                elif skillsMap[name][0] < level:
+                    skillsMap[name] = level, ID
 
                 skillsMap = self._buildSkillsTooltipCondensed(more, currItem, tabulationLevel + 1, skillsMap)
 


### PR DESCRIPTION
Changes to characterSelection.py:
grantMissingSkills now uses _buildSkillsTooltipCondensed to
generate a list of skills to update
_buildSkillsTooltipCondensed now outputs level and ID rather than
just level so that it can be used by grantMissingSkills
Anything else using _buildSkillsTooltipCondensed like exportSkills
and fitChanged have been amended to extract just the level from
the skills map rather than level and ID

---

#1289 

Granting missing skills (without strict skills set) now always provides the pre-requisite skills because _buildSkillsTooltipCondensed is used to generate the skills map (which contains the requirement skills). This does not appear to have any performance impact compared to the master version which only applied the top level skills and I couldn't really think of any scenario where only applying the top level skills would be beneficial.

If you have the strict skills set in the preferences there appears to be a performance hit because we are changing a large amount of skills from level 0 to unlearned. For example setting spaceship command to level 4 changes all of these skills to unlearned:

16591, 28656, 23950, 37615, 20524, 20526, 20527, 20528, 20532, 28374, 24312, 24311, 24313, 24314, 3344, 3345, 3346, 3347, 24606, 20525, 20530, 20531, 20533, 28374, 34327, 29029, 20342, 28667, 22761, 28609, 28374, 29637, 3327

It might be worth looking at exactly what strict skills is doing to try and reduce the performance impact... but I think this submission resolves the original issue.

