### PR TITLE
[fix] eos - remove Komodo thermalDamage double-dipping

### DIFF
--- a/eos/effects/shipbonustitang2alldamagebonus.py
+++ b/eos/effects/shipbonustitang2alldamagebonus.py
@@ -6,21 +6,15 @@ type = "passive"
 
 
 def handler(fit, src, context):
-    fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("Torpedoes"), "thermalDamage",
-                                  src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("Torpedoes"), "explosiveDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("Torpedoes"), "emDamage",
-                                  src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
-    fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Torpedoes"), "thermalDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Torpedoes"), "emDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Torpedoes"), "explosiveDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Cruise Missiles"), "emDamage",
-                                  src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
-    fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Cruise Missiles"), "thermalDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")
     fit.modules.filteredChargeBoost(lambda mod: mod.item.requiresSkill("XL Cruise Missiles"), "explosiveDamage",
                                   src.getModifiedItemAttr("shipBonusTitanG2"), skill="Gallente Titan")


### PR DESCRIPTION
Addresses erroneous thermal damage double-dipping for Komodo titan as outlined in [#1332](https://github.com/pyfa-org/Pyfa/issues/1332).