### PR TITLE
CapSim changes to make reloadtime a variable.

### DIFF
--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -79,6 +79,7 @@ class CapSimulator(object):
             # a cap booster module.
             if not self.reload and capNeed > 0:
                 clipSize = 0
+                reloadTime = 0
 
             # Group modules based on their properties
             if (duration, capNeed, clipSize, disableStagger, reloadTime) in mods:

--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -71,7 +71,7 @@ class CapSimulator(object):
         disable_period = False
 
         # Loop over modules, clearing clipSize if applicable, and group modules based on attributes
-        for (duration, capNeed, clipSize, disableStagger) in self.modules:
+        for (duration, capNeed, clipSize, disableStagger, reloadTime) in self.modules:
             if self.scale:
                 duration, capNeed = self.scale_activation(duration, capNeed)
 
@@ -81,22 +81,22 @@ class CapSimulator(object):
                 clipSize = 0
 
             # Group modules based on their properties
-            if (duration, capNeed, clipSize, disableStagger) in mods:
-                mods[(duration, capNeed, clipSize, disableStagger)] += 1
+            if (duration, capNeed, clipSize, disableStagger, reloadTime) in mods:
+                mods[(duration, capNeed, clipSize, disableStagger, reloadTime)] += 1
             else:
-                mods[(duration, capNeed, clipSize, disableStagger)] = 1
+                mods[(duration, capNeed, clipSize, disableStagger, reloadTime)] = 1
 
         # Loop over grouped modules, configure staggering and push to the simulation state
-        for (duration, capNeed, clipSize, disableStagger), amount in mods.iteritems():
+        for (duration, capNeed, clipSize, disableStagger, reloadTime), amount in mods.iteritems():
             if self.stagger and not disableStagger:
                 if clipSize == 0:
                     duration = int(duration / amount)
                 else:
-                    stagger_amount = (duration * clipSize + 10000) / (amount * clipSize)
+                    stagger_amount = (duration * clipSize + reloadTime) / (amount * clipSize)
                     for i in range(1, amount):
                         heapq.heappush(self.state,
                                        [i * stagger_amount, duration,
-                                        capNeed, 0, clipSize])
+                                        capNeed, 0, clipSize, reloadTime])
             else:
                 capNeed *= amount
 
@@ -106,7 +106,7 @@ class CapSimulator(object):
             if clipSize:
                 disable_period = True
 
-            heapq.heappush(self.state, [0, duration, capNeed, 0, clipSize])
+            heapq.heappush(self.state, [0, duration, capNeed, 0, clipSize, reloadTime])
 
         if disable_period:
             self.period = self.t_max
@@ -143,7 +143,7 @@ class CapSimulator(object):
 
         while 1:
             activation = pop(state)
-            t_now, duration, capNeed, shot, clipSize = activation
+            t_now, duration, capNeed, shot, clipSize, reloadTime = activation
             if t_now >= t_max:
                 break
 
@@ -179,7 +179,7 @@ class CapSimulator(object):
             if clipSize:
                 if shot % clipSize == 0:
                     shot = 0
-                    t_now += 10000  # include reload time
+                    t_now += reloadTime  # include reload time
             activation[0] = t_now
             activation[3] = shot
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1186,7 +1186,7 @@ class Fit(object):
         rechargeRate = self.ship.getModifiedItemAttr("shieldRechargeRate") / 1000.0
         return 10 / rechargeRate * sqrt(percent) * (1 - sqrt(percent)) * capacity
 
-    def addDrain(self, src, cycleTime, capNeed, clipSize=0):
+    def addDrain(self, src, cycleTime, capNeed, clipSize=0, reloadTime=0):
         """ Used for both cap drains and cap fills (fills have negative capNeed) """
 
         energyNeutralizerSignatureResolution = src.getModifiedItemAttr("energyNeutralizerSignatureResolution")
@@ -1196,7 +1196,7 @@ class Fit(object):
         if energyNeutralizerSignatureResolution:
             capNeed = capNeed * min(1, signatureRadius / energyNeutralizerSignatureResolution)
 
-        self.__extraDrains.append((cycleTime, capNeed, clipSize))
+        self.__extraDrains.append((cycleTime, capNeed, clipSize, reloadTime))
 
     def removeDrain(self, i):
         del self.__extraDrains[i]
@@ -1214,6 +1214,7 @@ class Fit(object):
                     cycleTime = mod.rawCycleTime or 0
                     reactivationTime = mod.getModifiedItemAttr("moduleReactivationDelay") or 0
                     fullCycleTime = cycleTime + reactivationTime
+                    reloadTime = mod.reloadTime
                     if fullCycleTime > 0:
                         capNeed = mod.capUse
                         if capNeed > 0:
@@ -1225,11 +1226,11 @@ class Fit(object):
                         disableStagger = mod.hardpoint == Hardpoint.TURRET
 
                         drains.append((int(fullCycleTime), mod.getModifiedItemAttr("capacitorNeed") or 0,
-                                       mod.numShots or 0, disableStagger))
+                                       mod.numShots or 0, disableStagger, reloadTime))
 
-        for fullCycleTime, capNeed, clipSize in self.iterDrains():
+        for fullCycleTime, capNeed, clipSize, reloadTime in self.iterDrains():
             # Stagger incoming effects for cap simulation
-            drains.append((int(fullCycleTime), capNeed, clipSize, False))
+            drains.append((int(fullCycleTime), capNeed, clipSize, False, reloadTime))
             if capNeed > 0:
                 capUsed += capNeed / (fullCycleTime / 1000.0)
             else:


### PR DESCRIPTION
This allows the module attribute reloadtime to be passed to the capsim. This addresses #1490. Without reload preference true, this capsim, sims exactly the same as previously. With reload preference true the capsim is only different for fits with modules that have a reload other than 10secs.