### PR TITLE
Ensure graph frame unbinds its event handlers.

### DIFF
--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -170,8 +170,8 @@ class GraphFrame(wx.Frame):
             self.AppendFitToList(fitID)
 
     def close(self, event):
-        self.fitList.fitList.Unbind(wx.EVT_LEFT_DCLICK)
-        self.mainFrame.Unbind(GE.FIT_CHANGED)
+        self.fitList.fitList.Unbind(wx.EVT_LEFT_DCLICK, handler=self.removeItem)
+        self.mainFrame.Unbind(GE.FIT_CHANGED, handler=self.draw)
         event.Skip()
 
     def getView(self):


### PR DESCRIPTION
This is a partial reversion of d4df989 which seems required for the graphFrame to unbind event handlers.