### PR TITLE
Remove energy warfare resistance on capNeed calc

### DIFF
--- a/eos/effects/energynosferatufalloff.py
+++ b/eos/effects/energynosferatufalloff.py
@@ -12,7 +12,7 @@ def handler(fit, src, context, **kwargs):
     amount = src.getModifiedItemAttr("powerTransferAmount")
     time = src.getModifiedItemAttr("duration")
 
-    if 'effect' in kwargs:
+    if 'effect' in kwargs and "projected" in context:
         amount *= ModifiedAttributeDict.getResistance(fit, kwargs['effect'])
 
     if "projected" in context:


### PR DESCRIPTION
When calculating the capactitor need of an energy nosferatu the
amount was being modified incorrectly by the energy warfare
resistance of the ship. Change to only apply energy warfare
resitance modifier if this is a projected effect.

---

#1360 

When fixing #1322 I introduced a new bug that caused the capacitor need of nosferatus to be modified by the energy warfare resistance of the ship. The correct approach is to only modify this amount in the case where this is a projected effect.