### PR TITLE
Issue#1484 Make various modules active

### DIFF
--- a/eos/effects/doomsdaybeamdot.py
+++ b/eos/effects/doomsdaybeamdot.py
@@ -1,0 +1,8 @@
+# doomsdayBeamDOT
+#
+# Used by:
+# Module: Lance type modules
+type = "active"
+
+def handler(fit, src, context):
+    pass

--- a/eos/effects/doomsdayconedot.py
+++ b/eos/effects/doomsdayconedot.py
@@ -1,0 +1,8 @@
+# doomsdayConeDOT
+#
+# Used by:
+# Module: Bosonic Field Generator
+type = "active"
+
+def handler(fit, src, context):
+    pass

--- a/eos/effects/doomsdayhog.py
+++ b/eos/effects/doomsdayhog.py
@@ -1,0 +1,8 @@
+# doomsdayHOG
+#
+# Used by:
+# Module: GTFO - Gravitational Transportation Field Oscillator
+type = "active"
+
+def handler(fit, src, context):
+    pass

--- a/eos/effects/doomsdayslash.py
+++ b/eos/effects/doomsdayslash.py
@@ -1,0 +1,8 @@
+# doomsdaySlash
+#
+# Used by:
+# Module: Reaper type modules
+type = "active"
+
+def handler(fit, src, context):
+    pass

--- a/eos/effects/microjumpportaldrive.py
+++ b/eos/effects/microjumpportaldrive.py
@@ -1,0 +1,8 @@
+# microJumpPortalDrive
+#
+# Used by:
+# Module: MJFG - Micro Jump Field Generator (used on command destroyers)
+type = "active"
+
+def handler(fit, src, context):
+    pass


### PR DESCRIPTION
Partially resolves #1484. We still have the following modules that use cap but have no active state.

Jump Portal Generators.
Cargo Scanners
Ship Scanners
Survey Scanners
Passive Targeters