### PR TITLE
improved DPS Simulator graph

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,32 @@
+# pyfa-taleden
+
+## Changes In This Fork
+
+The primary purpose of this fork is to introduce a new "DPS Simulator" in the Graph window which functions much like EFT's damage graph:
+
+* Multiple attackers and targets may be graphed simultaneously; plots of DPS by distance are calculated for each pair and rendered on the same axes for easy comparisons.
+* An attacker must be a saved fit; any fit can be dragged onto the Attackers list to add it, and currently opened fits can be added using the right-click context menu on the Attackers list.
+* A target may be either a saved fit or a target profile (previously called "target resists"); target fits can be added in the same ways, but target profiles can only be added by right-click (as there is no good place to drag them from).
+* Attackers and targets can both be removed by double-clicking them in their respective list.
+* Left-click on a line in the plot to select it; that line then becomes thicker and a caption appears to identify the corresponding attacker and target. The line's color can also be changed by clicking on the matching colored box beside the line caption.
+* Right-click on the plot to set a marker at a specific range; each plot will also show an annotation of its exact DPS value at that range.
+* Set attacker and target velocity vectors using the graphical vector widgets above the attacker and target lists; left-click to set to any values, right-click to snap to 15&deg;/5% increments, or mouse wheel to change only the speed (as a percentage of maximum).
+* For target fits, damage resistances can be ignored, calculated only for a specific layer (hull/armor/shield), or weighted by layer hitpoints (the default). Target profiles have only one set of resistances, so they can only be ignored or considered (any other setting).
+
+A few small changes are also made elsewhere to support the new DPS Simulator graph:
+
+* "Target resists" are now called "target profiles" and may optionally specify the target's signature radius and velocity in addition to its damage type resistances.
+* Existing profiles will default to 0 (or blank) for both new values, which will ignore those attributes for applied damage calculations (a signature radius of 0 is treated as infinite).
+* When a target profile is selected in an open fit's Firepower panel, the displayed effective firepower will reflect a "best-case scenario" in which range and transversal are zero, but the target's signature radius is still considered.
+* Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
+* Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.
+
+## Screenshots
+
+![DPS Simulator](https://i.imgur.com/HVwtnba.png)
+
+![Target Profile Editor](https://i.imgur.com/ugKq1Pm.png)
+
+# pyfa-org (upstream)
+
+Refer to (README.md)[https://github.com/taleden/Pyfa/blob/master/README.md] for information about the original upstream project. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.

--- a/README.markdown
+++ b/README.markdown
@@ -29,4 +29,4 @@ A few small changes are also made elsewhere to support the new DPS Simulator gra
 
 # pyfa-org (upstream)
 
-Refer to (README.md)[https://github.com/taleden/Pyfa/blob/master/README.md] for information about the original upstream project. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.
+Refer to [README.md](https://github.com/taleden/Pyfa/blob/master/README.md) for information about the original upstream project. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A few small changes are also made elsewhere to support the new DPS Simulator gra
 * Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
 * Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.
 
+Below, for reference, is upstream's original README in its entirety. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.
+
 # pyfa
 
 [![Join us on Slack!](https://pyfainvite.azurewebsites.net/badge.svg)](https://pyfainvite.azurewebsites.net/) [![Build Status](https://travis-ci.org/pyfa-org/Pyfa.svg?branch=master)](https://travis-ci.org/pyfa-org/Pyfa)

--- a/README.md
+++ b/README.md
@@ -1,36 +1,3 @@
-# pyfa-taleden
-
-## Changes In This Fork
-
-The primary purpose of this fork is to introduce a new "DPS Simulator" in the Graph window which functions much like EFT's damage graph:
-
-* Multiple attackers and targets may be graphed simultaneously; plots of DPS by distance are calculated for each pair and rendered on the same axes for easy comparisons.
-* An attacker must be a saved fit; any fit can be dragged onto the Attackers list to add it, and currently opened fits can be added using the right-click context menu on the Attackers list.
-* A target may be either a saved fit or a target profile (previously called "target resists"); target fits can be added in the same ways, but target profiles can only be added by right-click (as there is no good place to drag them from).
-* Attackers and targets can both be removed by double-clicking them in their respective list.
-* Left-click on a line in the plot to select it; that line then becomes thicker and a caption appears to identify the corresponding attacker and target. The line's color can also be changed by clicking on the matching colored box beside the line caption.
-* Right-click on the plot to set a marker at a specific range; each plot will also show an annotation of its exact DPS value at that range.
-* Set attacker and target velocity vectors using the graphical vector widgets above the attacker and target lists; left-click to set to any values, right-click to snap to 15&deg;/5% increments, or mouse wheel to change only the speed (as a percentage of maximum).
-* For target fits, damage resistances can be ignored, calculated only for a specific layer (hull/armor/shield), or weighted by layer hitpoints (the default). Target profiles have only one set of resistances, so they can only be ignored or considered (any other setting).
-
-A few small changes are also made elsewhere to support the new DPS Simulator graph:
-
-* "Target resists" are now called "target profiles" and may optionally specify the target's signature radius and velocity in addition to its damage type resistances.
-* Existing profiles will default to 0 (or blank) for both new values, which will ignore those attributes for applied damage calculations (a signature radius of 0 is treated as infinite).
-* When a target profile is selected in an open fit's Firepower panel, the displayed effective firepower will reflect a "best-case scenario" in which range and transversal are zero, but the target's signature radius is still considered.
-* Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
-* Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.
-
-## Screenshots
-
-![DPS Simulator](https://i.imgur.com/HVwtnba.png)
-
-![Target Profile Editor](https://i.imgur.com/ugKq1Pm.png)
-
-# pyfa-org (upstream)
-
-Below, for reference, is upstream's original README in its entirety. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.
-
 # pyfa
 
 [![Join us on Slack!](https://pyfainvite.azurewebsites.net/badge.svg)](https://pyfainvite.azurewebsites.net/) [![Build Status](https://travis-ci.org/pyfa-org/Pyfa.svg?branch=master)](https://travis-ci.org/pyfa-org/Pyfa)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ A few small changes are also made elsewhere to support the new DPS Simulator gra
 * Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
 * Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.
 
+## Screenshots
+
+![DPS Simulator](https://i.imgur.com/HVwtnba.png)
+
+![Target Profile Editor](https://i.imgur.com/ugKq1Pm.png)
+
+# pyfa-org (upstream)
+
 Below, for reference, is upstream's original README in its entirety. To test this fork, please refer to the [FAQ](https://github.com/pyfa-org/Pyfa/wiki/FAQ#requirements-for-running-pyfa-from-source) and [Setting Up Development Environment](https://github.com/pyfa-org/Pyfa/wiki/Setting-Up-Development-Environment) for notes on how to run from source.
 
 # pyfa

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+# pyfa-taleden
+
+## Changes In This Fork
+
+The primary purpose of this fork is to introduce a new "DPS Simulator" in the Graph window which functions much like EFT's damage graph:
+
+* Multiple attackers and targets may be graphed simultaneously; plots of DPS by distance are calculated for each pair and rendered on the same axes for easy comparisons.
+* An attacker must be a saved fit; any fit can be dragged onto the Attackers list to add it, and currently opened fits can be added using the right-click context menu on the Attackers list.
+* A target may be either a saved fit or a target profile (previously called "target resists"); target fits can be added in the same ways, but target profiles can only be added by right-click (as there is no good place to drag them from).
+* Attackers and targets can both be removed by double-clicking them in their respective list.
+* Left-click on a line in the plot to select it; that line then becomes thicker and a caption appears to identify the corresponding attacker and target. The line's color can also be changed by clicking on the matching colored box beside the line caption.
+* Right-click on the plot to set a marker at a specific range; each plot will also show an annotation of its exact DPS value at that range.
+* Set attacker and target velocity vectors using the graphical vector widgets above the attacker and target lists; left-click to set to any values, right-click to snap to 15&deg;/5% increments, or mouse wheel to change only the speed (as a percentage of maximum).
+* For target fits, damage resistances can be ignored, calculated only for a specific layer (hull/armor/shield), or weighted by layer hitpoints (the default). Target profiles have only one set of resistances, so they can only be ignored or considered (any other setting).
+
+A few small changes are also made elsewhere to support the new DPS Simulator graph:
+
+* "Target resists" are now called "target profiles" and may optionally specify the target's signature radius and velocity in addition to its damage type resistances.
+* Existing profiles will default to 0 (or blank) for both new values, which will ignore those attributes for applied damage calculations (a signature radius of 0 is treated as infinite).
+* When a target profile is selected in an open fit's Firepower panel, the displayed effective firepower will reflect a "best-case scenario" in which range and transversal are zero, but the target's signature radius is still considered.
+* Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
+* Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.
+
 # pyfa
 
 [![Join us on Slack!](https://pyfainvite.azurewebsites.net/badge.svg)](https://pyfainvite.azurewebsites.net/) [![Build Status](https://travis-ci.org/pyfa-org/Pyfa.svg?branch=master)](https://travis-ci.org/pyfa-org/Pyfa)

--- a/_development/helpers.py
+++ b/_development/helpers.py
@@ -130,6 +130,8 @@ def Saveddata():
     from eos.saveddata.fit import Fit
     from eos.saveddata.character import Character
     from eos.saveddata.module import Module, State
+    from eos.saveddata.drone import Drone
+    from eos.saveddata.fighter import Fighter
     from eos.saveddata.citadel import Citadel
     from eos.saveddata.booster import Booster
 
@@ -139,6 +141,8 @@ def Saveddata():
         'Fit'      : Fit,
         'Character': Character,
         'Module'   : Module,
+        'Drone'    : Drone,
+        'Fighter'  : Fighter,
         'State'    : State,
         'Booster'  : Booster,
     }

--- a/eos/db/migrations/upgrade28.py
+++ b/eos/db/migrations/upgrade28.py
@@ -1,0 +1,14 @@
+"""
+Migration 28
+
+- Adds the signatureRadius and maxVelocity fields to TargetResists
+"""
+import sqlalchemy
+
+
+def upgrade(saveddata_engine):
+    for column in ('signatureRadius','maxVelocity'):
+        try:
+            saveddata_engine.execute("SELECT {} FROM targetResists LIMIT 1;".format(column))
+        except sqlalchemy.exc.DatabaseError:
+            saveddata_engine.execute("ALTER TABLE targetResists ADD COLUMN {} FLOAT;".format(column))

--- a/eos/db/migrations/upgrade28.py
+++ b/eos/db/migrations/upgrade28.py
@@ -7,7 +7,7 @@ import sqlalchemy
 
 
 def upgrade(saveddata_engine):
-    for column in ('signatureRadius','maxVelocity'):
+    for column in ('signatureRadius', 'maxVelocity'):
         try:
             saveddata_engine.execute("SELECT {} FROM targetResists LIMIT 1;".format(column))
         except sqlalchemy.exc.DatabaseError:

--- a/eos/db/saveddata/loadDefaultDatabaseValues.py
+++ b/eos/db/saveddata/loadDefaultDatabaseValues.py
@@ -201,7 +201,6 @@ class DefaultDatabaseValues(object):
                 if update:
                     eos.db.save(resistsProfile)
 
-
     @classmethod
     def importRequiredDefaults(cls):
         damageProfileList = [["Uniform", "25", "25", "25", "25"]]

--- a/eos/db/saveddata/loadDefaultDatabaseValues.py
+++ b/eos/db/saveddata/loadDefaultDatabaseValues.py
@@ -34,8 +34,10 @@ class DefaultDatabaseValues(object):
 
     @classmethod
     def importDamageProfileDefaults(cls):
-        damageProfileList = [["Uniform", "25", "25", "25", "25"], ["[Generic]EM", "100", "0", "0", "0"],
-                             ["[Generic]Thermal", "0", "100", "0", "0"], ["[Generic]Kinetic", "0", "0", "100", "0"],
+        damageProfileList = [["Uniform", "25", "25", "25", "25"],
+                             ["[Generic]EM", "100", "0", "0", "0"],
+                             ["[Generic]Thermal", "0", "100", "0", "0"],
+                             ["[Generic]Kinetic", "0", "0", "100", "0"],
                              ["[Generic]Explosive", "0", "0", "0", "100"],
                              ["[NPC][Asteroid] Blood Raiders", "5067", "4214", "0", "0"],
                              ["[Bombs]Concussion Bomb", "0", "0", "6400", "0"],
@@ -66,8 +68,10 @@ class DefaultDatabaseValues(object):
                              ["[Hybrid Charges]Thorium", "0", "38.4", "48", "0"],
                              ["[Hybrid Charges]Tungsten", "0", "19.2", "38.4", "0"],
                              ["[Hybrid Charges]Uranium", "0", "38.4", "57.6", "0"],
-                             ["[Missiles]Mjolnir", "100", "0", "0", "0"], ["[Missiles]Inferno", "0", "100", "0", "0"],
-                             ["[Missiles]Scourge", "0", "0", "100", "0"], ["[Missiles]Nova", "0", "0", "0", "100"],
+                             ["[Missiles]Mjolnir", "100", "0", "0", "0"],
+                             ["[Missiles]Inferno", "0", "100", "0", "0"],
+                             ["[Missiles]Scourge", "0", "0", "100", "0"],
+                             ["[Missiles]Nova", "0", "0", "0", "100"],
                              ["[Missiles][Structure) Standup Missile", "100", "100", "100", "100"],
                              ["[Projectile Ammo][T2] Tremor", "0", "0", "24", "40"],
                              ["[Projectile Ammo][T2] Quake", "0", "0", "40", "72"],
@@ -179,11 +183,24 @@ class DefaultDatabaseValues(object):
 
         for targetResistProfileRow in targetResistProfileList:
             name, em, therm, kin, exp = targetResistProfileRow
+            sigRes = targetResistProfileRow[5] if len(targetResistProfileRow) > 5 else None
+            maxVel = targetResistProfileRow[6] if len(targetResistProfileRow) > 6 else None
             resistsProfile = eos.db.eos.db.getTargetResists(name)
             if resistsProfile is None:
                 resistsProfile = es_TargetResists(em, therm, kin, exp)
                 resistsProfile.name = name
                 eos.db.save(resistsProfile)
+            else:
+                update = False
+                if sigRes and not resistsProfile.signatureRadius:
+                    resistsProfile.signatureRadius = sigRes
+                    update = True
+                if maxVel and not resistsProfile.maxVelocity:
+                    resistsProfile.maxVelocity = maxVel
+                    update = True
+                if update:
+                    eos.db.save(resistsProfile)
+
 
     @classmethod
     def importRequiredDefaults(cls):

--- a/eos/db/saveddata/targetResists.py
+++ b/eos/db/saveddata/targetResists.py
@@ -33,7 +33,9 @@ targetResists_table = Table("targetResists", saveddata_meta,
                             Column("explosiveAmount", Float),
                             Column("ownerID", ForeignKey("users.ID"), nullable=True),
                             Column("created", DateTime, nullable=True, default=datetime.datetime.now),
-                            Column("modified", DateTime, nullable=True, onupdate=datetime.datetime.now)
+                            Column("modified", DateTime, nullable=True, onupdate=datetime.datetime.now),
+                            Column("signatureRadius", Float),
+                            Column("maxVelocity", Float)
                             )
 
 mapper(TargetResists, targetResists_table)

--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -52,18 +52,22 @@ class FitDpsGraph(Graph):
         transversal = sin(radians(data["atkAngle"])) * data["atkSpeed"] + sin(radians(data["tgtAngle"])) * tgtSpeed
 
         total = 0
+        damageStatsArgs = (
+            data["emRes"] / 100.0, data["thRes"] / 100.0, data["kiRes"] / 100.0, data["exRes"] / 100.0,
+            distance, signatureRadius, tgtSpeed, transversal
+        )
 
-        for mod,count in fit.weaponModules:
-            dps, _ = mod.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
+        for mod, count in fit.weaponModules:
+            dps, _ = mod.damageStats(*damageStatsArgs)
             total += dps * count
 
         if distance <= fit.extraAttributes["droneControlRange"]:
             for drone in fit.drones:
-                dps, _ = drone.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
+                dps, _ = drone.damageStats(*damageStatsArgs)
                 total += dps
 
         for fighter in fit.fighters:
-            dps, _ = fighter.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
-            total += dps * multiplier
+            dps, _ = fighter.damageStats(*damageStatsArgs)
+            total += dps
 
         return total

--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -1,5 +1,5 @@
 # ===============================================================================
-# Copyright (C) 2010 Diego Duclos
+# Copyright (C) 2010 Diego Duclos, 2017 taleden
 #
 # This file is part of eos.
 #
@@ -17,10 +17,9 @@
 # along with eos.  If not, see <http://www.gnu.org/licenses/>.
 # ===============================================================================
 
-from math import log, sin, radians, exp
+from math import sin, radians
 
 from eos.graph import Graph
-from eos.saveddata.module import State, Hardpoint
 from logbook import Logger
 
 pyfalog = Logger(__name__)
@@ -28,10 +27,16 @@ pyfalog = Logger(__name__)
 
 class FitDpsGraph(Graph):
     defaults = {
-        "angle"          : 0,
+        "emRes"          : 0,
+        "thRes"          : 0,
+        "kiRes"          : 0,
+        "exRes"          : 0,
         "distance"       : 0,
-        "signatureRadius": None,
-        "velocity"       : 0
+        "signatureRadius": 0,
+        "atkAngle"       : 0,
+        "atkSpeed"       : 0,
+        "tgtAngle"       : 0,
+        "tgtSpeed"       : 0,
     }
 
     def __init__(self, fit, data=None):
@@ -39,154 +44,26 @@ class FitDpsGraph(Graph):
         self.fit = fit
 
     def calcDps(self, data):
-        ew = {'signatureRadius': [], 'velocity': []}
         fit = self.fit
+
+        distance = (data["distance"] or 0) * 1000
+        signatureRadius = (data["signatureRadius"] or 0) * fit.calculateTargetSignatureRadiusMultiplier(distance)
+        tgtSpeed = (data["tgtSpeed"] or 0) * fit.calculateTargetSpeedModifier(distance)
+        transversal = sin(radians(data["atkAngle"])) * data["atkSpeed"] + sin(radians(data["tgtAngle"])) * tgtSpeed
+
         total = 0
-        distance = data["distance"] * 1000
-        abssort = lambda _val: -abs(_val - 1)
 
-        for mod in fit.modules:
-            if not mod.isEmpty and mod.state >= State.ACTIVE:
-                if "remoteTargetPaintFalloff" in mod.item.effects or "structureModuleEffectTargetPainter" in mod.item.effects:
-                    ew['signatureRadius'].append(
-                            1 + (mod.getModifiedItemAttr("signatureRadiusBonus") / 100) * self.calculateModuleMultiplier(
-                                    mod, data))
-                if "remoteWebifierFalloff" in mod.item.effects or "structureModuleEffectStasisWebifier" in mod.item.effects:
-                    if distance <= mod.getModifiedItemAttr("maxRange"):
-                        ew['velocity'].append(1 + (mod.getModifiedItemAttr("speedFactor") / 100))
-                    elif mod.getModifiedItemAttr("falloffEffectiveness") > 0:
-                        # I am affected by falloff
-                        ew['velocity'].append(
-                                1 + (mod.getModifiedItemAttr("speedFactor") / 100) * self.calculateModuleMultiplier(mod,
-                                                                                                                    data))
-
-        ew['signatureRadius'].sort(key=abssort)
-        ew['velocity'].sort(key=abssort)
-
-        for attr, values in ew.iteritems():
-            val = data[attr]
-            try:
-                for i in xrange(len(values)):
-                    bonus = values[i]
-                    val *= 1 + (bonus - 1) * exp(- i ** 2 / 7.1289)
-                data[attr] = val
-            except Exception as e:
-                pyfalog.critical("Caught exception in calcDPS.")
-                pyfalog.critical(e)
-
-        for mod in fit.modules:
-            dps, _ = mod.damageStats(fit.targetResists)
-            if mod.hardpoint == Hardpoint.TURRET:
-                if mod.state >= State.ACTIVE:
-                    total += dps * self.calculateTurretMultiplier(mod, data)
-
-            elif mod.hardpoint == Hardpoint.MISSILE:
-                if mod.state >= State.ACTIVE and mod.maxRange >= distance:
-                    total += dps * self.calculateMissileMultiplier(mod, data)
+        for mod,count in fit.weaponModules:
+            dps, _ = mod.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
+            total += dps * count
 
         if distance <= fit.extraAttributes["droneControlRange"]:
             for drone in fit.drones:
-                multiplier = 1 if drone.getModifiedItemAttr("maxVelocity") > 1 else self.calculateTurretMultiplier(
-                        drone, data)
-                dps, _ = drone.damageStats(fit.targetResists)
-                total += dps * multiplier
+                dps, _ = drone.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
+                total += dps
 
-        # this is janky as fuck
         for fighter in fit.fighters:
-            for ability in fighter.abilities:
-                if ability.dealsDamage and ability.active:
-                    multiplier = self.calculateFighterMissileMultiplier(ability, data)
-                    dps, _ = ability.damageStats(fit.targetResists)
-                    total += dps * multiplier
+            dps, _ = fighter.damageStats(data["emRes"]/100.0, data["thRes"]/100.0, data["kiRes"]/100.0, data["exRes"]/100.0, distance, signatureRadius, tgtSpeed, transversal)
+            total += dps * multiplier
 
         return total
-
-    @staticmethod
-    def calculateMissileMultiplier(mod, data):
-        targetSigRad = data["signatureRadius"]
-        targetVelocity = data["velocity"]
-        explosionRadius = mod.getModifiedChargeAttr("aoeCloudSize")
-        targetSigRad = explosionRadius if targetSigRad is None else targetSigRad
-        explosionVelocity = mod.getModifiedChargeAttr("aoeVelocity")
-        damageReductionFactor = mod.getModifiedChargeAttr("aoeDamageReductionFactor")
-
-        sigRadiusFactor = targetSigRad / explosionRadius
-        if targetVelocity:
-            velocityFactor = (explosionVelocity / explosionRadius * targetSigRad / targetVelocity) ** damageReductionFactor
-        else:
-            velocityFactor = 1
-
-        return min(sigRadiusFactor, velocityFactor, 1)
-
-    def calculateTurretMultiplier(self, mod, data):
-        # Source for most of turret calculation info: http://wiki.eveonline.com/en/wiki/Falloff
-        chanceToHit = self.calculateTurretChanceToHit(mod, data)
-        if chanceToHit > 0.01:
-            # AvgDPS = Base Damage * [ ( ChanceToHit^2 + ChanceToHit + 0.0499 ) / 2 ]
-            multiplier = (chanceToHit ** 2 + chanceToHit + 0.0499) / 2
-        else:
-            # All hits are wreckings
-            multiplier = chanceToHit * 3
-        dmgScaling = mod.getModifiedItemAttr("turretDamageScalingRadius")
-        if dmgScaling:
-            targetSigRad = data["signatureRadius"]
-            multiplier = min(1, (float(targetSigRad) / dmgScaling) ** 2)
-        return multiplier
-
-    @staticmethod
-    def calculateFighterMissileMultiplier(ability, data):
-        prefix = ability.attrPrefix
-
-        targetSigRad = data["signatureRadius"]
-        targetVelocity = data["velocity"]
-        explosionRadius = ability.fighter.getModifiedItemAttr("{}ExplosionRadius".format(prefix))
-        explosionVelocity = ability.fighter.getModifiedItemAttr("{}ExplosionVelocity".format(prefix))
-        damageReductionFactor = ability.fighter.getModifiedItemAttr("{}ReductionFactor".format(prefix))
-
-        # the following conditionals are because CCP can't keep a decent naming convention, as if fighter implementation
-        # wasn't already fucked.
-        if damageReductionFactor is None:
-            damageReductionFactor = ability.fighter.getModifiedItemAttr("{}DamageReductionFactor".format(prefix))
-
-        damageReductionSensitivity = ability.fighter.getModifiedItemAttr("{}ReductionSensitivity".format(prefix))
-        if damageReductionSensitivity is None:
-            damageReductionSensitivity = ability.fighter.getModifiedItemAttr(
-                    "{}DamageReductionSensitivity".format(prefix))
-
-        targetSigRad = explosionRadius if targetSigRad is None else targetSigRad
-        sigRadiusFactor = targetSigRad / explosionRadius
-
-        if targetVelocity:
-            velocityFactor = (explosionVelocity / explosionRadius * targetSigRad / targetVelocity) ** (
-                log(damageReductionFactor) / log(damageReductionSensitivity))
-        else:
-            velocityFactor = 1
-
-        return min(sigRadiusFactor, velocityFactor, 1)
-
-    @staticmethod
-    def calculateTurretChanceToHit(mod, data):
-        distance = data["distance"] * 1000
-        tracking = mod.getModifiedItemAttr("trackingSpeed")
-        turretOptimal = mod.maxRange
-        turretFalloff = mod.falloff
-        turretSigRes = mod.getModifiedItemAttr("optimalSigRadius")
-        targetSigRad = data["signatureRadius"]
-        targetSigRad = turretSigRes if targetSigRad is None else targetSigRad
-        transversal = sin(radians(data["angle"])) * data["velocity"]
-        trackingEq = (((transversal / (distance * tracking)) *
-                       (turretSigRes / targetSigRad)) ** 2)
-        rangeEq = ((max(0, distance - turretOptimal)) / turretFalloff) ** 2
-
-        return 0.5 ** (trackingEq + rangeEq)
-
-    @staticmethod
-    def calculateModuleMultiplier(mod, data):
-        # Simplified formula, we make some assumptions about the module
-        # This is basically the calculateTurretChanceToHit without tracking values
-        distance = data["distance"] * 1000
-        turretOptimal = mod.maxRange
-        turretFalloff = mod.falloff
-        rangeEq = ((max(0, distance - turretOptimal)) / turretFalloff) ** 2
-
-        return 0.5 ** rangeEq

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -122,7 +122,7 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         tracking = self.getModifiedItemAttr("trackingSpeed")
         optSigRes = self.getModifiedItemAttr("optimalSigRadius")
         tgtSigRad = signatureRadius or optSigRes
-        return 0.5 ** (((transversal / (max(1,distance) * tracking)) * (optSigRes / tgtSigRad)) ** 2)
+        return 0.5 ** (((transversal / (max(1, distance) * tracking)) * (optSigRes / tgtSigRad)) ** 2)
 
     def calculateFalloffMultiplier(self, distance):
         return 0.5 ** ((max(0, distance - self.maxRange) / self.falloff) ** 2)
@@ -161,7 +161,7 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             func = self.getModifiedItemAttr
 
         dps = 0
-        volley = sum(((func("{}Damage".format(dtype)) or 0) * (1 - res)) for dtype,res in zip(self.DAMAGE_TYPES,(emRes,thRes,kiRes,exRes)))
+        volley = sum(((func("{}Damage".format(dtype)) or 0) * (1 - res)) for dtype, res in zip(self.DAMAGE_TYPES, (emRes, thRes, kiRes, exRes)))
         if volley:
             volley *= self.amountActive
             volley *= self.getModifiedItemAttr("damageMultiplier") or 1

--- a/eos/saveddata/fighter.py
+++ b/eos/saveddata/fighter.py
@@ -161,7 +161,7 @@ class Fighter(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         if (not self.active) or (self.amountActive < 1):
             return 0, 0
 
-        for ability in self.abilities: #TODO this overwrites! only take the last one? should it sum?
+        for ability in self.abilities:  # TODO this overwrites! only take the last one? should it sum?
             dps, volley = ability.damageStats(emRes, thRes, kiRes, exRes, distance, signatureRadius, speed, transversal)
 
         # For forward compatability this assumes a fighter

--- a/eos/saveddata/fighterAbility.py
+++ b/eos/saveddata/fighterAbility.py
@@ -150,10 +150,10 @@ class FighterAbility(object):
         volley = 0
         if self.attrPrefix == "fighterAbilityLaunchBomb":
             # bomb calcs
-            for dtype,res in zip(self.DAMAGE_TYPES, (emRes, thRes, kiRes, exRes)):
+            for dtype, res in zip(self.DAMAGE_TYPES, (emRes, thRes, kiRes, exRes)):
                 volley += (self.fighter.getModifiedChargeAttr("{}Damage".format(dtype)) or 0) * (1 - res)
         else:
-            for dtype,res in zip(self.DAMAGE_TYPES2, (emRes, thRes, kiRes, exRes)):
+            for dtype, res in zip(self.DAMAGE_TYPES2, (emRes, thRes, kiRes, exRes)):
                 volley += (self.fighter.getModifiedItemAttr("{}Damage{}".format(self.attrPrefix, dtype)) or 0) * (1 - res)
 
         if volley:

--- a/eos/saveddata/fighterAbility.py
+++ b/eos/saveddata/fighterAbility.py
@@ -147,11 +147,14 @@ class FighterAbility(object):
             return 0, 0
 
         dps = 0
+        volley = 0
         if self.attrPrefix == "fighterAbilityLaunchBomb":
             # bomb calcs
-            volley = sum(((self.fighter.getModifiedChargeAttr("{}Damage".format(dtype)) or 0) * (1 - res)) for dtype,res in zip(self.DAMAGE_TYPES,(emRes,thRes,kiRes,exRes)))
+            for dtype,res in zip(self.DAMAGE_TYPES, (emRes, thRes, kiRes, exRes)):
+                volley += (self.fighter.getModifiedChargeAttr("{}Damage".format(dtype)) or 0) * (1 - res)
         else:
-            volley = sum(((self.fighter.getModifiedItemAttr("{}Damage{}".format(self.attrPrefix, dtype)) or 0) * (1 - res)) for dtype,res in zip(self.DAMAGE_TYPES2,(emRes,thRes,kiRes,exRes)))
+            for dtype,res in zip(self.DAMAGE_TYPES2, (emRes, thRes, kiRes, exRes)):
+                volley += (self.fighter.getModifiedItemAttr("{}Damage{}".format(self.attrPrefix, dtype)) or 0) * (1 - res)
 
         if volley:
             volley *= self.fighter.amountActive

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1379,23 +1379,39 @@ class Fit(object):
 
     @property
     def emAmount(self):
-        hp = self.hp
-        return 1 - sum(hp.itervalues()) / sum((layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("","em") if layer == "hull" else (layer,"Em")))) for layer,layerHP in hp.iteritems())
+        hp = 0
+        ehp = 0
+        for layer, layerHP in self.hp.iteritems():
+            hp += layerHP
+            ehp += layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("", "em") if layer == "hull" else (layer, "Em")))
+        return 1 - hp / ehp
 
     @property
     def thermalAmount(self):
-        hp = self.hp
-        return 1 - sum(hp.itervalues()) / sum((layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("","thermal") if layer == "hull" else (layer,"Thermal")))) for layer,layerHP in hp.iteritems())
+        hp = 0
+        ehp = 0
+        for layer, layerHP in self.hp.iteritems():
+            hp += layerHP
+            ehp += layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("", "thermal") if layer == "hull" else (layer, "Thermal")))
+        return 1 - hp / ehp
 
     @property
     def kineticAmount(self):
-        hp = self.hp
-        return 1 - sum(hp.itervalues()) / sum((layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("","kinetic") if layer == "hull" else (layer,"Kinetic")))) for layer,layerHP in hp.iteritems())
+        hp = 0
+        ehp = 0
+        for layer, layerHP in self.hp.iteritems():
+            hp += layerHP
+            ehp += layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("", "kinetic") if layer == "hull" else (layer, "Kinetic")))
+        return 1 - hp / ehp
 
     @property
     def explosiveAmount(self):
-        hp = self.hp
-        return 1 - sum(hp.itervalues()) / sum((layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("","explosive") if layer == "hull" else (layer,"Explosive")))) for layer,layerHP in hp.iteritems())
+        hp = 0
+        ehp = 0
+        for layer, layerHP in self.hp.iteritems():
+            hp += layerHP
+            ehp += layerHP / self.ship.getModifiedItemAttr("%s%sDamageResonance" % (("", "explosive") if layer == "hull" else (layer, "Explosive")))
+        return 1 - hp / ehp
 
     @property
     def tank(self):
@@ -1453,7 +1469,7 @@ class Fit(object):
 
     def calculateStackingPenalizedMultiplier(self, multipliers):
         multiplier = 1.0
-        for i,value in enumerate(sorted(multipliers, key=(lambda val: -abs(val - 1)))):
+        for i, value in enumerate(sorted(multipliers, key=(lambda val: -abs(val - 1)))):
             multiplier *= 1 + (value - 1) * exp(-i ** 2 / 7.1289)
         return multiplier
 
@@ -1498,11 +1514,11 @@ class Fit(object):
             weaponDPS += dps
             weaponVolley += volley
             if volley:
-                ids = (mod.itemID,mod.chargeID,mod.state)
+                ids = (mod.itemID, mod.chargeID, mod.state)
                 if ids in weapons:
                     weapons[ids][1] += 1
                 else:
-                    weapons[ids] = [mod,1]
+                    weapons[ids] = [mod, 1]
 
         if distance <= self.extraAttributes["droneControlRange"]:
             for drone in self.drones:

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -322,7 +322,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         tracking = self.getModifiedItemAttr("trackingSpeed")
         optSigRes = self.getModifiedItemAttr("optimalSigRadius")
         tgtSigRad = signatureRadius or optSigRes
-        return 0.5 ** (((transversal / (max(1,distance) * tracking)) * (optSigRes / tgtSigRad)) ** 2)
+        return 0.5 ** (((transversal / (max(1, distance) * tracking)) * (optSigRes / tgtSigRad)) ** 2)
 
     def calculateFalloffMultiplier(self, distance):
         return 0.5 ** ((max(0, distance - self.maxRange) / self.falloff) ** 2)
@@ -368,7 +368,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             func = self.getModifiedItemAttr
 
         dps = 0
-        volley = sum(((func("{}Damage".format(dtype)) or 0) * (1 - res)) for dtype,res in zip(self.DAMAGE_TYPES,(emRes,thRes,kiRes,exRes)))
+        volley = sum(((func("{}Damage".format(dtype)) or 0) * (1 - res)) for dtype, res in zip(self.DAMAGE_TYPES, (emRes, thRes, kiRes, exRes)))
         if volley:
             volley *= self.getModifiedItemAttr("damageMultiplier") or 1
             if distance or signatureRadius or speed or transversal:

--- a/eos/saveddata/targetResists.py
+++ b/eos/saveddata/targetResists.py
@@ -26,12 +26,26 @@ pyfalog = Logger(__name__)
 class TargetResists(object):
     # also determined import/export order - VERY IMPORTANT
     DAMAGE_TYPES = ("em", "thermal", "kinetic", "explosive")
+    ATTRIBUTES = ("signatureRadius", "maxVelocity")
 
-    def __init__(self, emAmount=0, thermalAmount=0, kineticAmount=0, explosiveAmount=0):
+    def __init__(self, emAmount=0, thermalAmount=0, kineticAmount=0, explosiveAmount=0, signatureRadius=0, maxVelocity=0):
         self.emAmount = emAmount
         self.thermalAmount = thermalAmount
         self.kineticAmount = kineticAmount
         self.explosiveAmount = explosiveAmount
+        self.signatureRadius = signatureRadius
+        self.maxVelocity = maxVelocity
+
+    def getAttribute(self, attr):
+        if attr in ("emDamageResonance","armorEmDamageResonance","shieldEmDamageResonance"):
+            attr = "emAmount"
+        elif attr in ("thermalDamageResonance","armorThermalDamageResonance","shieldThermalDamageResonance"):
+            attr = "thermalAmount"
+        elif attr in ("kineticDamageResonance","armorKineticDamageResonance","shieldKineticDamageResonance"):
+            attr = "kineticAmount"
+        elif attr in ("explosiveDamageResonance","armorExplosiveDamageResonance","shieldExplosiveDamageResonance"):
+            attr = "explosiveAmount"
+        return getattr(self, attr, None)
 
     @classmethod
     def importPatterns(cls, text):
@@ -53,44 +67,55 @@ class TargetResists(object):
                 continue
 
             numPatterns += 1
-            name, data = data[0], data[1:5]
+            name, data = data[0], data[1:7]
             fields = {}
 
             for index, val in enumerate(data):
-                val = float(val)
-                try:
-                    assert 0 <= val <= 100
-                    fields["%sAmount" % cls.DAMAGE_TYPES[index]] = val / 100
-                except:
-                    pyfalog.warning("Caught unhandled exception in import patterns.")
-                    continue
+                if index < 4:
+                    val = float(val)
+                    try:
+                        assert 0 <= val <= 100
+                        fields["%sAmount" % cls.DAMAGE_TYPES[index]] = val / 100
+                    except:
+                        pyfalog.warning("Caught unhandled exception in import patterns.")
+                        continue
+                elif index < 6:
+                    val = float(val)
+                    try:
+                        assert 0 <= val
+                        fields[cls.ATTRIBUTES[index - 4]] = val
+                    except:
+                        pyfalog.warning("Caught unhandled exception in import patterns.")
+                        continue
 
-            if len(fields) == 4:  # Avoid possible blank lines
+            if len(fields) >= 4 and len(fields) <= 6:  # Avoid possible blank lines
                 pattern = TargetResists(**fields)
                 pattern.name = name.strip()
                 patterns.append(pattern)
 
         return patterns, numPatterns
 
-    EXPORT_FORMAT = "TargetResists = %s,%.1f,%.1f,%.1f,%.1f\n"
+    EXPORT_FORMAT = "TargetResists = %s,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f\n"
 
     @classmethod
     def exportPatterns(cls, *patterns):
         out = "# Exported from pyfa\n#\n"
         out += "# Values are in following format:\n"
-        out += "# TargetResists = [name],[EM %],[Thermal %],[Kinetic %],[Explosive %]\n\n"
+        out += "# TargetResists = [name],[EM %],[Thermal %],[Kinetic %],[Explosive %],[Signature Radius],[Max Velocity]\n\n"
         for dp in patterns:
             out += cls.EXPORT_FORMAT % (
                 dp.name,
                 dp.emAmount * 100,
                 dp.thermalAmount * 100,
                 dp.kineticAmount * 100,
-                dp.explosiveAmount * 100
+                dp.explosiveAmount * 100,
+                dp.signatureRadius,
+                dp.maxVelocity
             )
 
         return out.strip()
 
     def __deepcopy__(self, memo):
-        p = TargetResists(self.emAmount, self.thermalAmount, self.kineticAmount, self.explosiveAmount)
+        p = TargetResists(self.emAmount, self.thermalAmount, self.kineticAmount, self.explosiveAmount, self.signatureRadius, self.maxVelocity)
         p.name = "%s copy" % self.name
         return p

--- a/eos/saveddata/targetResists.py
+++ b/eos/saveddata/targetResists.py
@@ -37,13 +37,13 @@ class TargetResists(object):
         self.maxVelocity = maxVelocity
 
     def getAttribute(self, attr):
-        if attr in ("emDamageResonance","armorEmDamageResonance","shieldEmDamageResonance"):
+        if attr in ("emDamageResonance", "armorEmDamageResonance", "shieldEmDamageResonance"):
             attr = "emAmount"
-        elif attr in ("thermalDamageResonance","armorThermalDamageResonance","shieldThermalDamageResonance"):
+        elif attr in ("thermalDamageResonance", "armorThermalDamageResonance", "shieldThermalDamageResonance"):
             attr = "thermalAmount"
-        elif attr in ("kineticDamageResonance","armorKineticDamageResonance","shieldKineticDamageResonance"):
+        elif attr in ("kineticDamageResonance", "armorKineticDamageResonance", "shieldKineticDamageResonance"):
             attr = "kineticAmount"
-        elif attr in ("explosiveDamageResonance","armorExplosiveDamageResonance","shieldExplosiveDamageResonance"):
+        elif attr in ("explosiveDamageResonance", "armorExplosiveDamageResonance", "shieldExplosiveDamageResonance"):
             attr = "explosiveAmount"
         return getattr(self, attr, None)
 

--- a/gui/builtinContextMenus/tabbedFits.py
+++ b/gui/builtinContextMenus/tabbedFits.py
@@ -45,7 +45,7 @@ class TabbedFits(ContextMenu):
             id = ContextMenu.nextID()
             mitem = wx.MenuItem(rootMenu, id, u"{}: {}".format(fit.ship.item.name, fit.name))
             bindmenu.Bind(wx.EVT_MENU, self.handleSelection, mitem)
-            self.fitLookup[id] = (page.activeFitID,fit)
+            self.fitLookup[id] = (page.activeFitID, fit)
             m.AppendItem(mitem)
 
         return m
@@ -54,7 +54,7 @@ class TabbedFits(ContextMenu):
         sFit = Fit.getInstance()
         fitID = self.mainFrame.getActiveFit()
 
-        selFitID,selFit = self.fitLookup[event.Id]
+        selFitID, selFit = self.fitLookup[event.Id]
 
         if self.context == 'commandView':
             sFit.addCommandFit(fitID, selFit)

--- a/gui/builtinContextMenus/tabbedFits.py
+++ b/gui/builtinContextMenus/tabbedFits.py
@@ -16,7 +16,7 @@ class TabbedFits(ContextMenu):
 
     def display(self, srcContext, selection):
 
-        if self.mainFrame.getActiveFit() is None or srcContext not in ("projected", "commandView"):
+        if self.mainFrame.getActiveFit() is None or srcContext not in ("projected", "commandView", "graphAttacker", "graphTargetFitsResists", "graphTargetFits"):
             return False
 
         return True
@@ -45,7 +45,7 @@ class TabbedFits(ContextMenu):
             id = ContextMenu.nextID()
             mitem = wx.MenuItem(rootMenu, id, u"{}: {}".format(fit.ship.item.name, fit.name))
             bindmenu.Bind(wx.EVT_MENU, self.handleSelection, mitem)
-            self.fitLookup[id] = fit
+            self.fitLookup[id] = (page.activeFitID,fit)
             m.AppendItem(mitem)
 
         return m
@@ -54,12 +54,16 @@ class TabbedFits(ContextMenu):
         sFit = Fit.getInstance()
         fitID = self.mainFrame.getActiveFit()
 
-        fit = self.fitLookup[event.Id]
+        selFitID,selFit = self.fitLookup[event.Id]
 
         if self.context == 'commandView':
-            sFit.addCommandFit(fitID, fit)
+            sFit.addCommandFit(fitID, selFit)
         elif self.context == 'projected':
-            sFit.project(fitID, fit)
+            sFit.project(fitID, selFit)
+        elif self.context == "graphAttacker":
+            self.mainFrame.graphFrame.AppendFitToList(selFitID)
+        elif self.context in ("graphTargetFitsResists", "graphTargetFits"):
+            self.mainFrame.graphFrame.addTargetFit(selFitID)
 
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
 

--- a/gui/builtinContextMenus/targetResists.py
+++ b/gui/builtinContextMenus/targetResists.py
@@ -26,7 +26,7 @@ class TargetResists(ContextMenu):
         if srcContext == "firepowerViewFull":
             if self.mainFrame.getActiveFit() is None:
                 return False
-        elif srcContext in ("graphTargetFitsResists","graphTargetResists"):
+        elif srcContext in ("graphTargetFitsResists", "graphTargetResists"):
             pass
         else:
             return False
@@ -51,7 +51,7 @@ class TargetResists(ContextMenu):
             fitID = self.mainFrame.getActiveFit()
             sFit.setTargetResists(fitID, pattern)
             wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
-        elif self.context in ("graphTargetFitsResists","graphTargetResists"):
+        elif self.context in ("graphTargetFitsResists", "graphTargetResists"):
             self.mainFrame.graphFrame.addTargetProfile(pattern)
 
     def addPattern(self, rootMenu, pattern):

--- a/gui/builtinGraphs/__init__.py
+++ b/gui/builtinGraphs/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["fitDps"]
+__all__ = ["fitDps","fitDpsSim"]

--- a/gui/builtinGraphs/fitDps.py
+++ b/gui/builtinGraphs/fitDps.py
@@ -47,7 +47,7 @@ class FitDpsGraph(Graph):
         return "DPS Calculator"
 
     def getFields(self):
-        return dict((k,v) for k,v in self.defaults.iteritems() if k in self.propertyLabelMap)
+        return dict((k, v) for k, v in self.defaults.iteritems() if k in self.propertyLabelMap)
 
     def getLabels(self):
         return self.propertyLabelMap

--- a/gui/builtinGraphs/fitDpsSim.py
+++ b/gui/builtinGraphs/fitDpsSim.py
@@ -145,7 +145,7 @@ class FitDpsGraphSim(Graph):
             data["tgtSpeed"] = tgt.ship.getModifiedItemAttr("maxVelocity")
         else:
             if resists != "":
-                for type in ("em","thermal","kinetic","explosive"):
+                for type in ("em", "thermal", "kinetic", "explosive"):
                     data["%sRes" % (type[:2],)] = 100.0 * getattr(tgt, "%sAmount" % (type,))
             data["signatureRadius"] = tgt.signatureRadius
             data["tgtSpeed"] = tgt.maxVelocity
@@ -198,6 +198,7 @@ class FitDpsGraphSim(Graph):
 
         return x, y
 
+
 class VectorEvent(wx.PyCommandEvent):
     def __init__(self, evtType, id):
         wx.PyCommandEvent.__init__(self, evtType, id)
@@ -212,6 +213,7 @@ class VectorEvent(wx.PyCommandEvent):
 
     def GetLength(self):
         return self._length
+
 
 class VectorPicker(wx.PyControl):
 

--- a/gui/builtinGraphs/fitDpsSim.py
+++ b/gui/builtinGraphs/fitDpsSim.py
@@ -1,0 +1,423 @@
+# -*- coding: utf-8 -*-
+# =============================================================================
+# Copyright (C) 2017 taleden
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================
+
+# noinspection PyPackageRequirements
+import wx
+
+from math import floor, ceil, sin, cos, atan2, radians, degrees
+from gui.graph import Graph
+from gui.bitmapLoader import BitmapLoader
+from eos.saveddata.fit import Fit
+from eos.saveddata.targetResists import TargetResists
+from eos.graph.fitDps import FitDpsGraph as FitDps
+from eos.graph import Data
+import gui.mainFrame
+from service.attribute import Attribute
+from logbook import Logger
+
+pyfalog = Logger(__name__)
+
+
+class FitDpsGraphSim(Graph):
+    propertyAttributeMap = {"signatureRadius": "signatureRadius",
+                            "velocity": "maxVelocity"}
+
+    defaults = FitDps.defaults.copy()
+
+    def __init__(self):
+        Graph.__init__(self)
+        self.defaults["distance"] = "0-20"
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self.fields = {}
+
+    def getName(self):
+        return "DPS Simulator"
+
+    def allowTargetFits(self):
+        return True
+
+    def allowTargetResists(self):
+        return True
+
+    def getControlPanel(self, parent, onFieldChanged):
+        self.fields.clear()
+
+        panel = wx.Panel(parent)
+        sizer = wx.GridBagSizer(vgap=3, hgap=3)
+        panel.SetSizer(sizer)
+
+        # attacker vector
+        self.fields["attackerVector"] = vector = VectorPicker(panel, style=wx.NO_BORDER, size=60, offset=90, label="Atk", labelpos=2)
+        vector.Bind(VectorPicker.EVT_VECTOR_CHANGED, onFieldChanged)
+        sizer.Add(vector, pos=(0,1), span=(3,1), flag=wx.SHAPED | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+
+        # target vector
+        self.fields["targetVector"] = vector = VectorPicker(panel, style=wx.NO_BORDER, size=60, offset=-90, label="Tgt", labelpos=3)
+        vector.Bind(VectorPicker.EVT_VECTOR_CHANGED, onFieldChanged)
+        sizer.Add(vector, pos=(0,2), span=(3,1), flag=wx.SHAPED | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+
+        """
+        # behavior
+        icon = wx.StaticBitmap(panel, bitmap=BitmapLoader.getBitmap("22_13", "icons"))
+        sizer.Add(icon, pos=(1,7), flag=wx.ALIGN_CENTER)
+
+        label = wx.StaticText(panel, label="Behavior: ")
+        sizer.Add(label, pos=(1,8), flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+
+        self.fields["behavior"] = choice = wx.Choice(panel)
+        choice.Append("Target Vector", "vector")
+        choice.Append("Target Profile AI", "ai")
+        choice.SetSelection(0)
+        choice.Bind(wx.EVT_CHOICE, onFieldChanged)
+        sizer.Add(choice, pos=(1,9), flag=wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+"""
+
+        # resists
+        icon = wx.StaticBitmap(panel, bitmap=BitmapLoader.getBitmap("22_19", "icons"))
+        sizer.Add(icon, pos=(1,3), flag=wx.ALIGN_CENTER)
+
+        label = wx.StaticText(panel, label="Resistances: ")
+        sizer.Add(label, pos=(1,4), flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+
+        self.fields["resists"] = choice = wx.Choice(panel)
+        choice.Append("Weighted Average", "ehp")
+        choice.Append("Shield", "shield")
+        choice.Append("Armor", "armor")
+        choice.Append("Hull", "hull")
+        choice.Append("None", "")
+        choice.SetSelection(0)
+        choice.Bind(wx.EVT_CHOICE, onFieldChanged)
+        sizer.Add(choice, pos=(1,5), flag=wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+
+        # spacers
+        sizer.Add(wx.StaticText(panel, label=""), pos=(1,0), flag=wx.EXPAND)
+        sizer.Add(wx.StaticText(panel, label=""), pos=(1,6), flag=wx.EXPAND)
+
+        sizer.AddGrowableRow(0, proportion=1)
+        sizer.AddGrowableRow(2, proportion=1)
+        sizer.AddGrowableCol(0, proportion=1)
+        sizer.AddGrowableCol(6, proportion=1)
+        return panel
+
+    def getVariableLabels(self, values):
+        return ("Distance (km)",)
+
+    def prepareData(self, values, fit, tgt):
+        data = FitDps.defaults.copy()
+
+        resists = self.fields["resists"].GetClientData(self.fields["resists"].GetSelection())
+        if hasattr(tgt, "ship"):
+            hp = tgt.hp
+            if resists == "ehp":
+                for type in ("em","thermal","kinetic","explosive"):
+                    ehp = sum((layerHP / tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (("",type,"") if layer == "hull" else (layer,type[0].upper(),type[1:])))) for layer,layerHP in hp.iteritems())
+                    data["%sRes" % (type[:2],)] = 100.0 * (1 - (sum(hp.itervalues()) / ehp))
+            elif resists in hp:
+                for type in ("em","thermal","kinetic","explosive"):
+                    res = 1 - tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (("",type,"") if resists == "hull" else (resists,type[0].upper(),type[1:])))
+                    data["%sRes" % (type[:2],)] = 100.0 * res
+            data["signatureRadius"] = tgt.ship.getModifiedItemAttr("signatureRadius")
+            data["tgtSpeed"] = tgt.ship.getModifiedItemAttr("maxVelocity")
+        else:
+            if resists != "":
+                for type in ("em","thermal","kinetic","explosive"):
+                    data["%sRes" % (type[:2],)] = 100.0 * getattr(tgt, "%sAmount" % (type,))
+            data["signatureRadius"] = tgt.signatureRadius
+            data["tgtSpeed"] = tgt.maxVelocity
+
+        data["distance"] = "0-%d" % (ceil(fit.maxTargetRange / 1000.0),)
+        data["atkAngle"], atkThrottle = self.fields["attackerVector"].GetValue()
+        data["atkSpeed"] = atkThrottle * fit.ship.getModifiedItemAttr("maxVelocity")
+        data["tgtAngle"], tgtThrottle = self.fields["targetVector"].GetValue()
+        data["tgtSpeed"] *= tgtThrottle
+
+        return data
+
+    def getPoint(self, values, point, fit=None, tgt=None):
+        # yes, we're bypassing the whole superclass pipeline because it's futzy and overcomplicated for fetching just one point
+        if fit and tgt and point[0] > 0 and point[0] <= fit.maxTargetRange:
+            fitDps = FitDps(fit)
+            data = self.prepareData(values, fit, tgt)
+            data["distance"] = point[0]
+            return fitDps.calcDps(data)
+        return None
+
+    def getPoints(self, values, fit=None, tgt=None):
+        if not fit:
+            return False, "Attacker is required"
+        if not tgt:
+            return False, "Target is required"
+
+        fitDps = FitDps(fit)
+        data = self.prepareData(values, fit, tgt)
+        variable = None
+        for fieldName, value in data.iteritems():
+            d = Data(fieldName, value, 1 if fieldName == "distance" else None)
+            if not d.isConstant():
+                if variable is None:
+                    variable = fieldName
+                else:
+                    # We can't handle more then one variable atm, OOPS FUCK OUT
+                    return False, "Can only handle 1 variable"
+
+            fitDps.setData(d)
+
+        if variable is None:
+            return False, "No variable"
+
+        x = []
+        y = []
+        for point, val in fitDps.getIterator():
+            x.append(point[variable])
+            y.append(val)
+
+        return x, y
+
+
+class VectorEvent(wx.PyCommandEvent):
+    def __init__(self, evtType, id):
+        wx.PyCommandEvent.__init__(self, evtType, id)
+        self._angle = 0
+        self._length = 0
+
+
+    def GetValue(self):
+        return self._angle, self._length
+
+
+    def GetAngle(self):
+        return self._angle
+
+
+    def GetLength(self):
+        return self._length
+
+
+class VectorPicker(wx.PyControl):
+
+    UNICODE = "unicode" in wx.PlatformInfo
+    myEVT_VECTOR_CHANGED = wx.NewEventType()
+    EVT_VECTOR_CHANGED = wx.PyEventBinder(myEVT_VECTOR_CHANGED, 1)
+
+    def __init__(self, *args, **kwargs):
+        self._label = str(kwargs.pop("label", ""))
+        self._labelpos = int(kwargs.pop("labelpos", 0))
+        self._offset = float(kwargs.pop("offset", 0))
+        self._size = max(0, float(kwargs.pop("size", 50)))
+        self._fontsize = max(1, float(kwargs.pop("fontsize", 8)))
+        wx.PyControl.__init__(self, *args, **kwargs)
+        self._font = wx.Font(self._fontsize, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False)
+        self._angle = 0
+        self._length = 1
+        self._left = False
+        self._right = False
+        self._tooltip = "Click to set angle and velocity, right-click for increments; mouse wheel for velocity only"
+        self.SetToolTip(wx.ToolTip(self._tooltip))
+        self.Bind(wx.EVT_PAINT, self.OnPaint)
+        self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
+        self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)
+        self.Bind(wx.EVT_RIGHT_DOWN, self.OnRightDown)
+        self.Bind(wx.EVT_MOUSEWHEEL, self.OnWheel) 
+
+
+    def DoGetBestSize(self):
+        return wx.Size(self._size, self._size)
+
+
+    def AcceptsFocusFromKeyboard(self):
+        return False
+
+
+    def GetValue(self):
+        return self._angle, self._length
+
+
+    def GetAngle(self):
+        return self._angle
+
+
+    def GetLength(self):
+        return self._length
+
+
+    def SetValue(self, angle=None, length=None):
+        if angle is not None:
+            self._angle = min(max(angle, -180), 180)
+        if length is not None:
+            self._length = min(max(length, 0), 1)
+        self.Refresh()
+
+
+    def GetAngle(self, angle):
+        self.SetValue(angle, None)
+
+
+    def GetLength(self, length):
+        self.SetValue(None, length)
+
+
+    def OnPaint(self, event):
+        dc = wx.BufferedPaintDC(self)
+        self.Draw(dc)
+
+
+    def Draw(self, dc):
+        width, height = self.GetClientSize()
+        if not width or not height:
+            return
+
+        dc.SetBackground(wx.Brush(self.GetBackgroundColour(), wx.SOLID))
+        dc.Clear()
+        dc.SetTextForeground(wx.Colour(0))
+        dc.SetFont(self._font)
+
+        radius = min(width, height) / 2 - 2
+        dc.SetBrush(wx.WHITE_BRUSH)
+        dc.DrawCircle(radius + 2, radius + 2, radius)
+        a = radians(self._angle + self._offset)
+        x = sin(a) * radius
+        y = cos(a) * radius
+        dc.DrawLine(radius + 2, radius + 2, radius + 2 + x * self._length, radius + 2 - y * self._length)
+        dc.SetBrush(wx.BLACK_BRUSH)
+        dc.DrawCircle(radius + 2 + x * self._length, radius + 2 - y * self._length, 2)
+
+        if self._label:
+            labelText = self._label
+            labelTextW,labelTextH = dc.GetTextExtent(labelText)
+            labelTextX = (radius * 2 + 4 - labelTextW) if (self._labelpos & 1) else 0
+            labelTextY = (radius * 2 + 4 - labelTextH) if (self._labelpos & 2) else 0
+            dc.DrawText(labelText, labelTextX, labelTextY)
+
+        lengthText = "%d%%" % (100 * self._length,)
+        lengthTextW, lengthTextH = dc.GetTextExtent(lengthText)
+        lengthTextX = radius + 2 + x / 2 - y / 3 - lengthTextW / 2
+        lengthTextY = radius + 2 - y / 2 - x / 3 - lengthTextH / 2
+        dc.DrawText(lengthText, lengthTextX, lengthTextY)
+
+        angleText = (u"%d\u00B0" if self.UNICODE else "%d") % (self._angle,)
+        angleTextW, angleTextH = dc.GetTextExtent(angleText)
+        angleTextX = radius + 2 - x / 2 - angleTextW / 2
+        angleTextY = radius + 2 + y / 2 - angleTextH / 2
+        if not self.UNICODE:
+            dc.SetBrush(wx.WHITE_BRUSH)
+            dc.DrawCircle(angleTextX + angleTextW + 1, angleTextY + 1, 1.5)
+        dc.DrawText(angleText, angleTextX, angleTextY)
+
+
+    def OnEraseBackground(self, event):
+        pass
+
+
+    def OnLeftDown(self, event):
+        self._left = True
+        self.SetToolTip(None)
+        self.Bind(wx.EVT_LEFT_UP, self.OnLeftUp)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self.OnLeftUp)
+        if not self._right:
+            self.Bind(wx.EVT_MOTION, self.OnMotion)
+        if not self.HasCapture():
+            self.CaptureMouse()
+        self.HandleMouseEvent(event)
+
+
+    def OnRightDown(self, event):
+        self._right = True
+        self.SetToolTip(None)
+        self.Bind(wx.EVT_RIGHT_UP, self.OnRightUp)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self.OnRightUp)
+        if not self._left:
+            self.Bind(wx.EVT_MOTION, self.OnMotion)
+        if not self.HasCapture():
+            self.CaptureMouse()
+        self.HandleMouseEvent(event)
+
+
+    def OnLeftUp(self, event):
+        self.HandleMouseEvent(event)
+        self.Unbind(wx.EVT_LEFT_UP, handler=self.OnLeftUp)
+        self.Unbind(wx.EVT_MOUSE_CAPTURE_LOST, handler=self.OnLeftUp)
+        self._left = False
+        if not self._right:
+            self.Unbind(wx.EVT_MOTION, handler=self.OnMotion)
+            self.SendChangeEvent()
+            self.SetToolTip(wx.ToolTip(self._tooltip))
+            if self.HasCapture():
+                self.ReleaseMouse()
+
+
+    def OnRightUp(self, event):
+        self.HandleMouseEvent(event)
+        self.Unbind(wx.EVT_RIGHT_UP, handler=self.OnRightUp)
+        self.Unbind(wx.EVT_MOUSE_CAPTURE_LOST, handler=self.OnRightUp)
+        self._right = False
+        if not self._left:
+            self.Unbind(wx.EVT_MOTION, handler=self.OnMotion)
+            self.SendChangeEvent()
+            self.SetToolTip(wx.ToolTip(self._tooltip))
+            if self.HasCapture():
+                self.ReleaseMouse()
+
+
+    def OnMotion(self, event):
+        self.HandleMouseEvent(event)
+        event.Skip()
+
+
+    def OnWheel(self, event):
+        amount = 0.1 * event.GetWheelRotation() / event.GetWheelDelta()
+        self._length = min(max(self._length + amount, 0.0), 1.0)
+        self.Refresh()
+        self.SendChangeEvent()
+
+
+    def HandleMouseEvent(self, event):
+        width, height = self.GetClientSize()
+        if width and height:
+            center = min(width, height) / 2
+            x,y = event.GetPositionTuple()
+            x = x - center
+            y = center - y
+            angle = self._angle
+            length = min((x*x + y*y) ** 0.5 / (center - 2), 1.0)
+            if length < 0.01:
+                length = 0
+            else:
+                angle = ((degrees(atan2(x,y)) - self._offset + 180) % 360) - 180
+            if (self._right and not self._left) or event.ShiftDown():
+                angle = round(angle / 15.0) * 15.0
+                # floor() for length to make it easier to hit 0%, can still hit 100% outside the circle
+                length = floor(length / 0.05) * 0.05
+            if (angle != self._angle) or (length != self._length):
+                self._angle = angle
+                self._length = length
+                self.Refresh()
+                if self._right and not self._left:
+                    self.SendChangeEvent()
+
+
+    def SendChangeEvent(self):
+        changeEvent = wx.CommandEvent(self.myEVT_VECTOR_CHANGED, self.GetId())
+        changeEvent._object = self
+        changeEvent._angle = self._angle
+        changeEvent._length = self._length
+        self.GetEventHandler().ProcessEvent(changeEvent)
+
+
+FitDpsGraphSim.register()

--- a/gui/builtinGraphs/fitDpsSim.py
+++ b/gui/builtinGraphs/fitDpsSim.py
@@ -152,7 +152,7 @@ class FitDpsGraphSim(Graph):
 
         data["distance"] = "0-%d" % (ceil(fit.maxTargetRange / 1000.0),)
         data["atkAngle"], atkThrottle = self.fields["attackerVector"].GetValue()
-        data["atkSpeed"] = atkThrottle * fit.ship.getModifiedItemAttr("maxVelocity")
+        data["atkSpeed"] = atkThrottle * (fit.ship.getModifiedItemAttr("maxVelocity") or 0)
         data["tgtAngle"], tgtThrottle = self.fields["targetVector"].GetValue()
         data["tgtSpeed"] *= tgtThrottle
 

--- a/gui/builtinGraphs/fitDpsSim.py
+++ b/gui/builtinGraphs/fitDpsSim.py
@@ -66,12 +66,12 @@ class FitDpsGraphSim(Graph):
         # attacker vector
         self.fields["attackerVector"] = vector = VectorPicker(panel, style=wx.NO_BORDER, size=60, offset=90, label="Atk", labelpos=2)
         vector.Bind(VectorPicker.EVT_VECTOR_CHANGED, onFieldChanged)
-        sizer.Add(vector, pos=(0,1), span=(3,1), flag=wx.SHAPED | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(vector, pos=(0, 1), span=(3, 1), flag=wx.SHAPED | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
 
         # target vector
         self.fields["targetVector"] = vector = VectorPicker(panel, style=wx.NO_BORDER, size=60, offset=-90, label="Tgt", labelpos=3)
         vector.Bind(VectorPicker.EVT_VECTOR_CHANGED, onFieldChanged)
-        sizer.Add(vector, pos=(0,2), span=(3,1), flag=wx.SHAPED | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(vector, pos=(0, 2), span=(3, 1), flag=wx.SHAPED | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         """
         # behavior
@@ -91,10 +91,10 @@ class FitDpsGraphSim(Graph):
 
         # resists
         icon = wx.StaticBitmap(panel, bitmap=BitmapLoader.getBitmap("22_19", "icons"))
-        sizer.Add(icon, pos=(1,3), flag=wx.ALIGN_CENTER)
+        sizer.Add(icon, pos=(1, 3), flag=wx.ALIGN_CENTER)
 
         label = wx.StaticText(panel, label="Resistances: ")
-        sizer.Add(label, pos=(1,4), flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(label, pos=(1, 4), flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         self.fields["resists"] = choice = wx.Choice(panel)
         choice.Append("Weighted Average", "ehp")
@@ -104,11 +104,11 @@ class FitDpsGraphSim(Graph):
         choice.Append("None", "")
         choice.SetSelection(0)
         choice.Bind(wx.EVT_CHOICE, onFieldChanged)
-        sizer.Add(choice, pos=(1,5), flag=wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(choice, pos=(1, 5), flag=wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         # spacers
-        sizer.Add(wx.StaticText(panel, label=""), pos=(1,0), flag=wx.EXPAND)
-        sizer.Add(wx.StaticText(panel, label=""), pos=(1,6), flag=wx.EXPAND)
+        sizer.Add(wx.StaticText(panel, label=""), pos=(1, 0), flag=wx.EXPAND)
+        sizer.Add(wx.StaticText(panel, label=""), pos=(1, 6), flag=wx.EXPAND)
 
         sizer.AddGrowableRow(0, proportion=1)
         sizer.AddGrowableRow(2, proportion=1)
@@ -126,12 +126,20 @@ class FitDpsGraphSim(Graph):
         if hasattr(tgt, "ship"):
             hp = tgt.hp
             if resists == "ehp":
-                for type in ("em","thermal","kinetic","explosive"):
-                    ehp = sum((layerHP / tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (("",type,"") if layer == "hull" else (layer,type[0].upper(),type[1:])))) for layer,layerHP in hp.iteritems())
+                for type in ("em", "thermal", "kinetic", "explosive"):
+                    ehp = 0
+                    for layer, layerHP in hp.iteritems():
+                        if layer == "hull":
+                            ehp += (layerHP / tgt.ship.getModifiedItemAttr("%sDamageResonance" % type))
+                        else:
+                            ehp += (layerHP / tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (layer, type[0].upper(), type[1:])))
                     data["%sRes" % (type[:2],)] = 100.0 * (1 - (sum(hp.itervalues()) / ehp))
             elif resists in hp:
-                for type in ("em","thermal","kinetic","explosive"):
-                    res = 1 - tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (("",type,"") if resists == "hull" else (resists,type[0].upper(),type[1:])))
+                for type in ("em", "thermal", "kinetic", "explosive"):
+                    if resists == "hull":
+                        res = 1 - tgt.ship.getModifiedItemAttr("%sDamageResonance" % type)
+                    else:
+                        res = 1 - tgt.ship.getModifiedItemAttr("%s%s%sDamageResonance" % (resists, type[0].upper(), type[1:]))
                     data["%sRes" % (type[:2],)] = 100.0 * res
             data["signatureRadius"] = tgt.ship.getModifiedItemAttr("signatureRadius")
             data["tgtSpeed"] = tgt.ship.getModifiedItemAttr("maxVelocity")
@@ -190,25 +198,20 @@ class FitDpsGraphSim(Graph):
 
         return x, y
 
-
 class VectorEvent(wx.PyCommandEvent):
     def __init__(self, evtType, id):
         wx.PyCommandEvent.__init__(self, evtType, id)
         self._angle = 0
         self._length = 0
 
-
     def GetValue(self):
         return self._angle, self._length
-
 
     def GetAngle(self):
         return self._angle
 
-
     def GetLength(self):
         return self._length
-
 
 class VectorPicker(wx.PyControl):
 
@@ -234,28 +237,22 @@ class VectorPicker(wx.PyControl):
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)
         self.Bind(wx.EVT_RIGHT_DOWN, self.OnRightDown)
-        self.Bind(wx.EVT_MOUSEWHEEL, self.OnWheel) 
-
+        self.Bind(wx.EVT_MOUSEWHEEL, self.OnWheel)
 
     def DoGetBestSize(self):
         return wx.Size(self._size, self._size)
 
-
     def AcceptsFocusFromKeyboard(self):
         return False
-
 
     def GetValue(self):
         return self._angle, self._length
 
-
     def GetAngle(self):
         return self._angle
 
-
     def GetLength(self):
         return self._length
-
 
     def SetValue(self, angle=None, length=None):
         if angle is not None:
@@ -264,19 +261,15 @@ class VectorPicker(wx.PyControl):
             self._length = min(max(length, 0), 1)
         self.Refresh()
 
-
-    def GetAngle(self, angle):
+    def SetAngle(self, angle):
         self.SetValue(angle, None)
 
-
-    def GetLength(self, length):
+    def SetLength(self, length):
         self.SetValue(None, length)
-
 
     def OnPaint(self, event):
         dc = wx.BufferedPaintDC(self)
         self.Draw(dc)
-
 
     def Draw(self, dc):
         width, height = self.GetClientSize()
@@ -300,7 +293,7 @@ class VectorPicker(wx.PyControl):
 
         if self._label:
             labelText = self._label
-            labelTextW,labelTextH = dc.GetTextExtent(labelText)
+            labelTextW, labelTextH = dc.GetTextExtent(labelText)
             labelTextX = (radius * 2 + 4 - labelTextW) if (self._labelpos & 1) else 0
             labelTextY = (radius * 2 + 4 - labelTextH) if (self._labelpos & 2) else 0
             dc.DrawText(labelText, labelTextX, labelTextY)
@@ -320,10 +313,8 @@ class VectorPicker(wx.PyControl):
             dc.DrawCircle(angleTextX + angleTextW + 1, angleTextY + 1, 1.5)
         dc.DrawText(angleText, angleTextX, angleTextY)
 
-
     def OnEraseBackground(self, event):
         pass
-
 
     def OnLeftDown(self, event):
         self._left = True
@@ -336,7 +327,6 @@ class VectorPicker(wx.PyControl):
             self.CaptureMouse()
         self.HandleMouseEvent(event)
 
-
     def OnRightDown(self, event):
         self._right = True
         self.SetToolTip(None)
@@ -347,7 +337,6 @@ class VectorPicker(wx.PyControl):
         if not self.HasCapture():
             self.CaptureMouse()
         self.HandleMouseEvent(event)
-
 
     def OnLeftUp(self, event):
         self.HandleMouseEvent(event)
@@ -361,7 +350,6 @@ class VectorPicker(wx.PyControl):
             if self.HasCapture():
                 self.ReleaseMouse()
 
-
     def OnRightUp(self, event):
         self.HandleMouseEvent(event)
         self.Unbind(wx.EVT_RIGHT_UP, handler=self.OnRightUp)
@@ -374,11 +362,9 @@ class VectorPicker(wx.PyControl):
             if self.HasCapture():
                 self.ReleaseMouse()
 
-
     def OnMotion(self, event):
         self.HandleMouseEvent(event)
         event.Skip()
-
 
     def OnWheel(self, event):
         amount = 0.1 * event.GetWheelRotation() / event.GetWheelDelta()
@@ -386,20 +372,19 @@ class VectorPicker(wx.PyControl):
         self.Refresh()
         self.SendChangeEvent()
 
-
     def HandleMouseEvent(self, event):
         width, height = self.GetClientSize()
         if width and height:
             center = min(width, height) / 2
-            x,y = event.GetPositionTuple()
+            x, y = event.GetPositionTuple()
             x = x - center
             y = center - y
             angle = self._angle
-            length = min((x*x + y*y) ** 0.5 / (center - 2), 1.0)
+            length = min((x * x + y * y) ** 0.5 / (center - 2), 1.0)
             if length < 0.01:
                 length = 0
             else:
-                angle = ((degrees(atan2(x,y)) - self._offset + 180) % 360) - 180
+                angle = ((degrees(atan2(x, y)) - self._offset + 180) % 360) - 180
             if (self._right and not self._left) or event.ShiftDown():
                 angle = round(angle / 15.0) * 15.0
                 # floor() for length to make it easier to hit 0%, can still hit 100% outside the circle
@@ -410,7 +395,6 @@ class VectorPicker(wx.PyControl):
                 self.Refresh()
                 if self._right and not self._left:
                     self.SendChangeEvent()
-
 
     def SendChangeEvent(self):
         changeEvent = wx.CommandEvent(self.myEVT_VECTOR_CHANGED, self.GetId())

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -81,7 +81,7 @@ class PFGeneralPref(PreferenceView):
         self.btnDeleteDamagePatterns = wx.Button(panel, wx.ID_ANY, u"Delete All Damage Pattern Profiles", wx.DefaultPosition, wx.DefaultSize, 0)
         btnSizer.Add(self.btnDeleteDamagePatterns, 0, wx.ALL, 5)
 
-        self.btnDeleteTargetResists = wx.Button(panel, wx.ID_ANY, u"Delete All Target Resist Profiles", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnDeleteTargetResists = wx.Button(panel, wx.ID_ANY, u"Delete All Target Profiles", wx.DefaultPosition, wx.DefaultSize, 0)
         btnSizer.Add(self.btnDeleteTargetResists, 0, wx.ALL, 5)
 
         self.btnPrices = wx.Button(panel, wx.ID_ANY, u"Delete All Prices", wx.DefaultPosition, wx.DefaultSize, 0)
@@ -102,7 +102,7 @@ class PFGeneralPref(PreferenceView):
             clearDamagePatterns()
 
     def DeleteTargetResists(self, event):
-        question = u"This is a destructive action that will delete all target resist profiles.\nAre you sure you want to do this?"
+        question = u"This is a destructive action that will delete all target profiles.\nAre you sure you want to do this?"
         if wxHelpers.YesNoDialog(question, "Confirm"):
             clearTargetResists()
 

--- a/gui/builtinViewColumns/attributeDisplay.py
+++ b/gui/builtinViewColumns/attributeDisplay.py
@@ -26,6 +26,7 @@ from gui.utils.numberFormatter import formatAmount
 
 from service.attribute import Attribute
 from service.market import Market
+from eos.saveddata.fit import Fit
 
 
 class AttributeDisplay(ViewColumn):
@@ -36,6 +37,7 @@ class AttributeDisplay(ViewColumn):
         sAttr = Attribute.getInstance()
         info = sAttr.getAttributeInfo(params["attribute"])
         self.info = info
+        self.direct = False
         if params["showIcon"]:
             if info.name == "power":
                 iconFile = "pg_small"
@@ -71,7 +73,9 @@ class AttributeDisplay(ViewColumn):
             fittingView.refresh = refresh
 
     def getText(self, mod):
-        if hasattr(mod, "item"):
+        if isinstance(mod, Fit):
+            attr = mod.ship.getModifiedItemAttr(self.info.name)
+        elif hasattr(mod, "item"):
             attr = mod.getModifiedItemAttr(self.info.name)
         else:
             if self.direct:

--- a/gui/builtinViewColumns/baseIcon.py
+++ b/gui/builtinViewColumns/baseIcon.py
@@ -4,7 +4,11 @@ from eos.saveddata.implant import Implant
 from eos.saveddata.drone import Drone
 from eos.saveddata.module import Module, Slot, Rack
 from eos.saveddata.fit import Fit
+from eos.saveddata.targetResists import TargetResists
 from gui.viewColumn import ViewColumn
+from logbook import Logger
+
+pyfalog = Logger(__name__)
 
 
 class BaseIcon(ViewColumn):
@@ -36,8 +40,13 @@ class BaseIcon(ViewColumn):
                                                                 "gui")
             else:
                 return self.loadIconFile(stuff.item.icon.iconFile if stuff.item.icon else "")
+        elif isinstance(stuff, TargetResists):
+            return self.fittingView.imageList.GetImageIndex("explosive_small", "gui")
 
         item = getattr(stuff, "item", stuff)
+        if not hasattr(item, "icon"):
+            pyfalog.critical("item class %s has no .icon attribute" % (type(stuff).__name__,))
+            return -1
         return self.loadIconFile(item.icon.iconFile if item.icon else "")
 
     def loadIconFile(self, iconFile):

--- a/gui/builtinViewColumns/baseName.py
+++ b/gui/builtinViewColumns/baseName.py
@@ -27,6 +27,7 @@ from eos.saveddata.drone import Drone
 from eos.saveddata.fighter import Fighter
 from eos.saveddata.module import Module, Slot, Rack
 from eos.saveddata.fit import Fit
+from eos.saveddata.targetResists import TargetResists
 from service.fit import Fit as FitSvc
 from gui.viewColumn import ViewColumn
 import gui.mainFrame
@@ -41,7 +42,7 @@ class BaseName(ViewColumn):
         ViewColumn.__init__(self, fittingView)
 
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
-        self.columnText = "Name"
+        self.columnText = params["columnText"] if params != None else "Name"
         self.shipImage = fittingView.imageList.GetImageIndex("ship_small", "gui")
         self.mask = wx.LIST_MASK_TEXT
         self.projectedView = isinstance(fittingView, gui.builtinAdditionPanes.projectedView.ProjectedView)
@@ -83,6 +84,12 @@ class BaseName(ViewColumn):
                 return stuff.item.name
         elif isinstance(stuff, Implant):
             return stuff.item.name
+        elif isinstance(stuff, TargetResists):
+            name = getattr(stuff, "name")
+            if name is None:
+                pyfalog.warning("no name for TargetResists instance")
+                name = "?"
+            return name
         else:
             item = getattr(stuff, "item", stuff)
 
@@ -96,6 +103,10 @@ class BaseName(ViewColumn):
                     return shortcut + item.name
 
             return item.name
+
+    @staticmethod
+    def getParameters():
+        return (("columnText", str, "Name"),)
 
 
 BaseName.register()

--- a/gui/builtinViewColumns/baseName.py
+++ b/gui/builtinViewColumns/baseName.py
@@ -42,7 +42,7 @@ class BaseName(ViewColumn):
         ViewColumn.__init__(self, fittingView)
 
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
-        self.columnText = params["columnText"] if params != None else "Name"
+        self.columnText = params["columnText"] if (params is not None) else "Name"
         self.shipImage = fittingView.imageList.GetImageIndex("ship_small", "gui")
         self.mask = wx.LIST_MASK_TEXT
         self.projectedView = isinstance(fittingView, gui.builtinAdditionPanes.projectedView.ProjectedView)

--- a/gui/builtinViewColumns/propertyDisplay.py
+++ b/gui/builtinViewColumns/propertyDisplay.py
@@ -17,6 +17,9 @@
 # along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
+# noinspection PyPackageRequirements
+import wx
+
 from gui.viewColumn import ViewColumn
 from gui.utils.numberFormatter import formatAmount
 from service.attribute import Attribute
@@ -47,6 +50,8 @@ class PropertyDisplay(ViewColumn):
                 self.imageId = fittingView.imageList.GetImageIndex(iconFile, iconType)
             else:
                 self.imageId = -1
+
+            self.mask = wx.LIST_MASK_IMAGE
         else:
             self.imageId = -1
 

--- a/gui/display.py
+++ b/gui/display.py
@@ -251,9 +251,6 @@ class Display(wx.ListCtrl):
 
                 newImageId = col.getImageId(st)
 
-                colItem.SetText(newText)
-                colItem.SetImage(newImageId)
-
                 mask = 0
 
                 if oldText != newText:

--- a/gui/globalEvents.py
+++ b/gui/globalEvents.py
@@ -2,6 +2,7 @@
 import wx.lib.newevent
 
 FitChanged, FIT_CHANGED = wx.lib.newevent.NewEvent()
+TargetResistsChanged, TARGET_RESISTS_CHANGED = wx.lib.newevent.NewEvent()
 CharListUpdated, CHAR_LIST_UPDATED = wx.lib.newevent.NewEvent()
 CharChanged, CHAR_CHANGED = wx.lib.newevent.NewEvent()
 

--- a/gui/graph.py
+++ b/gui/graph.py
@@ -58,6 +58,6 @@ class Graph(object):
     def getPoints(self, values, fit=None, tgt=None):
         raise NotImplementedError()
 
+
 # noinspection PyUnresolvedReferences
-#from gui.builtinGraphs import fitDps  # noqa: E402, F401
-from gui.builtinGraphs import *
+from gui.builtinGraphs import fitDps, fitDpsSim  # noqa: E402, F401

--- a/gui/graph.py
+++ b/gui/graph.py
@@ -26,14 +26,38 @@ class Graph(object):
         Graph.views.append(cls)
 
     def __init__(self):
-        self.name = ""
+        pass
 
-    def getFields(self, fit, fields):
+    def getName(self):
         raise NotImplementedError()
+
+    def allowTargetFits(self):
+        return False
+
+    def allowTargetResists(self):
+        return False
+
+    def getControlPanel(self, parent, onFieldChanged):
+        return None
+
+    def getFields(self):
+        return None
+
+    def getLabels(self):
+        return None
 
     def getIcons(self):
         return None
 
+    def getVariableLabels(self, values):
+        return None
+
+    def getPoint(self, values, point, fit=None, tgt=None):
+        return None
+
+    def getPoints(self, values, fit=None, tgt=None):
+        raise NotImplementedError()
 
 # noinspection PyUnresolvedReferences
-from gui.builtinGraphs import fitDps  # noqa: E402, F401
+#from gui.builtinGraphs import fitDps  # noqa: E402, F401
+from gui.builtinGraphs import *

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -34,7 +34,6 @@ from gui.bitmapLoader import BitmapLoader
 import traceback
 from gui.contextMenu import ContextMenu
 from eos.saveddata.targetResists import TargetResists
-import time
 import collections
 
 pyfalog = Logger(__name__)
@@ -50,11 +49,12 @@ try:
         mplImported = False
     from matplotlib.patches import Patch
     from matplotlib.colors import hsv_to_rgb
-    def hsl_to_hsv(hsl): # why is this not in matplotlib.colors ?!
-        h,s,l = hsl
+
+    def hsl_to_hsv(hsl):  # why is this not in matplotlib.colors ?!
+        h, s, l = hsl
         s *= l if (l < 0.5) else (1 - l)
         l += s
-        return (h, 2*s/l, l)
+        return (h, 2 * s / l, l)
 
     from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as Canvas
     from matplotlib.figure import Figure
@@ -79,31 +79,31 @@ except Exception:
 
 
 class GraphFrame(wx.Frame):
-    COLORS = ( # TODO find a good colorblind-friendly palette
-        (  0 / 360.0, 1.0, 0.5 , "Red"),
-        (120 / 360.0, 1.0, 0.5 , "Green"),
-        (240 / 360.0, 1.0, 0.5 , "Blue"),
-        ( 56 / 360.0, 1.0, 0.5 , "Yellow"),
-        (180 / 360.0, 1.0, 0.5 , "Cyan"),
-        (300 / 360.0, 1.0, 0.5 , "Magenta"),
-        ( 40 / 360.0, 1.0, 0.5 , "Orange"),
-        (275 / 360.0, 1.0, 0.5 , "Purple"),
-        (  0 / 360.0, 0.7, 0.35, "Dark Red"),
-        (120 / 360.0, 0.7, 0.35, "Dark Green"),
-        (240 / 360.0, 0.7, 0.35, "Dark Blue"),
-        ( 56 / 360.0, 0.7, 0.35, "Dark Yellow"),
-        (180 / 360.0, 0.7, 0.35, "Dark Cyan"),
-        (300 / 360.0, 0.7, 0.35, "Dark Magenta"),
-        ( 40 / 360.0, 0.7, 0.35, "Dark Orange"),
-        (275 / 360.0, 0.7, 0.35, "Dark Purple"),
-        (  0 / 360.0, 0.7, 0.7 , "Light Red"),
-        (120 / 360.0, 0.7, 0.7 , "Light Green"),
-        (240 / 360.0, 0.7, 0.7 , "Light Blue"),
-        ( 56 / 360.0, 0.7, 0.7 , "Light Yellow"),
-        (180 / 360.0, 0.7, 0.7 , "Light Cyan"),
-        (300 / 360.0, 0.7, 0.7 , "Light Magenta"),
-        ( 40 / 360.0, 0.7, 0.7 , "Light Orange"),
-        (275 / 360.0, 0.7, 0.7 , "Light Purple"),
+    COLORS = (  # TODO find a good colorblind-friendly palette
+        (   0 / 360.0, 1.0, 0.5 , "Red" ),
+        ( 120 / 360.0, 1.0, 0.5 , "Green" ),
+        ( 240 / 360.0, 1.0, 0.5 , "Blue" ),
+        (  56 / 360.0, 1.0, 0.5 , "Yellow" ),
+        ( 180 / 360.0, 1.0, 0.5 , "Cyan" ),
+        ( 300 / 360.0, 1.0, 0.5 , "Magenta" ),
+        (  40 / 360.0, 1.0, 0.5 , "Orange" ),
+        ( 275 / 360.0, 1.0, 0.5 , "Purple" ),
+        (   0 / 360.0, 0.7, 0.35, "Dark Red" ),
+        ( 120 / 360.0, 0.7, 0.35, "Dark Green" ),
+        ( 240 / 360.0, 0.7, 0.35, "Dark Blue" ),
+        (  56 / 360.0, 0.7, 0.35, "Dark Yellow" ),
+        ( 180 / 360.0, 0.7, 0.35, "Dark Cyan" ),
+        ( 300 / 360.0, 0.7, 0.35, "Dark Magenta" ),
+        (  40 / 360.0, 0.7, 0.35, "Dark Orange" ),
+        ( 275 / 360.0, 0.7, 0.35, "Dark Purple" ),
+        (   0 / 360.0, 0.7, 0.7 , "Light Red" ),
+        ( 120 / 360.0, 0.7, 0.7 , "Light Green" ),
+        ( 240 / 360.0, 0.7, 0.7 , "Light Blue" ),
+        (  56 / 360.0, 0.7, 0.7 , "Light Yellow" ),
+        ( 180 / 360.0, 0.7, 0.7 , "Light Cyan" ),
+        ( 300 / 360.0, 0.7, 0.7 , "Light Magenta" ),
+        (  40 / 360.0, 0.7, 0.7 , "Light Orange" ),
+        ( 275 / 360.0, 0.7, 0.7 , "Light Purple" ),
     )
 
     def __init__(self, parent, style=wx.DEFAULT_FRAME_STYLE | wx.NO_FULL_REPAINT_ON_RESIZE | wx.FRAME_FLOAT_ON_PARENT):
@@ -136,7 +136,7 @@ class GraphFrame(wx.Frame):
         sizer.Add(linePanel, 0, wx.EXPAND)
 
         self.buttonLineColor = wx.Button(linePanel, label=" ", style=wx.BU_EXACTFIT | wx.BORDER_NONE)
-        self.buttonLineColor.SetSize(2*self.buttonLineColor.GetSize()[-1:])
+        self.buttonLineColor.SetSize(2 * self.buttonLineColor.GetSize()[-1:])
         lineSizer.Add(self.buttonLineColor, 0, flag=wx.SHAPED | wx.ALIGN_CENTER_VERTICAL | wx.ALL, border=3)
 
         self.labelLine = wx.StaticText(linePanel, label="")
@@ -261,7 +261,7 @@ class GraphFrame(wx.Frame):
 
         self.tgts.clear()
         if self.currentView.allowTargetResists():
-            for fitID,fit in self.fits.iteritems():
+            for fitID, fit in self.fits.iteritems():
                 tgtID = fit.targetResists.name if fit.targetResists else ""
                 if tgtID not in self.tgts:
                     self.tgts[tgtID] = svc_TargetResists.getTargetResists(tgtID) if tgtID else self.dummyTargetProfile
@@ -401,17 +401,15 @@ class GraphFrame(wx.Frame):
             self.draw()
 
     def calculate(self, calcID=None, markerOnly=False):
-        t0 = time.time()
-
         values = self.getValues()
         sFit = Fit.getInstance()
         oldLineData = self.lineData
         self.lineData = {}
         # don't clear lineColor so that removing and re-adding a pairing re-uses the previous color
 
-        for fitID,fit in self.fits.iteritems():
-            for tgtID,tgt in (self.tgts.iteritems() if self.tgts else ((None,None),)):
-                lineID = (fitID,tgtID)
+        for fitID, fit in self.fits.iteritems():
+            for tgtID, tgt in (self.tgts.iteritems() if self.tgts else ((None, None),)):
+                lineID = (fitID, tgtID)
 
                 # if we're only recalculating for a specific fit, recycle plotted data for lines that don't involve that fit
                 if (lineID in oldLineData) and (calcID is not None):
@@ -448,7 +446,9 @@ class GraphFrame(wx.Frame):
                     if self.markerX and markerY is None:
                         x = bisect.bisect(self.lineData[lineID][0], self.markerX)
                         if x > 0 and x < (len(self.lineData[lineID][1]) - 1):
-                            markerY = self.lineData[lineID][1][x-1] + (self.lineData[lineID][1][x] - self.lineData[lineID][1][x-1]) * (self.markerX - self.lineData[lineID][0][x-1]) / (self.lineData[lineID][0][x] - self.lineData[lineID][0][x-1])
+                            dx = (self.lineData[lineID][0][x] - self.lineData[lineID][0][x - 1])
+                            dy = (self.lineData[lineID][1][x] - self.lineData[lineID][1][x - 1])
+                            markerY = self.lineData[lineID][1][x - 1] + dy * (self.markerX - self.lineData[lineID][0][x - 1]) / dx
                     self.lineData[lineID][2] = markerY
 
                 except ValueError as e:
@@ -457,24 +457,21 @@ class GraphFrame(wx.Frame):
                     pyfalog.warning(msg)
                     pyfalog.warning(str(e))
                     return False
-            #for tgtID
-        #for fitID
+            # for tgtID
+        # for fitID
 
         self.plotPanel.labelX.SetLabel(self.currentView.getVariableLabels(values)[0])
         self.SetStatusText("")
-        t1 = time.time()
-        #DEBUG pyfalog.critical("calculate(): %1.3f seconds" % (t1-t0,))
         return True
-    #calculate()
+    # calculate()
 
     def draw(self):
-        t0 = time.time()
-        lineDataGen = (([lineID] + lineXYM + [self.lineColor.get(lineID), lineID == self.selected]) for lineID,lineXYM in self.lineData.iteritems())
+        lineDataGen = (([lineID] + lineXYM + [self.lineColor.get(lineID), lineID == self.selected]) for lineID, lineXYM in self.lineData.iteritems())
         self.plotPanel.draw(lineDataGen, self.markerX)
         if self.selected:
             self.buttonLineColor.Enable()
-            self.buttonLineColor.SetBackgroundColour(tuple(c*255 for c in self.lineColor[self.selected]))
-            fitID,tgtID = self.selected
+            self.buttonLineColor.SetBackgroundColour(tuple(c * 255 for c in self.lineColor[self.selected]))
+            fitID, tgtID = self.selected
             if tgtID is None:
                 self.labelLine.SetLabel(self.fits[fitID].name)
             else:
@@ -483,8 +480,6 @@ class GraphFrame(wx.Frame):
             self.buttonLineColor.Disable()
             self.buttonLineColor.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
             self.labelLine.SetLabel("")
-        t1 = time.time()
-        #DEBUG pyfalog.critical("draw(): %1.3f seconds" % (t1-t0,))
 
 
 class FitList(wx.Panel):
@@ -573,7 +568,7 @@ class PlotPanelMPL(wx.Panel):
         self.sizer.AddGrowableCol(1)
         self.SetSizer(self.sizer)
 
-        self.labelY = wx.StaticText(self, label="") # TODO custom control for rotated text?
+        self.labelY = wx.StaticText(self, label="")  # TODO custom control for rotated text?
         self.sizer.Add(self.labelY, flag=wx.ALIGN_CENTER | wx.ALL, border=3)
 
         self.figure = Figure(figsize=(4, 3))
@@ -581,7 +576,7 @@ class PlotPanelMPL(wx.Panel):
         colorFloat = [c / 255. for c in colorByte]
         self.figure.set_facecolor(colorFloat)
         self.figure.set_edgecolor(colorFloat)
-        self.subplot = self.figure.add_axes([0,0,1,1])
+        self.subplot = self.figure.add_axes([0, 0, 1, 1])
 
         self.canvas = Canvas(self, -1, self.figure)
         self.canvas.SetBackgroundColour(wx.Colour(*colorByte))
@@ -606,27 +601,37 @@ class PlotPanelMPL(wx.Panel):
         self.subplot.clear()
         self.subplot.grid(True)
 
-        for lineID,xdata,ydata,markerY,color,selected in lineData:
+        for lineID, xdata, ydata, markerY, color, selected in lineData:
             self._lines[lineID], = self.subplot.plot(xdata, ydata, color=color, linewidth=(2 if selected else 1), picker=5)
             self.maxX = max(self.maxX, max(xdata))
             self.maxY = max(self.maxY, max(ydata))
             if markerX and (markerY is not None):
-                self.subplot.annotate("%.1f" % (markerY,), xy=(markerX,markerY), xytext=(-1,1), textcoords="offset pixels", ha="right", va="bottom", fontsize="small")
+                self.subplot.annotate(
+                    "%.1f" % (markerY,),
+                    xy=(markerX, markerY), xytext=(-1, 1), textcoords="offset pixels",
+                    ha="right", va="bottom", fontsize="small"
+                )
         if markerX:
-            self.subplot.axvline(x=markerX, linestyle="dotted", linewidth=1, color=(0,0,0))
-            self.subplot.annotate("@ %.1f" % (markerX,), xy=(markerX,self.maxY*1.1), xytext=(-1,-1), textcoords="offset pixels", ha="right", va="top", fontsize="small")
+            self.subplot.axvline(x=markerX, linestyle="dotted", linewidth=1, color=(0, 0, 0))
+            self.subplot.annotate(
+                "@ %.1f" % (markerX,),
+                xy=(markerX, self.maxY * 1.1), xytext=(-1, -1), textcoords="offset pixels",
+                ha="right", va="top", fontsize="small"
+            )
 
-        self.subplot.set_xlim(left=0, right=self.maxX*1.05)
-        self.subplot.set_ylim(bottom=0, top=self.maxY*1.1)
+        self.subplot.set_xlim(left=0, right=self.maxX * 1.05)
+        self.subplot.set_ylim(bottom=0, top=self.maxY * 1.1)
         self.subplot.tick_params(direction="in", width=2, length=6)
 
         self.subplot.tick_params(axis="x", pad=-5.0)
-        xticks = list(int(v) for v in mpl.ticker.MaxNLocator(nbins=15, steps=[1,2,5,10], integer=True, min_n_ticks=10, prune="lower").tick_values(0, self.maxX * 1.025))
+        tickvalues = mpl.ticker.MaxNLocator(nbins=15, steps=[1, 2, 5, 10], integer=True, min_n_ticks=10, prune="lower").tick_values(0, self.maxX * 1.025)
+        xticks = list(int(v) for v in tickvalues)
         self.subplot.set_xticks(xticks)
         self.subplot.set_xticklabels(xticks, va="bottom")
 
         self.subplot.tick_params(axis="y", pad=-8.0)
-        yticks = list(int(v) for v in mpl.ticker.MaxNLocator(nbins=12, steps=[1,2,5,10], integer=True, min_n_ticks=8, prune="lower").tick_values(0, self.maxY * 1.05))
+        tickvalues = mpl.ticker.MaxNLocator(nbins=12, steps=[1, 2, 5, 10], integer=True, min_n_ticks=8, prune="lower").tick_values(0, self.maxY * 1.05)
+        yticks = list(int(v) for v in tickvalues)
         self.subplot.set_yticks(yticks)
         self.subplot.set_yticklabels(yticks, ha="left")
 
@@ -654,10 +659,10 @@ class PlotPanelMPL(wx.Panel):
                 self.onrelease = None
 
     def onPick(self, event):
-        for lineID,line in self._lines.iteritems():
+        for lineID, line in self._lines.iteritems():
             if line == event.artist:
                 self._parent.setSelectedLine(lineID)
-#PlotPanelMPL
+# PlotPanelMPL
 
 
 COLORPOPUP_SELECT = wx.NewEventType()
@@ -668,8 +673,8 @@ class ColorPopupSelectEvent(wx.PyCommandEvent):
     def __init__(self, windowID, color):
         wx.PyCommandEvent.__init__(self, COLORPOPUP_SELECT, windowID)
         self.color = color
-    #__init__()
-#ColorPopupSelectEvent
+    # __init__()
+# ColorPopupSelectEvent
 
 
 class ColorPickerPopup(wx.PopupTransientWindow):
@@ -688,7 +693,6 @@ class ColorPickerPopup(wx.PopupTransientWindow):
         self.patches = list()
         for hsln in colors:
             patch = wx.StaticText(self, label=wx.EmptyString, size=wx.Size(24, 24), style=wx.BORDER_STATIC)
-            #patch.Wrap(-1)
             color = wx.Colour(*(v*255 for v in hsv_to_rgb(hsl_to_hsv(hsln[:3]))))
             patch.SetBackgroundColour(color)
             patch.SetToolTipString(hsln[3])
@@ -706,13 +710,11 @@ class ColorPickerPopup(wx.PopupTransientWindow):
 
         sizer.Fit(self)
         self.Layout()
-    #__init__()
-
+    # __init__()
 
     def OnLeftUp_Patch(self, evt):
         self.PickColor(evt.GetEventObject().GetBackgroundColour())
-    #OnLeftUp_Patch()
-
+    # OnLeftUp_Patch()
 
     def OnButton_Custom(self, evt):
         data = wx.ColourData()
@@ -721,14 +723,13 @@ class ColorPickerPopup(wx.PopupTransientWindow):
         if dialog.ShowModal() == wx.ID_OK:
             self.PickColor(dialog.GetColourData().Colour)
         dialog.Destroy()
-    #OnButton_Custom()
-
+    # OnButton_Custom()
 
     def PickColor(self, color):
         evt = ColorPopupSelectEvent(self.parent.GetId(), color)
         self.parent.GetEventHandler().AddPendingEvent(evt)
         self.Hide()
         self.Destroy()
-    #PickColor()
+    # PickColor()
 
-#ColorPickerPopup
+# ColorPickerPopup

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (C) 2010 Diego Duclos
+# Copyright (C) 2010 Diego Duclos, 2017 taleden
 #
 # This file is part of pyfa.
 #
@@ -17,6 +17,7 @@
 # along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
+import bisect
 import os
 from logbook import Logger
 
@@ -24,12 +25,17 @@ from logbook import Logger
 import wx
 
 from service.fit import Fit
+from service.targetResists import TargetResists as svc_TargetResists
 import gui.display
 import gui.mainFrame
 import gui.globalEvents as GE
 from gui.graph import Graph
 from gui.bitmapLoader import BitmapLoader
 import traceback
+from gui.contextMenu import ContextMenu
+from eos.saveddata.targetResists import TargetResists
+import time
+import collections
 
 pyfalog = Logger(__name__)
 
@@ -43,6 +49,12 @@ try:
     else:
         mplImported = False
     from matplotlib.patches import Patch
+    from matplotlib.colors import hsv_to_rgb
+    def hsl_to_hsv(hsl): # why is this not in matplotlib.colors ?!
+        h,s,l = hsl
+        s *= l if (l < 0.5) else (1 - l)
+        l += s
+        return (h, 2*s/l, l)
 
     from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as Canvas
     from matplotlib.figure import Figure
@@ -67,115 +79,206 @@ except Exception:
 
 
 class GraphFrame(wx.Frame):
+    COLORS = ( # TODO find a good colorblind-friendly palette
+        (  0 / 360.0, 1.0, 0.5 , "Red"),
+        (120 / 360.0, 1.0, 0.5 , "Green"),
+        (240 / 360.0, 1.0, 0.5 , "Blue"),
+        ( 56 / 360.0, 1.0, 0.5 , "Yellow"),
+        (180 / 360.0, 1.0, 0.5 , "Cyan"),
+        (300 / 360.0, 1.0, 0.5 , "Magenta"),
+        ( 40 / 360.0, 1.0, 0.5 , "Orange"),
+        (275 / 360.0, 1.0, 0.5 , "Purple"),
+        (  0 / 360.0, 0.7, 0.35, "Dark Red"),
+        (120 / 360.0, 0.7, 0.35, "Dark Green"),
+        (240 / 360.0, 0.7, 0.35, "Dark Blue"),
+        ( 56 / 360.0, 0.7, 0.35, "Dark Yellow"),
+        (180 / 360.0, 0.7, 0.35, "Dark Cyan"),
+        (300 / 360.0, 0.7, 0.35, "Dark Magenta"),
+        ( 40 / 360.0, 0.7, 0.35, "Dark Orange"),
+        (275 / 360.0, 0.7, 0.35, "Dark Purple"),
+        (  0 / 360.0, 0.7, 0.7 , "Light Red"),
+        (120 / 360.0, 0.7, 0.7 , "Light Green"),
+        (240 / 360.0, 0.7, 0.7 , "Light Blue"),
+        ( 56 / 360.0, 0.7, 0.7 , "Light Yellow"),
+        (180 / 360.0, 0.7, 0.7 , "Light Cyan"),
+        (300 / 360.0, 0.7, 0.7 , "Light Magenta"),
+        ( 40 / 360.0, 0.7, 0.7 , "Light Orange"),
+        (275 / 360.0, 0.7, 0.7 , "Light Purple"),
+    )
+
     def __init__(self, parent, style=wx.DEFAULT_FRAME_STYLE | wx.NO_FULL_REPAINT_ON_RESIZE | wx.FRAME_FLOAT_ON_PARENT):
-        global graphFrame_enabled
-        global mplImported
-        global mpl_version
-
-        self.legendFix = False
-
-        if not graphFrame_enabled:
-            pyfalog.warning("Matplotlib is not enabled. Skipping initialization.")
-            return
-
-        try:
-            cache_dir = mpl._get_cachedir()
-        except:
-            cache_dir = os.path.expanduser(os.path.join("~", ".matplotlib"))
-
-        cache_file = os.path.join(cache_dir, 'fontList.cache')
-
-        if os.access(cache_dir, os.W_OK | os.X_OK) and os.path.isfile(cache_file):
-            # remove matplotlib font cache, see #234
-            os.remove(cache_file)
-        if not mplImported:
-            mpl.use('wxagg')
-
-        graphFrame_enabled = True
-        if int(mpl.__version__[0]) < 1:
-            print("pyfa: Found matplotlib version ", mpl.__version__, " - activating OVER9000 workarounds")
-            print("pyfa: Recommended minimum matplotlib version is 1.0.0")
-            self.legendFix = True
-
-        mplImported = True
-
         wx.Frame.__init__(self, parent, title=u"pyfa: Graph Generator", style=style, size=(520, 390))
 
-        i = wx.IconFromBitmap(BitmapLoader.getBitmap("graphs_small", "gui"))
-        self.SetIcon(i)
+        try:
+            self.plotPanel = PlotPanelMPL(self)
+        except Exception as e:
+            pyfalog.critical(e)
+            return
+
+        self.SetIcon(wx.IconFromBitmap(BitmapLoader.getBitmap("graphs_small", "gui")))
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.CreateStatusBar()
 
-        self.mainSizer = wx.BoxSizer(wx.VERTICAL)
-        self.SetSizer(self.mainSizer)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(sizer)
 
-        sFit = Fit.getInstance()
-        fit = sFit.getFit(self.mainFrame.getActiveFit())
-        self.fits = [fit] if fit is not None else []
-        self.fitList = FitList(self)
-        self.fitList.SetMinSize((270, -1))
-
-        self.fitList.fitList.update(self.fits)
-
-        self.graphSelection = wx.Choice(self, wx.ID_ANY, style=0)
-        self.mainSizer.Add(self.graphSelection, 0, wx.EXPAND)
-
-        self.figure = Figure(figsize=(4, 3))
-
-        rgbtuple = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE).Get()
-        clr = [c / 255. for c in rgbtuple]
-        self.figure.set_facecolor(clr)
-        self.figure.set_edgecolor(clr)
-
-        self.canvas = Canvas(self, -1, self.figure)
-        self.canvas.SetBackgroundColour(wx.Colour(*rgbtuple))
-
-        self.subplot = self.figure.add_subplot(111)
-        self.subplot.grid(True)
-
-        self.mainSizer.Add(self.canvas, 1, wx.EXPAND)
-        self.mainSizer.Add(wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL), 0,
-                           wx.EXPAND)
-
-        self.gridPanel = wx.Panel(self)
-        self.mainSizer.Add(self.gridPanel, 0, wx.EXPAND)
-
-        dummyBox = wx.BoxSizer(wx.VERTICAL)
-        self.gridPanel.SetSizer(dummyBox)
-
-        self.gridSizer = wx.FlexGridSizer(0, 4)
-        self.gridSizer.AddGrowableCol(1)
-        dummyBox.Add(self.gridSizer, 0, wx.EXPAND)
-
+        self.graphSelection = wx.Choice(self)
         for view in Graph.views:
             view = view()
-            self.graphSelection.Append(view.name, view)
+            self.graphSelection.Append(view.getName(), view)
+        sizer.Add(self.graphSelection, 0, wx.EXPAND)
 
-        self.graphSelection.SetSelection(0)
-        self.fields = {}
-        self.select(0)
-        self.sl1 = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
-        self.mainSizer.Add(self.sl1, 0, wx.EXPAND)
-        self.mainSizer.Add(self.fitList, 0, wx.EXPAND)
+        sizer.Add(self.plotPanel, 1, wx.EXPAND)
 
+        linePanel = wx.Panel(self)
+        lineSizer = wx.BoxSizer(wx.HORIZONTAL)
+        linePanel.SetSizer(lineSizer)
+        sizer.Add(linePanel, 0, wx.EXPAND)
+
+        self.buttonLineColor = wx.Button(linePanel, label=" ", style=wx.BU_EXACTFIT | wx.BORDER_NONE)
+        self.buttonLineColor.SetSize(2*self.buttonLineColor.GetSize()[-1:])
+        lineSizer.Add(self.buttonLineColor, 0, flag=wx.SHAPED | wx.ALIGN_CENTER_VERTICAL | wx.ALL, border=3)
+
+        self.labelLine = wx.StaticText(linePanel, label="")
+        lineSizer.Add(self.labelLine, 1, flag=wx.ALIGN_CENTER_VERTICAL | wx.ALL, border=3)
+
+        sizer.Add(wx.StaticLine(self, style=wx.LI_HORIZONTAL), 0, wx.EXPAND)
+
+        self.controlPanel = wx.Panel(self)
+        self.controlSizer = wx.BoxSizer(wx.VERTICAL)
+        self.controlPanel.SetSizer(self.controlSizer)
+        sizer.Add(self.controlPanel, 0, wx.EXPAND)
+
+        sizer.Add(wx.StaticLine(self, style=wx.LI_HORIZONTAL), 0, wx.EXPAND)
+
+        listPanel = wx.Panel(self)
+        listSizer = wx.BoxSizer(wx.HORIZONTAL)
+        listPanel.SetSizer(listSizer)
+        sizer.Add(listPanel, 0, wx.EXPAND)
+
+        self.fitList = FitList(listPanel, self)
+        self.fitList.SetMinSize((270, -1))
+        listSizer.Add(self.fitList, 1, wx.EXPAND)
+
+        self.tgtList = TargetList(listPanel, self)
+        self.tgtList.SetMinSize((270, -1))
+        listSizer.Add(self.tgtList, 1, wx.EXPAND)
+
+        self.graphSelection.Bind(wx.EVT_CHOICE, self.onSelectViewChanged)
+        self.buttonLineColor.Bind(wx.EVT_BUTTON, self.onButtonColorClick)
+        self.Bind(EVT_COLORPOPUP_SELECT, self.onSelectColor)
         self.fitList.fitList.Bind(wx.EVT_LEFT_DCLICK, self.removeItem)
-        self.mainFrame.Bind(GE.FIT_CHANGED, self.draw)
-        self.Bind(wx.EVT_CLOSE, self.close)
+        self.fitList.fitList.Bind(wx.EVT_RIGHT_DOWN, self.onAttackerContext)
+        self.tgtList.fitList.Bind(wx.EVT_LEFT_DCLICK, self.removeTarget)
+        self.tgtList.fitList.Bind(wx.EVT_RIGHT_DOWN, self.onTargetContext)
+        self.mainFrame.Bind(GE.FIT_CHANGED, self.onFitChanged)
+        self.mainFrame.Bind(GE.TARGET_RESISTS_CHANGED, self.onTargetResistsChanged)
+        self.Bind(wx.EVT_CLOSE, self.onClose)
 
+        self.dummyTargetProfile = TargetResists()
+        self.dummyTargetProfile.name = "Dummy"
+        self.fits = collections.OrderedDict()
+        fitID = self.mainFrame.getActiveFit()
+        if fitID:
+            self.fits[fitID] = Fit.getInstance().getFit(fitID)
+        self.fitList.fitList.update(self.fits.values())
+        self.tgts = collections.OrderedDict()
+        self.fields = {}
+        self.markerX = 0
+        self.selected = None
+        self.nextColor = 0
+        self.lineColor = {}
+        self.lineData = {}
+        self.currentViewIndex = None
+        self.currentView = None
+        self.selectView(0)
         self.Fit()
         self.SetMinSize(self.GetSize())
 
-    def handleDrag(self, type, fitID):
-        if type == "fit":
-            self.AppendFitToList(fitID)
-
-    def close(self, event):
+    def onClose(self, event):
+        self.graphSelection.Unbind(wx.EVT_CHOICE, handler=self.onSelectViewChanged)
+        self.buttonLineColor.Unbind(wx.EVT_BUTTON, handler=self.onButtonColorClick)
+        self.Unbind(EVT_COLORPOPUP_SELECT, handler=self.onSelectColor)
         self.fitList.fitList.Unbind(wx.EVT_LEFT_DCLICK, handler=self.removeItem)
-        self.mainFrame.Unbind(GE.FIT_CHANGED, handler=self.draw)
+        self.fitList.fitList.Unbind(wx.EVT_RIGHT_DOWN, handler=self.onAttackerContext)
+        self.tgtList.fitList.Unbind(wx.EVT_LEFT_DCLICK, handler=self.removeTarget)
+        self.tgtList.fitList.Unbind(wx.EVT_RIGHT_DOWN, handler=self.onTargetContext)
+        self.mainFrame.Unbind(GE.FIT_CHANGED, handler=self.onFitChanged)
+        self.mainFrame.Unbind(GE.TARGET_RESISTS_CHANGED, handler=self.onTargetResistsChanged)
         event.Skip()
 
-    def getView(self):
-        return self.graphSelection.GetClientData(self.graphSelection.GetSelection())
+    def onSelectViewChanged(self, event):
+        self.selectView(self.graphSelection.GetSelection())
+
+    def selectView(self, index):
+        if self.currentViewIndex == index:
+            return
+        self.currentViewIndex = index
+        self.currentView = self.graphSelection.GetClientData(index)
+        self.graphSelection.SetSelection(index)
+
+        self.controlPanel.DestroyChildren()
+        self.fields.clear()
+
+        viewPanel = self.currentView.getControlPanel(self.controlPanel, self.onFieldChanged)
+        if not viewPanel:
+            fields = self.currentView.getFields()
+            if fields:
+                viewPanel = wx.Panel(self.controlPanel)
+                viewSizer = wx.FlexGridSizer(0, 4)
+                viewSizer.AddGrowableCol(1)
+                viewPanel.SetSizer(viewSizer)
+
+                # Setup textboxes
+                icons = self.currentView.getIcons()
+                labels = self.currentView.getLabels()
+                for field in sorted(fields.keys()):
+                    textBox = wx.TextCtrl(viewPanel)
+                    self.fields[field] = textBox
+                    textBox.Bind(wx.EVT_TEXT_ENTER, self.onFieldChanged)
+                    textBox.Bind(wx.EVT_KILL_FOCUS, self.onFieldChanged)
+                    defaultVal = fields[field]
+                    if defaultVal is not None:
+                        if not isinstance(defaultVal, basestring):
+                            defaultVal = "%g" % (defaultVal,)
+                        textBox.ChangeValue(defaultVal)
+                    viewSizer.Add(textBox, proportion=1, flag=wx.ALIGN_CENTER_VERTICAL | wx.ALL, border=3)
+
+                    imgLabelSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+                    icon = icons.get(field) if icons else None
+                    if icon is not None:
+                        static = wx.StaticBitmap(viewPanel, bitmap=icon)
+                        imgLabelSizer.Add(static, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=1)
+
+                    label = labels.get(field, field) if labels else field
+                    imgLabelSizer.Add(wx.StaticText(viewPanel, label=label), proportion=0, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, border=3)
+
+                    viewSizer.Add(imgLabelSizer, proportion=0, flag=wx.ALIGN_CENTER_VERTICAL)
+
+        if viewPanel is not None:
+            self.controlSizer.Add(viewPanel, 0, wx.EXPAND)
+
+        self.tgts.clear()
+        if self.currentView.allowTargetResists():
+            for fitID,fit in self.fits.iteritems():
+                tgtID = fit.targetResists.name if fit.targetResists else ""
+                if tgtID not in self.tgts:
+                    self.tgts[tgtID] = svc_TargetResists.getTargetResists(tgtID) if tgtID else self.dummyTargetProfile
+            self.tgtList.Show()
+        elif self.currentView.allowTargetFits():
+            self.tgtList.Show()
+        else:
+            self.tgtList.Hide()
+        self.tgtList.fitList.update(self.tgts.values())
+
+        self.nextColor = 0
+        self.markerX = 0
+        self.selected = None
+
+        self.Layout()
+        self.calculate()
+        self.draw()
 
     def getValues(self):
         values = {}
@@ -184,159 +287,448 @@ class GraphFrame(wx.Frame):
 
         return values
 
-    def select(self, index):
-        view = self.getView()
-        icons = view.getIcons()
-        labels = view.getLabels()
-        sizer = self.gridSizer
-        self.gridPanel.DestroyChildren()
-        self.fields.clear()
+    def AppendFitToList(self, fitID, fit=None):
+        if fitID not in self.fits:
+            self.fits[fitID] = fit or Fit.getInstance().getFit(fitID)
+            self.fitList.fitList.update(self.fits.values())
+            self.calculate(fitID)
+            self.draw()
 
-        # Setup textboxes
-        for field, defaultVal in view.getFields().iteritems():
+    def addTargetFit(self, fitID, fit=None):
+        if self.currentView.allowTargetFits() and (fitID not in self.tgts):
+            self.tgts[fitID] = fit or Fit.getInstance().getFit(fitID)
+            self.tgtList.fitList.update(self.tgts.values())
+            self.calculate(fitID)
+            self.draw()
 
-            textBox = wx.TextCtrl(self.gridPanel, wx.ID_ANY, style=0)
-            self.fields[field] = textBox
-            textBox.Bind(wx.EVT_TEXT, self.onFieldChanged)
-            sizer.Add(textBox, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 3)
-            if defaultVal is not None:
-                if not isinstance(defaultVal, basestring):
-                    defaultVal = ("%f" % defaultVal).rstrip("0")
-                    if defaultVal[-1:] == ".":
-                        defaultVal += "0"
-
-                textBox.ChangeValue(defaultVal)
-
-            imgLabelSizer = wx.BoxSizer(wx.HORIZONTAL)
-            if icons:
-                icon = icons.get(field)
-                if icon is not None:
-                    static = wx.StaticBitmap(self.gridPanel)
-                    static.SetBitmap(icon)
-                    imgLabelSizer.Add(static, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 1)
-
-            if labels:
-                label = labels.get(field)
-                label = label if label is not None else field
-            else:
-                label = field
-
-            imgLabelSizer.Add(wx.StaticText(self.gridPanel, wx.ID_ANY, label), 0,
-                              wx.LEFT | wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 3)
-            sizer.Add(imgLabelSizer, 0, wx.ALIGN_CENTER_VERTICAL)
-        self.draw()
-
-    def draw(self, event=None):
-        global mpl_version
-
-        values = self.getValues()
-        view = self.getView()
-        self.subplot.clear()
-        self.subplot.grid(True)
-        legend = []
-
-        for fit in self.fits:
-            try:
-                success, status = view.getPoints(fit, values)
-                if not success:
-                    # TODO: Add a pwetty statys bar to report errors with
-                    self.SetStatusText(status)
-                    return
-
-                x, y = success, status
-
-                self.subplot.plot(x, y)
-                legend.append(fit.name)
-            except:
-                pyfalog.warning(u"Invalid values in '{0}'", fit.name)
-                self.SetStatusText(u"Invalid values in '%s'" % fit.name)
-                self.canvas.draw()
-                return
-
-        if mpl_version < 2:
-            if self.legendFix and len(legend) > 0:
-                leg = self.subplot.legend(tuple(legend), "upper right", shadow=False)
-                for t in leg.get_texts():
-                    t.set_fontsize('small')
-
-                for l in leg.get_lines():
-                    l.set_linewidth(1)
-
-            elif not self.legendFix and len(legend) > 0:
-                leg = self.subplot.legend(tuple(legend), "upper right", shadow=False, frameon=False)
-                for t in leg.get_texts():
-                    t.set_fontsize('small')
-
-                for l in leg.get_lines():
-                    l.set_linewidth(1)
-        elif mpl_version >= 2:
-            legend2 = []
-            legend_colors = {
-                0: "blue",
-                1: "orange",
-                2: "green",
-                3: "red",
-                4: "purple",
-                5: "brown",
-                6: "pink",
-                7: "grey",
-            }
-
-            for i, i_name in enumerate(legend):
-                try:
-                    selected_color = legend_colors[i]
-                except:
-                    selected_color = None
-                legend2.append(Patch(color=selected_color, label=i_name), )
-
-            if len(legend2) > 0:
-                leg = self.subplot.legend(handles=legend2)
-                for t in leg.get_texts():
-                    t.set_fontsize('small')
-
-                for l in leg.get_lines():
-                    l.set_linewidth(1)
-
-        self.canvas.draw()
-        self.SetStatusText("")
-        if event is not None:
-            event.Skip()
-
-    def onFieldChanged(self, event):
-        self.draw()
-
-    def AppendFitToList(self, fitID):
-        sFit = Fit.getInstance()
-        fit = sFit.getFit(fitID)
-        if fit not in self.fits:
-            self.fits.append(fit)
-
-        self.fitList.fitList.update(self.fits)
-        self.draw()
+    def addTargetProfile(self, profile):
+        tgtID = profile.name if profile else ""
+        if self.currentView.allowTargetResists() and (tgtID not in self.tgts):
+            self.tgts[tgtID] = profile or self.dummyTargetProfile
+            self.tgtList.fitList.update(self.tgts.values())
+            self.calculate(tgtID)
+            self.draw()
 
     def removeItem(self, event):
         row, _ = self.fitList.fitList.HitTest(event.Position)
         if row != -1:
-            del self.fits[row]
-            self.fitList.fitList.update(self.fits)
+            fitID = list(self.fits.keys())[row]
+            del self.fits[fitID]
+            self.fitList.fitList.update(self.fits.values())
+            trash = list(lineID for lineID in self.lineData if lineID[0] == fitID)
+            for lineID in trash:
+                del self.lineData[lineID]
+            if self.selected in trash:
+                self.selected = None
             self.draw()
+
+    def removeTarget(self, event):
+        row, _ = self.tgtList.fitList.HitTest(event.Position)
+        if row != -1:
+            tgtID = list(self.tgts.keys())[row]
+            del self.tgts[tgtID]
+            self.tgtList.fitList.update(self.tgts.values())
+            trash = list(lineID for lineID in self.lineData if lineID[1] == tgtID)
+            for lineID in trash:
+                del self.lineData[lineID]
+            if self.selected in trash:
+                self.selected = None
+            self.draw()
+
+    def onAttackerContext(self, event):
+        menu = ContextMenu.getMenu(None, ("graphAttacker",))
+        if menu is not None:
+            self.fitList.fitList.PopupMenu(menu)
+
+    def onTargetContext(self, event):
+        if self.currentView.allowTargetFits() and self.currentView.allowTargetResists():
+            context = "graphTargetFitsResists"
+        elif self.currentView.allowTargetFits():
+            context = "graphTargetFits"
+        elif self.currentView.allowTargetResists():
+            context = "graphTargetResists"
+        else:
+            return
+        menu = ContextMenu.getMenu(None, (context,))
+        if menu is not None:
+            self.tgtList.fitList.PopupMenu(menu)
+
+    def onFitChanged(self, event):
+        update = False
+        if event.fitID in self.fits:
+            self.fitList.fitList.update(self.fits.values())
+            update = True
+        if event.fitID in self.tgts:
+            self.tgtList.fitList.update(self.tgts.values())
+            update = True
+        if update:
+            self.calculate(event.fitID)
+            self.draw()
+        event.Skip()
+
+    def onTargetResistsChanged(self, event):
+        if event.name in self.tgts:
+            self.tgtList.fitList.update(self.tgts.values())
+            self.calculate(event.name)
+            self.draw()
+        event.Skip()
+
+    def onFieldChanged(self, event=None):
+        self.calculate()
+        self.draw()
+        if event:
+            event.Skip()
+
+    def setMarkerX(self, markerX):
+        self.markerX = markerX
+        self.calculate(markerOnly=True)
+        self.draw()
+
+    def setSelectedLine(self, lineID):
+        self.selected = lineID if (lineID in self.lineData) else None
+        self.draw()
+
+    def onButtonColorClick(self, event):
+        if self.selected:
+            win = ColorPickerPopup(self, self.COLORS, 8, 3)
+            pos = wx.GetMousePosition()
+            win.Position(pos, (0, 0))
+            win.Popup()
+
+    def onSelectColor(self, event):
+        if self.selected in self.lineData:
+            self.lineColor[self.selected] = tuple(c / 255.0 for c in event.color.Get(False))
+            self.draw()
+
+    def calculate(self, calcID=None, markerOnly=False):
+        t0 = time.time()
+
+        values = self.getValues()
+        sFit = Fit.getInstance()
+        oldLineData = self.lineData
+        self.lineData = {}
+        # don't clear lineColor so that removing and re-adding a pairing re-uses the previous color
+
+        for fitID,fit in self.fits.iteritems():
+            for tgtID,tgt in (self.tgts.iteritems() if self.tgts else ((None,None),)):
+                lineID = (fitID,tgtID)
+
+                # if we're only recalculating for a specific fit, recycle plotted data for lines that don't involve that fit
+                if (lineID in oldLineData) and (calcID is not None):
+                    if ((type(calcID) != type(fitID)) or (calcID != fitID)) and ((type(calcID) != type(tgtID)) or (calcID != tgtID)):
+                        self.lineData[lineID] = oldLineData[lineID]
+                        continue
+
+                color = self.lineColor.get(lineID)
+                if color is None:
+                    color = hsv_to_rgb(hsl_to_hsv(self.COLORS[self.nextColor][:3]))
+                    self.nextColor = (self.nextColor + 1) % len(self.COLORS)
+                    self.lineColor[lineID] = color
+                if tgtID is None:
+                    tgt = None
+                elif tgtID == "":
+                    tgt = self.dummyTargetProfile
+                elif type(tgtID) is int:
+                    tgt = sFit.getFit(tgtID)
+                else:
+                    tgt = svc_TargetResists.getTargetResists(tgtID)
+
+                try:
+                    if markerOnly and (lineID in oldLineData):
+                        self.lineData[lineID] = oldLineData[lineID]
+                    else:
+                        x_success, y_status = self.currentView.getPoints(values, fit, tgt)
+                        if not x_success:
+                            # TODO: Add a pwetty statys bar to report errors with
+                            self.SetStatusText(y_status)
+                            return False
+                        self.lineData[lineID] = [x_success, y_status, None]
+
+                    markerY = self.currentView.getPoint(values, (self.markerX,), fit, tgt) if self.markerX else None
+                    if self.markerX and markerY is None:
+                        x = bisect.bisect(self.lineData[lineID][0], self.markerX)
+                        if x > 0 and x < (len(self.lineData[lineID][1]) - 1):
+                            markerY = self.lineData[lineID][1][x-1] + (self.lineData[lineID][1][x] - self.lineData[lineID][1][x-1]) * (self.markerX - self.lineData[lineID][0][x-1]) / (self.lineData[lineID][0][x] - self.lineData[lineID][0][x-1])
+                    self.lineData[lineID][2] = markerY
+
+                except ValueError as e:
+                    msg = u"Error calculating fit '{}' vs target '{}'".format(fit.name, (tgt.name if tgt else "N/A"))
+                    self.SetStatusText(msg)
+                    pyfalog.warning(msg)
+                    pyfalog.warning(str(e))
+                    return False
+            #for tgtID
+        #for fitID
+
+        self.plotPanel.labelX.SetLabel(self.currentView.getVariableLabels(values)[0])
+        self.SetStatusText("")
+        t1 = time.time()
+        #DEBUG pyfalog.critical("calculate(): %1.3f seconds" % (t1-t0,))
+        return True
+    #calculate()
+
+    def draw(self):
+        t0 = time.time()
+        lineDataGen = (([lineID] + lineXYM + [self.lineColor.get(lineID), lineID == self.selected]) for lineID,lineXYM in self.lineData.iteritems())
+        self.plotPanel.draw(lineDataGen, self.markerX)
+        if self.selected:
+            self.buttonLineColor.Enable()
+            self.buttonLineColor.SetBackgroundColour(tuple(c*255 for c in self.lineColor[self.selected]))
+            fitID,tgtID = self.selected
+            if tgtID is None:
+                self.labelLine.SetLabel(self.fits[fitID].name)
+            else:
+                self.labelLine.SetLabel("%s vs. %s" % (self.fits[fitID].name, self.tgts[tgtID].name))
+        else:
+            self.buttonLineColor.Disable()
+            self.buttonLineColor.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
+            self.labelLine.SetLabel("")
+        t1 = time.time()
+        #DEBUG pyfalog.critical("draw(): %1.3f seconds" % (t1-t0,))
 
 
 class FitList(wx.Panel):
-    def __init__(self, parent):
+    def __init__(self, parent, frame):
         wx.Panel.__init__(self, parent)
         self.mainSizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(self.mainSizer)
+        self.frame = frame
 
         self.fitList = FitDisplay(self)
         self.mainSizer.Add(self.fitList, 1, wx.EXPAND)
-        fitToolTip = wx.ToolTip("Drag a fit into this list to graph it")
+        fitToolTip = wx.ToolTip("Right-click or drag to add an attacker fit; double-click to remove")
         self.fitList.SetToolTip(fitToolTip)
+
+    def handleDrag(self, type, fitID):
+        if type == "fit":
+            self.frame.AppendFitToList(fitID)
 
 
 class FitDisplay(gui.display.Display):
     DEFAULT_COLS = ["Base Icon",
-                    "Base Name"]
+                    "Base Name:Attacker Name"]
 
     def __init__(self, parent):
         gui.display.Display.__init__(self, parent)
+
+
+class TargetList(wx.Panel):
+    def __init__(self, parent, frame):
+        wx.Panel.__init__(self, parent)
+        self.mainSizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(self.mainSizer)
+        self.frame = frame
+
+        self.fitList = TargetDisplay(self)
+        self.mainSizer.Add(self.fitList, 1, wx.EXPAND)
+        fitToolTip = wx.ToolTip("Right-click or drag to add a target fit or profile; double-click to remove")
+        self.fitList.SetToolTip(fitToolTip)
+
+    def handleDrag(self, type, fitID):
+        if type == "fit":
+            self.frame.addTargetFit(fitID)
+
+
+class TargetDisplay(gui.display.Display):
+    DEFAULT_COLS = ["Base Icon",
+                    "Base Name:Target Name"]
+
+    def __init__(self, parent):
+        gui.display.Display.__init__(self, parent)
+
+
+class PlotPanelMPL(wx.Panel):
+    def __init__(self, parent):
+        global graphFrame_enabled
+        global mplImported
+        global mpl_version
+
+        if not graphFrame_enabled:
+            pyfalog.warning("Matplotlib is not enabled. Skipping initialization.")
+            raise Exception()
+
+        try:
+            cache_dir = mpl._get_cachedir()
+        except:
+            cache_dir = os.path.expanduser(os.path.join("~", ".matplotlib"))
+        cache_file = os.path.join(cache_dir, 'fontList.cache')
+        if os.access(cache_dir, os.W_OK | os.X_OK) and os.path.isfile(cache_file):
+            # remove matplotlib font cache, see #234
+            os.remove(cache_file)
+        if not mplImported:
+            mpl.use('wxagg')
+
+        graphFrame_enabled = True
+        self.legendFix = False
+        if int(mpl.__version__[0]) < 1:
+            print("pyfa: Found matplotlib version ", mpl.__version__, " - activating OVER9000 workarounds")
+            print("pyfa: Recommended minimum matplotlib version is 1.0.0")
+            self.legendFix = True
+        mplImported = True
+
+        wx.Panel.__init__(self, parent)
+
+        self.sizer = wx.FlexGridSizer(2, 2)
+        self.sizer.AddGrowableRow(0)
+        self.sizer.AddGrowableCol(1)
+        self.SetSizer(self.sizer)
+
+        self.labelY = wx.StaticText(self, label="") # TODO custom control for rotated text?
+        self.sizer.Add(self.labelY, flag=wx.ALIGN_CENTER | wx.ALL, border=3)
+
+        self.figure = Figure(figsize=(4, 3))
+        colorByte = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE).Get()
+        colorFloat = [c / 255. for c in colorByte]
+        self.figure.set_facecolor(colorFloat)
+        self.figure.set_edgecolor(colorFloat)
+        self.subplot = self.figure.add_axes([0,0,1,1])
+
+        self.canvas = Canvas(self, -1, self.figure)
+        self.canvas.SetBackgroundColour(wx.Colour(*colorByte))
+        self.canvas.mpl_connect('pick_event', lambda event: self.onPick(event))
+        self.canvas.mpl_connect('button_press_event', lambda event: self.onPlotClick(event))
+        self.sizer.Add(self.canvas, proportion=1, flag=wx.EXPAND)
+
+        self.sizer.Add(wx.StaticText(self, label=""), flag=wx.ALIGN_CENTER | wx.ALL, border=3)
+
+        self.labelX = wx.StaticText(self, label="")
+        self.sizer.Add(self.labelX, flag=wx.ALIGN_CENTER | wx.ALL, border=3)
+
+        self._parent = parent
+        self._lines = {}
+        self.ondrag = None
+        self.onrelease = None
+
+    def draw(self, lineData, markerX=None):
+        self._lines.clear()
+        self.maxX = 1
+        self.maxY = 1
+        self.subplot.clear()
+        self.subplot.grid(True)
+
+        for lineID,xdata,ydata,markerY,color,selected in lineData:
+            self._lines[lineID], = self.subplot.plot(xdata, ydata, color=color, linewidth=(2 if selected else 1), picker=5)
+            self.maxX = max(self.maxX, max(xdata))
+            self.maxY = max(self.maxY, max(ydata))
+            if markerX and (markerY is not None):
+                self.subplot.annotate("%.1f" % (markerY,), xy=(markerX,markerY), xytext=(-1,1), textcoords="offset pixels", ha="right", va="bottom", fontsize="small")
+        if markerX:
+            self.subplot.axvline(x=markerX, linestyle="dotted", linewidth=1, color=(0,0,0))
+            self.subplot.annotate("@ %.1f" % (markerX,), xy=(markerX,self.maxY*1.1), xytext=(-1,-1), textcoords="offset pixels", ha="right", va="top", fontsize="small")
+
+        self.subplot.set_xlim(left=0, right=self.maxX*1.05)
+        self.subplot.set_ylim(bottom=0, top=self.maxY*1.1)
+        self.subplot.tick_params(direction="in", width=2, length=6)
+
+        self.subplot.tick_params(axis="x", pad=-5.0)
+        xticks = list(int(v) for v in mpl.ticker.MaxNLocator(nbins=15, steps=[1,2,5,10], integer=True, min_n_ticks=10, prune="lower").tick_values(0, self.maxX * 1.025))
+        self.subplot.set_xticks(xticks)
+        self.subplot.set_xticklabels(xticks, va="bottom")
+
+        self.subplot.tick_params(axis="y", pad=-8.0)
+        yticks = list(int(v) for v in mpl.ticker.MaxNLocator(nbins=12, steps=[1,2,5,10], integer=True, min_n_ticks=8, prune="lower").tick_values(0, self.maxY * 1.05))
+        self.subplot.set_yticks(yticks)
+        self.subplot.set_yticklabels(yticks, ha="left")
+
+        self.canvas.draw()
+
+    def onPlotClick(self, event):
+        if event.button == 3:
+            self._parent.setMarkerX(event.xdata)
+            if not self.ondrag:
+                self.ondrag = self.canvas.mpl_connect('motion_notify_event', lambda event: self.onPlotDrag(event))
+            if not self.onrelease:
+                self.onrelease = self.canvas.mpl_connect('button_release_event', lambda event: self.onPlotRelease(event))
+
+    def onPlotDrag(self, event):
+        self._parent.setMarkerX(event.xdata)
+
+    def onPlotRelease(self, event):
+        if event.button == 3:
+            self._parent.setMarkerX(event.xdata)
+            if self.ondrag:
+                self.canvas.mpl_disconnect(self.ondrag)
+                self.ondrag = None
+            if self.onrelease:
+                self.canvas.mpl_disconnect(self.onrelease)
+                self.onrelease = None
+
+    def onPick(self, event):
+        for lineID,line in self._lines.iteritems():
+            if line == event.artist:
+                self._parent.setSelectedLine(lineID)
+#PlotPanelMPL
+
+
+COLORPOPUP_SELECT = wx.NewEventType()
+EVT_COLORPOPUP_SELECT = wx.PyEventBinder(COLORPOPUP_SELECT, 0)
+
+
+class ColorPopupSelectEvent(wx.PyCommandEvent):
+    def __init__(self, windowID, color):
+        wx.PyCommandEvent.__init__(self, COLORPOPUP_SELECT, windowID)
+        self.color = color
+    #__init__()
+#ColorPopupSelectEvent
+
+
+class ColorPickerPopup(wx.PopupTransientWindow):
+
+    def __init__(self, parent, colors, ncol=0, nrow=0):
+        wx.PopupTransientWindow.__init__(self, parent, style=wx.BORDER_SIMPLE)
+        self.parent = parent
+        ncol = ncol or len(colors)
+        nrow = nrow or int(len(colors) / ncol) + (1 if (len(colors) % ncol) else 0)
+
+        self.SetBackgroundColour(wx.Colour(255, 255, 255))
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(sizer)
+
+        grid = wx.GridSizer(nrow, ncol, 0, 0)
+        self.patches = list()
+        for hsln in colors:
+            patch = wx.StaticText(self, label=wx.EmptyString, size=wx.Size(24, 24), style=wx.BORDER_STATIC)
+            #patch.Wrap(-1)
+            color = wx.Colour(*(v*255 for v in hsv_to_rgb(hsl_to_hsv(hsln[:3]))))
+            patch.SetBackgroundColour(color)
+            patch.SetToolTipString(hsln[3])
+            patch.Bind(wx.EVT_LEFT_UP, self.OnLeftUp_Patch)
+            grid.Add(patch, flag=wx.ALL, border=3)
+        sizer.Add(grid)
+
+        line = wx.StaticLine(self, style=wx.LI_HORIZONTAL)
+        sizer.Add(line, flag=wx.EXPAND)
+
+        button = wx.Button(self, label="Custom")
+        button.SetToolTipString("Choose a custom color")
+        button.Bind(wx.EVT_BUTTON, self.OnButton_Custom)
+        sizer.Add(button, flag=wx.EXPAND | wx.ALL, border=2)
+
+        sizer.Fit(self)
+        self.Layout()
+    #__init__()
+
+
+    def OnLeftUp_Patch(self, evt):
+        self.PickColor(evt.GetEventObject().GetBackgroundColour())
+    #OnLeftUp_Patch()
+
+
+    def OnButton_Custom(self, evt):
+        data = wx.ColourData()
+        data.SetChooseFull(True)
+        dialog = wx.ColourDialog(self.parent, data)
+        if dialog.ShowModal() == wx.ID_OK:
+            self.PickColor(dialog.GetColourData().Colour)
+        dialog.Destroy()
+    #OnButton_Custom()
+
+
+    def PickColor(self, color):
+        evt = ColorPopupSelectEvent(self.parent.GetId(), color)
+        self.parent.GetEventHandler().AddPendingEvent(evt)
+        self.Hide()
+        self.Destroy()
+    #PickColor()
+
+#ColorPickerPopup

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -80,30 +80,30 @@ except Exception:
 
 class GraphFrame(wx.Frame):
     COLORS = (  # TODO find a good colorblind-friendly palette
-        (   0 / 360.0, 1.0, 0.5 , "Red" ),
-        ( 120 / 360.0, 1.0, 0.5 , "Green" ),
-        ( 240 / 360.0, 1.0, 0.5 , "Blue" ),
-        (  56 / 360.0, 1.0, 0.5 , "Yellow" ),
-        ( 180 / 360.0, 1.0, 0.5 , "Cyan" ),
-        ( 300 / 360.0, 1.0, 0.5 , "Magenta" ),
-        (  40 / 360.0, 1.0, 0.5 , "Orange" ),
-        ( 275 / 360.0, 1.0, 0.5 , "Purple" ),
-        (   0 / 360.0, 0.7, 0.35, "Dark Red" ),
-        ( 120 / 360.0, 0.7, 0.35, "Dark Green" ),
-        ( 240 / 360.0, 0.7, 0.35, "Dark Blue" ),
-        (  56 / 360.0, 0.7, 0.35, "Dark Yellow" ),
-        ( 180 / 360.0, 0.7, 0.35, "Dark Cyan" ),
-        ( 300 / 360.0, 0.7, 0.35, "Dark Magenta" ),
-        (  40 / 360.0, 0.7, 0.35, "Dark Orange" ),
-        ( 275 / 360.0, 0.7, 0.35, "Dark Purple" ),
-        (   0 / 360.0, 0.7, 0.7 , "Light Red" ),
-        ( 120 / 360.0, 0.7, 0.7 , "Light Green" ),
-        ( 240 / 360.0, 0.7, 0.7 , "Light Blue" ),
-        (  56 / 360.0, 0.7, 0.7 , "Light Yellow" ),
-        ( 180 / 360.0, 0.7, 0.7 , "Light Cyan" ),
-        ( 300 / 360.0, 0.7, 0.7 , "Light Magenta" ),
-        (  40 / 360.0, 0.7, 0.7 , "Light Orange" ),
-        ( 275 / 360.0, 0.7, 0.7 , "Light Purple" ),
+        (0   / 360.0, 1.0, 0.5 , "Red"),
+        (120 / 360.0, 1.0, 0.5 , "Green"),
+        (240 / 360.0, 1.0, 0.5 , "Blue"),
+        (56  / 360.0, 1.0, 0.5 , "Yellow"),
+        (180 / 360.0, 1.0, 0.5 , "Cyan"),
+        (300 / 360.0, 1.0, 0.5 , "Magenta"),
+        (40  / 360.0, 1.0, 0.5 , "Orange"),
+        (275 / 360.0, 1.0, 0.5 , "Purple"),
+        (0   / 360.0, 0.7, 0.35, "Dark Red"),
+        (120 / 360.0, 0.7, 0.35, "Dark Green"),
+        (240 / 360.0, 0.7, 0.35, "Dark Blue"),
+        (56  / 360.0, 0.7, 0.35, "Dark Yellow"),
+        (180 / 360.0, 0.7, 0.35, "Dark Cyan"),
+        (300 / 360.0, 0.7, 0.35, "Dark Magenta"),
+        (40  / 360.0, 0.7, 0.35, "Dark Orange"),
+        (275 / 360.0, 0.7, 0.35, "Dark Purple"),
+        (0   / 360.0, 0.7, 0.7 , "Light Red"),
+        (120 / 360.0, 0.7, 0.7 , "Light Green"),
+        (240 / 360.0, 0.7, 0.7 , "Light Blue"),
+        (56  / 360.0, 0.7, 0.7 , "Light Yellow"),
+        (180 / 360.0, 0.7, 0.7 , "Light Cyan"),
+        (300 / 360.0, 0.7, 0.7 , "Light Magenta"),
+        (40  / 360.0, 0.7, 0.7 , "Light Orange"),
+        (275 / 360.0, 0.7, 0.7 , "Light Purple"),
     )
 
     def __init__(self, parent, style=wx.DEFAULT_FRAME_STYLE | wx.NO_FULL_REPAINT_ON_RESIZE | wx.FRAME_FLOAT_ON_PARENT):
@@ -693,7 +693,7 @@ class ColorPickerPopup(wx.PopupTransientWindow):
         self.patches = list()
         for hsln in colors:
             patch = wx.StaticText(self, label=wx.EmptyString, size=wx.Size(24, 24), style=wx.BORDER_STATIC)
-            color = wx.Colour(*(v*255 for v in hsv_to_rgb(hsl_to_hsv(hsln[:3]))))
+            color = wx.Colour(*(v * 255 for v in hsv_to_rgb(hsl_to_hsv(hsln[:3]))))
             patch.SetBackgroundColour(color)
             patch.SetToolTipString(hsln[3])
             patch.Bind(wx.EVT_LEFT_UP, self.OnLeftUp_Patch)

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -80,29 +80,29 @@ except Exception:
 
 class GraphFrame(wx.Frame):
     COLORS = (  # TODO find a good colorblind-friendly palette
-        (0   / 360.0, 1.0, 0.5 , "Red"),
+        (  0 / 360.0, 1.0, 0.5 , "Red"),  #noqa: E201
         (120 / 360.0, 1.0, 0.5 , "Green"),
         (240 / 360.0, 1.0, 0.5 , "Blue"),
-        (56  / 360.0, 1.0, 0.5 , "Yellow"),
+        ( 56 / 360.0, 1.0, 0.5 , "Yellow"),  #noqa: E201
         (180 / 360.0, 1.0, 0.5 , "Cyan"),
         (300 / 360.0, 1.0, 0.5 , "Magenta"),
-        (40  / 360.0, 1.0, 0.5 , "Orange"),
+        ( 40 / 360.0, 1.0, 0.5 , "Orange"),  #noqa: E201
         (275 / 360.0, 1.0, 0.5 , "Purple"),
-        (0   / 360.0, 0.7, 0.35, "Dark Red"),
+        (  0 / 360.0, 0.7, 0.35, "Dark Red"),  #noqa: E201
         (120 / 360.0, 0.7, 0.35, "Dark Green"),
         (240 / 360.0, 0.7, 0.35, "Dark Blue"),
-        (56  / 360.0, 0.7, 0.35, "Dark Yellow"),
+        ( 56 / 360.0, 0.7, 0.35, "Dark Yellow"),  #noqa: E201
         (180 / 360.0, 0.7, 0.35, "Dark Cyan"),
         (300 / 360.0, 0.7, 0.35, "Dark Magenta"),
-        (40  / 360.0, 0.7, 0.35, "Dark Orange"),
+        ( 40 / 360.0, 0.7, 0.35, "Dark Orange"),  #noqa: E201
         (275 / 360.0, 0.7, 0.35, "Dark Purple"),
-        (0   / 360.0, 0.7, 0.7 , "Light Red"),
+        (  0 / 360.0, 0.7, 0.7 , "Light Red"),  #noqa: E201
         (120 / 360.0, 0.7, 0.7 , "Light Green"),
         (240 / 360.0, 0.7, 0.7 , "Light Blue"),
-        (56  / 360.0, 0.7, 0.7 , "Light Yellow"),
+        ( 56 / 360.0, 0.7, 0.7 , "Light Yellow"),  #noqa: E201
         (180 / 360.0, 0.7, 0.7 , "Light Cyan"),
         (300 / 360.0, 0.7, 0.7 , "Light Magenta"),
-        (40  / 360.0, 0.7, 0.7 , "Light Orange"),
+        ( 40 / 360.0, 0.7, 0.7 , "Light Orange"),  #noqa: E201
         (275 / 360.0, 0.7, 0.7 , "Light Purple"),
     )
 

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -80,29 +80,29 @@ except Exception:
 
 class GraphFrame(wx.Frame):
     COLORS = (  # TODO find a good colorblind-friendly palette
-        (  0 / 360.0, 1.0, 0.5 , "Red"),  #noqa: E201
+        (  0 / 360.0, 1.0, 0.5 , "Red"),  # noqa: E201
         (120 / 360.0, 1.0, 0.5 , "Green"),
         (240 / 360.0, 1.0, 0.5 , "Blue"),
-        ( 56 / 360.0, 1.0, 0.5 , "Yellow"),  #noqa: E201
+        ( 56 / 360.0, 1.0, 0.5 , "Yellow"),  # noqa: E201
         (180 / 360.0, 1.0, 0.5 , "Cyan"),
         (300 / 360.0, 1.0, 0.5 , "Magenta"),
-        ( 40 / 360.0, 1.0, 0.5 , "Orange"),  #noqa: E201
+        ( 40 / 360.0, 1.0, 0.5 , "Orange"),  # noqa: E201
         (275 / 360.0, 1.0, 0.5 , "Purple"),
-        (  0 / 360.0, 0.7, 0.35, "Dark Red"),  #noqa: E201
+        (  0 / 360.0, 0.7, 0.35, "Dark Red"),  # noqa: E201
         (120 / 360.0, 0.7, 0.35, "Dark Green"),
         (240 / 360.0, 0.7, 0.35, "Dark Blue"),
-        ( 56 / 360.0, 0.7, 0.35, "Dark Yellow"),  #noqa: E201
+        ( 56 / 360.0, 0.7, 0.35, "Dark Yellow"),  # noqa: E201
         (180 / 360.0, 0.7, 0.35, "Dark Cyan"),
         (300 / 360.0, 0.7, 0.35, "Dark Magenta"),
-        ( 40 / 360.0, 0.7, 0.35, "Dark Orange"),  #noqa: E201
+        ( 40 / 360.0, 0.7, 0.35, "Dark Orange"),  # noqa: E201
         (275 / 360.0, 0.7, 0.35, "Dark Purple"),
-        (  0 / 360.0, 0.7, 0.7 , "Light Red"),  #noqa: E201
+        (  0 / 360.0, 0.7, 0.7 , "Light Red"),  # noqa: E201
         (120 / 360.0, 0.7, 0.7 , "Light Green"),
         (240 / 360.0, 0.7, 0.7 , "Light Blue"),
-        ( 56 / 360.0, 0.7, 0.7 , "Light Yellow"),  #noqa: E201
+        ( 56 / 360.0, 0.7, 0.7 , "Light Yellow"),  # noqa: E201
         (180 / 360.0, 0.7, 0.7 , "Light Cyan"),
         (300 / 360.0, 0.7, 0.7 , "Light Magenta"),
-        ( 40 / 360.0, 0.7, 0.7 , "Light Orange"),  #noqa: E201
+        ( 40 / 360.0, 0.7, 0.7 , "Light Orange"),  # noqa: E201
         (275 / 360.0, 0.7, 0.7 , "Light Purple"),
     )
 

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -113,7 +113,7 @@ class MainMenuBar(wx.MenuBar):
         damagePatternEditItem.SetBitmap(BitmapLoader.getBitmap("damagePattern_small", "gui"))
         windowMenu.AppendItem(damagePatternEditItem)
 
-        targetResistsEditItem = wx.MenuItem(windowMenu, self.targetResistsEditorId, "Target Resists Editor\tCTRL+R")
+        targetResistsEditItem = wx.MenuItem(windowMenu, self.targetResistsEditorId, "Target Profile Editor\tCTRL+R")
         targetResistsEditItem.SetBitmap(BitmapLoader.getBitmap("explosive_small", "gui"))
         windowMenu.AppendItem(targetResistsEditItem)
 

--- a/gui/resistsEditor.py
+++ b/gui/resistsEditor.py
@@ -122,7 +122,8 @@ class ResistsEditorDlg(wx.Dialog):
             else:
                 style = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT
                 border = 5
-            bmp = wx.StaticBitmap(self, wx.ID_ANY, BitmapLoader.getBitmap("22_%d" % (14-i,), "icons")) # TODO get larger gui icons for signatureRadius and maxVelocity
+            # TODO get larger gui icons for signatureRadius and maxVelocity
+            bmp = wx.StaticBitmap(self, wx.ID_ANY, BitmapLoader.getBitmap("22_%d" % (14 - i,), "icons"))
             resistEditSizer.Add(bmp, 0, style, border)
             # set text edit
             setattr(self, "%sEdit" % attr, wx.TextCtrl(self, wx.ID_ANY, "", wx.DefaultPosition, defSize))

--- a/service/fit.py
+++ b/service/fit.py
@@ -1033,7 +1033,7 @@ class Fit(object):
 
     @staticmethod
     def getTargetResists(fitID):
-        pyfalog.debug("Get target resists for fit ID: {0}", fitID)
+        pyfalog.debug("Get target profile for fit ID: {0}", fitID)
         if fitID is None:
             return
 
@@ -1041,7 +1041,7 @@ class Fit(object):
         return fit.targetResists
 
     def setTargetResists(self, fitID, pattern):
-        pyfalog.debug("Set target resist for fit ID: {0}", fitID)
+        pyfalog.debug("Set target profile for fit ID: {0}", fitID)
         if fitID is None:
             return
 

--- a/service/targetResists.py
+++ b/service/targetResists.py
@@ -47,7 +47,7 @@ class TargetResists(object):
 
     @staticmethod
     def newPattern(name):
-        p = es_TargetResists(0.0, 0.0, 0.0, 0.0)
+        p = es_TargetResists()
         p.name = name
         db.save(p)
         return p
@@ -88,9 +88,9 @@ class TargetResists(object):
 
         lenImports = len(imports)
         if lenImports == 0:
-            raise ImportError("No patterns found for import")
+            raise ImportError("No profiles found for import")
         if lenImports != num:
-            raise ImportError("%d patterns imported from clipboard; %d had errors" % (num, num - lenImports))
+            raise ImportError("%d profiles imported from clipboard; %d had errors" % (num, num - lenImports))
 
     def exportPatterns(self):
         patterns = self.getTargetResistsList()

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -25,8 +25,13 @@ def test_fit_dps(DB, Saveddata, RifterFit):
     # add a turret
     mod = Saveddata['Module'](DB['db'].getItem("280mm Howitzer Artillery II"))
     mod.state = Saveddata['State'].ACTIVE
-    ammo = DB['gamedata_session'].query(Gamedata['Item']).filter(Gamedata['Item'].name == "EMP S").first()
-    mod.charge = ammo
+    # there must be a better way to fetch this ammo directly, but I couldn't figure out the appropriate Gamedata voodoo
+    # this, for example, did not work:
+    # mod.charge = DB['gamedata_session'].query(Gamedata['Item']).filter(Gamedata['Item'].name == "EMP S").first()
+    for charge in mod.getValidCharges():
+        if charge.name == "EMP S":
+            mod.charge = charge
+            break
     RifterFit.modules.append(mod)
 
     # update values

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -132,6 +132,7 @@ def test_fighter_dps(DB, Saveddata, KeepstarFit):
 
     # add a fighter
     fighter = Saveddata['Fighter'](DB['db'].getItem("Equite II"))
+    fighter.owner = KeepstarFit
     fighter.amountActive = 1
     KeepstarFit.fighters.append(fighter)
 

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -10,22 +10,33 @@ sys.path.append(script_dir)
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata
-from _development.helpers_fits import RifterFit
+from _development.helpers_fits import RifterFit, KeepstarFit
 from eos.graph.fitDps import FitDpsGraph
 
-def test_fit_dps(DB, Saveddata, RifterFit):
+def test_turret_dps(DB, Saveddata, RifterFit):
     """
-    Tests applied damage
+    Tests applied turret damage
     """
 
     # set pilot
     char0 = Saveddata['Character'].getAll0()
     RifterFit.character = char0
 
+    # configure DPS analysis to include as many factors as possible
+    # (damage type reistance, distance past turret optimal, sig/speed/angle to incur turret tracking penalty)
+    graph = FitDpsGraph(RifterFit)
+    data = graph.defaults.copy()
+    data['emRes'] = 10.0
+    data['distance'] = 7.0
+    data['signatureRadius'] = 100.0
+    data['tgtAngle'] = 90.0
+    data['tgtSpeed'] = 100.0
+
     # add a turret
     mod = Saveddata['Module'](DB['db'].getItem("280mm Howitzer Artillery II"))
+    mod.owner = RifterFit
     mod.state = Saveddata['State'].ACTIVE
-    # there must be a better way to fetch this ammo directly, but I couldn't figure out the appropriate Gamedata voodoo
+    # there must be a better way to fetch this ammo directly, but I couldn't figure out the appropriate Gamedata voodoo;
     # this, for example, did not work:
     # mod.charge = DB['gamedata_session'].query(Gamedata['Item']).filter(Gamedata['Item'].name == "EMP S").first()
     for charge in mod.getValidCharges():
@@ -33,20 +44,100 @@ def test_fit_dps(DB, Saveddata, RifterFit):
             mod.charge = charge
             break
     RifterFit.modules.append(mod)
-    mod.owner = RifterFit
-
-    # update values
-    RifterFit.clear()
-    RifterFit.calculateModifiedAttributes()
 
     # calculate applied DPS
+    RifterFit.clear()
+    RifterFit.calculateModifiedAttributes()
+    dps = graph.calcDps(data)
+    assert abs(dps - 8.8) < 0.05
+
+def test_missile_dps(DB, Saveddata, RifterFit):
+    """
+    Tests applied missile damage
+    """
+
+    # set pilot
+    char0 = Saveddata['Character'].getAll0()
+    RifterFit.character = char0
+
+    # configure DPS analysis to include as many factors as possible
+    # (damage type reistance, sig/speed to incur missile application penalty)
     graph = FitDpsGraph(RifterFit)
     data = graph.defaults.copy()
     data['emRes'] = 10.0
     data['distance'] = 7.0
-    data['signatureRadius'] = 50.0
-    data['tgtAngle'] = 90.0
+    data['signatureRadius'] = 100.0
     data['tgtSpeed'] = 100.0
-    dps = graph.calcDps(data)
 
-    assert abs(dps - 8.6) < 0.05
+    # add a launcher
+    mod = Saveddata['Module'](DB['db'].getItem("Heavy Missile Launcher II"))
+    mod.owner = RifterFit
+    mod.state = Saveddata['State'].ACTIVE
+    # there must be a better way to fetch this ammo directly, but I couldn't figure out the appropriate Gamedata voodoo;
+    # this, for example, did not work:
+    # mod.charge = DB['gamedata_session'].query(Gamedata['Item']).filter(Gamedata['Item'].name == "Mjolnir Heavy Missile").first()
+    for charge in mod.getValidCharges():
+        if charge.name == "Mjolnir Heavy Missile":
+            mod.charge = charge
+            break
+    RifterFit.modules.append(mod)
+
+    # calculate applied DPS
+    RifterFit.clear()
+    RifterFit.calculateModifiedAttributes()
+    dps = graph.calcDps(data)
+    assert abs(dps - 7.3) < 0.05
+
+def test_drone_dps(DB, Saveddata, RifterFit):
+    """
+    Tests applied drone damage
+    """
+
+    # set pilot
+    char0 = Saveddata['Character'].getAll0()
+    RifterFit.character = char0
+
+    # configure DPS analysis to include as many factors as possible
+    # (damage type reistance)
+    graph = FitDpsGraph(RifterFit)
+    data = graph.defaults.copy()
+    data['emRes'] = 10.0
+
+    # add a drone
+    drone = Saveddata['Drone'](DB['db'].getItem("Acolyte II"))
+    drone.amount = 1
+    drone.amountActive = 1
+    RifterFit.drones.append(drone)
+
+    # calculate applied DPS
+    RifterFit.clear()
+    RifterFit.calculateModifiedAttributes()
+    dps = graph.calcDps(data)
+    assert abs(dps - 7.6) < 0.05
+
+def test_fighter_dps(DB, Saveddata, KeepstarFit):
+    """
+    Tests applied fighter damage
+    """
+
+    # set pilot
+    char0 = Saveddata['Character'].getAll0()
+    KeepstarFit.character = char0
+
+    # configure DPS analysis to include as many factors as possible
+    # (damage type reistance)
+    graph = FitDpsGraph(KeepstarFit)
+    data = graph.defaults.copy()
+    data['emRes'] = 10.0
+
+    # add a fighter
+    KeepstarFit.modules.clear()
+    fighter = Saveddata['Fighter'](DB['db'].getItem("Equite II"))
+    fighter.amountActive = 1
+    KeepstarFit.fighters.append(fighter)
+
+    # calculate applied DPS
+    KeepstarFit.clear()
+    KeepstarFit.calculateModifiedAttributes()
+    dps = graph.calcDps(data)
+    assert abs(dps - 10.8) < 0.05

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -131,7 +131,6 @@ def test_fighter_dps(DB, Saveddata, KeepstarFit):
     data['emRes'] = 10.0
 
     # add a fighter
-    KeepstarFit.modules.clear()
     fighter = Saveddata['Fighter'](DB['db'].getItem("Equite II"))
     fighter.amountActive = 1
     KeepstarFit.fighters.append(fighter)

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -133,7 +133,10 @@ def test_fighter_dps(DB, Saveddata, KeepstarFit):
     # add a fighter
     fighter = Saveddata['Fighter'](DB['db'].getItem("Equite II"))
     fighter.owner = KeepstarFit
+    fighter.active = True
     fighter.amountActive = 1
+    for ability in fighter.abilities:
+        ability.active = True
     KeepstarFit.fighters.append(fighter)
 
     # calculate applied DPS

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -33,6 +33,7 @@ def test_fit_dps(DB, Saveddata, RifterFit):
             mod.charge = charge
             break
     RifterFit.modules.append(mod)
+    mod.owner = RifterFit
 
     # update values
     RifterFit.clear()

--- a/tests/test_modules/test_eos/test_fitDps.py
+++ b/tests/test_modules/test_eos/test_fitDps.py
@@ -1,0 +1,46 @@
+# Add root folder to python paths
+# This must be done on every test in order to pass in Travis
+import math
+import os
+import sys
+script_dir = os.path.dirname(os.path.abspath(__file__))
+script_dir = os.path.realpath(os.path.join(script_dir, '..', '..', '..'))
+print script_dir
+sys.path.append(script_dir)
+
+# noinspection PyPackageRequirements
+from _development.helpers import DBInMemory as DB, Gamedata, Saveddata
+from _development.helpers_fits import RifterFit
+from eos.graph.fitDps import FitDpsGraph
+
+def test_fit_dps(DB, Saveddata, RifterFit):
+    """
+    Tests applied damage
+    """
+
+    # set pilot
+    char0 = Saveddata['Character'].getAll0()
+    RifterFit.character = char0
+
+    # add a turret
+    mod = Saveddata['Module'](DB['db'].getItem("280mm Howitzer Artillery II"))
+    mod.state = Saveddata['State'].ACTIVE
+    ammo = DB['gamedata_session'].query(Gamedata['Item']).filter(Gamedata['Item'].name == "EMP S").first()
+    mod.charge = ammo
+    RifterFit.modules.append(mod)
+
+    # update values
+    RifterFit.clear()
+    RifterFit.calculateModifiedAttributes()
+
+    # calculate applied DPS
+    graph = FitDpsGraph(RifterFit)
+    data = graph.defaults.copy()
+    data['emRes'] = 10.0
+    data['distance'] = 7.0
+    data['signatureRadius'] = 50.0
+    data['tgtAngle'] = 90.0
+    data['tgtSpeed'] = 100.0
+    dps = graph.calcDps(data)
+
+    assert abs(dps - 8.6) < 0.05


### PR DESCRIPTION
## Changes

The primary purpose of this pull request is to introduce a new "DPS Simulator" in the Graph window which functions much like EFT's damage graph:

* Multiple attackers and targets may be graphed simultaneously; plots of DPS by distance are calculated for each pair and rendered on the same axes for easy comparisons.
* An attacker must be a saved fit; any fit can be dragged onto the Attackers list to add it, and currently opened fits can be added using the right-click context menu on the Attackers list.
* A target may be either a saved fit or a target profile (previously called "target resists"); target fits can be added in the same ways, but target profiles can only be added by right-click (as there is no good place to drag them from).
* Attackers and targets can both be removed by double-clicking them in their respective list.
* Left-click on a line in the plot to select it; that line then becomes thicker and a caption appears to identify the corresponding attacker and target. The line's color can also be changed by clicking on the matching colored box beside the line caption.
* Right-click on the plot to set a marker at a specific range; each plot will also show an annotation of its exact DPS value at that range.
* Set attacker and target velocity vectors using the graphical vector widgets above the attacker and target lists; left-click to set to any values, right-click to snap to 15&deg;/5% increments, or mouse wheel to change only the speed (as a percentage of maximum).
* For target fits, damage resistances can be ignored, calculated only for a specific layer (hull/armor/shield), or weighted by layer hitpoints (the default). Target profiles have only one set of resistances, so they can only be ignored or considered (any other setting).

A few small changes are also made elsewhere to support the new DPS Simulator graph:

* "Target resists" are now called "target profiles" and may optionally specify the target's signature radius and velocity in addition to its damage type resistances.
* Existing profiles will default to 0 (or blank) for both new values, which will ignore those attributes for applied damage calculations (a signature radius of 0 is treated as infinite).
* When a target profile is selected in an open fit's Firepower panel, the displayed effective firepower will reflect a "best-case scenario" in which range and transversal are zero, but the target's signature radius is still considered.
* Consequently, effective turret damage will appear slightly higher than before since signature radius does not impact turret damage with zero transversal, but the signature radius calculation still factors in wrecking shots which were previously ignored.
* Conversely, effective missile damage may appear lower than before unless the target's signature radius is larger than the missile's explosion radius. Any activated target painters or missile guidance computers on the fit will be factored in, however.

## Screenshots

![DPS Simulator](https://i.imgur.com/HVwtnba.png)

![Target Profile Editor](https://i.imgur.com/ugKq1Pm.png)