### PR TITLE
Include service modules in EFT export

### DIFF
--- a/service/port.py
+++ b/service/port.py
@@ -59,13 +59,14 @@ try:
 except ImportError:
     from utils.compat import OrderedDict
 
-EFT_SLOT_ORDER = [Slot.LOW, Slot.MED, Slot.HIGH, Slot.RIG, Slot.SUBSYSTEM]
+EFT_SLOT_ORDER = [Slot.LOW, Slot.MED, Slot.HIGH, Slot.RIG, Slot.SUBSYSTEM, Slot.SERVICE]
 INV_FLAGS = {
     Slot.LOW: 11,
     Slot.MED: 19,
     Slot.HIGH: 27,
     Slot.RIG: 92,
-    Slot.SUBSYSTEM: 125
+    Slot.SUBSYSTEM: 125,
+    Slot.SERVICE: 164
 }
 
 INV_FLAG_CARGOBAY = 5


### PR DESCRIPTION
Change to service/port.py to include Slot.SERVICE in export
Also fixes a crash when attempting to export citadel with service
modules to CREST

--

#1362 

Service slots were not being included in EFT or CREST exports. This was causing a crash in the case of exporting a citadel with service modules. Example exports after change, EFT:

```
[Athanor, Athanor fit]

Standup Ballistic Control System I

Standup Stasis Webifier I
Standup Warp Scrambler I
Standup Target Painter I

Standup ASML Missile Launcher I, Standup ASML-LD Missile
Standup Heavy Energy Neutralizer I
Standup Heavy Energy Neutralizer I

[Empty Rig slot]
[Empty Rig slot]
[Empty Rig slot]

Standup Cloning Center I
Standup Cloning Center I
[Empty Service slot]
```
CREST:
`{"items": [{"flag": 11, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35959/", "id": 35959, "name": ""}, "quantity": 1}, {"flag": 19, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35943/", "id": 35943, "name": ""}, "quantity": 1}, {"flag": 20, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35949/", "id": 35949, "name": ""}, "quantity": 1}, {"flag": 21, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35947/", "id": 35947, "name": ""}, "quantity": 1}, {"flag": 27, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35922/", "id": 35922, "name": ""}, "quantity": 1}, {"flag": 28, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35925/", "id": 35925, "name": ""}, "quantity": 1}, {"flag": 29, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35925/", "id": 35925, "name": ""}, "quantity": 1}, {"flag": 164, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35894/", "id": 35894, "name": ""}, "quantity": 1}, {"flag": 165, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/35894/", "id": 35894, "name": ""}, "quantity": 1}, {"flag": 5, "type": {"href": "https://crest-tq.eveonline.com/inventory/types/37846/", "id": 37846, "name": ""}, "quantity": 50}], "ship": {"href": "https://crest-tq.eveonline.com/inventory/types/35835/", "id": 35835, "name": ""}, "name": "Athanor fit", "description": ""}`