### PR TITLE
Respect 'Factor in Reload' preference for sustainable tank (tidied up).

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1169,8 +1169,8 @@ class Fit(object):
                 # Sort repairers by efficiency. We want to use the most efficient repairers first
                 repairers.sort(key=lambda _mod: _mod.getModifiedItemAttr(
                     groupAttrMap[_mod.item.group.name]) * (_mod.getModifiedItemAttr(
-                    "chargedArmorDamageMultiplier") or 1)
-                                                / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
+                        "chargedArmorDamageMultiplier") or 1)
+                            / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
 
                 # Loop through every module until we're above peak recharge
                 # Most efficient first, as we sorted earlier.

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1084,7 +1084,7 @@ class Fit(object):
 
     def calculateSustainableTank(self, effective=True):
         if self.__sustainableTank is None:
-            if self.capStable:
+            if self.capStable and not self.factorReload:
                 sustainable = {
                     "armorRepair" : self.extraAttributes["armorRepair"],
                     "shieldRepair": self.extraAttributes["shieldRepair"],
@@ -1142,16 +1142,35 @@ class Fit(object):
                                         usesCap = False
                                 except AttributeError:
                                     usesCap = False
-                                # Modules which do not use cap are not penalized based on cap use
-                                if usesCap:
-                                    cycleTime = mod.getModifiedItemAttr("duration")
-                                    amount = mod.getModifiedItemAttr(groupAttrMap[mod.item.group.name])
+
+                                cycleTime = mod.rawCycleTime
+                                amount = mod.getModifiedItemAttr(groupAttrMap[mod.item.group.name])
+                                # Normal Repairers
+                                if usesCap and not mod.charge:
                                     sustainable[attr] -= amount / (cycleTime / 1000.0)
                                     repairers.append(mod)
+                                # Ancillary Armor reps etc
+                                elif usesCap and mod.charge:
+                                    if mod.charge.name == "Nanite Repair Paste":
+                                        multiplier = mod.getModifiedItemAttr("chargedArmorDamageMultiplier") or 1
+                                    else:
+                                        multiplier = 1
+                                    sustainable[attr] -= amount * multiplier / (cycleTime / 1000.0)
+                                    repairers.append(mod)
+                                # Ancillary Shield boosters etc
+                                elif not usesCap:
+                                    if self.factorReload and mod.charge:
+                                        reloadtime = mod.reloadTime
+                                    else:
+                                        reloadtime = 0.0
+                                    offdutycycle = reloadtime / ((max(mod.numShots, 1) * cycleTime) + reloadtime)
+                                    sustainable[attr] -= amount * offdutycycle / (cycleTime / 1000.0)
 
                 # Sort repairers by efficiency. We want to use the most efficient repairers first
                 repairers.sort(key=lambda _mod: _mod.getModifiedItemAttr(
-                        groupAttrMap[_mod.item.group.name]) / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
+                    groupAttrMap[_mod.item.group.name]) * (_mod.getModifiedItemAttr(
+                    "chargedArmorDamageMultiplier") or 1)
+                                                / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
 
                 # Loop through every module until we're above peak recharge
                 # Most efficient first, as we sorted earlier.
@@ -1160,15 +1179,35 @@ class Fit(object):
                 for mod in repairers:
                     if capUsed > totalPeakRecharge:
                         break
-                    cycleTime = mod.cycleTime
+
+                    if self.factorReload and mod.charge:
+                        reloadtime = mod.reloadTime
+                    else:
+                        reloadtime = 0.0
+
+                    cycleTime = mod.rawCycleTime
                     capPerSec = mod.capUse
+
                     if capPerSec is not None and cycleTime is not None:
                         # Check how much this repper can work
                         sustainability = min(1, (totalPeakRecharge - capUsed) / capPerSec)
-
-                        # Add the sustainable amount
                         amount = mod.getModifiedItemAttr(groupAttrMap[mod.item.group.name])
-                        sustainable[groupStoreMap[mod.item.group.name]] += sustainability * (amount / (cycleTime / 1000.0))
+                        # Add the sustainable amount
+
+                        if not mod.charge:
+                            sustainable[groupStoreMap[mod.item.group.name]] += sustainability * amount / (
+                                    cycleTime / 1000.0)
+                        else:
+                            if mod.charge.name == "Nanite Repair Paste":
+                                multiplier = mod.getModifiedItemAttr("chargedArmorDamageMultiplier") or 1
+                            else:
+                                multiplier = 1
+                            ondutycycle = (max(mod.numShots, 1) * cycleTime) / (
+                                    (max(mod.numShots, 1) * cycleTime) + reloadtime)
+                            sustainable[groupStoreMap[
+                                mod.item.group.name]] += sustainability * amount * ondutycycle * multiplier / (
+                                    cycleTime / 1000.0)
+
                         capUsed += capPerSec
 
             sustainable["passiveShield"] = self.calculateShieldRecharge()

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1169,8 +1169,7 @@ class Fit(object):
                 # Sort repairers by efficiency. We want to use the most efficient repairers first
                 repairers.sort(key=lambda _mod: _mod.getModifiedItemAttr(
                     groupAttrMap[_mod.item.group.name]) * (_mod.getModifiedItemAttr(
-                        "chargedArmorDamageMultiplier") or 1)
-                            / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
+                        "chargedArmorDamageMultiplier") or 1) / _mod.getModifiedItemAttr("capacitorNeed"), reverse=True)
 
                 # Loop through every module until we're above peak recharge
                 # Most efficient first, as we sorted earlier.


### PR DESCRIPTION
This fixes the reported sustainable tank for AAR and ASB. Resolves #1439 when used with the new capsim.

I did this fix in eso/savedata/fit.py. You can do it in effects but that involves overwriting the peak (reinforced) repair figures which I think should be shown all the time as the actual peak. If extrattributes were put in to hold sustained values then you could do the fix in effects without any down side.

Anyway have a play and see if it breaks. Comment welcome.