### PR TITLE
Use list control length instead of sys.maxsize for platform compatibility

### DIFF
--- a/gui/builtinItemStatsViews/itemAttributes.py
+++ b/gui/builtinItemStatsViews/itemAttributes.py
@@ -1,4 +1,3 @@
-import sys
 import csv
 import config
 
@@ -203,7 +202,7 @@ class ItemParams(wx.Panel):
             else:
                 attrIcon = self.imageList.Add(BitmapLoader.getBitmap("7_15", "icons"))
 
-            index = self.paramList.InsertItem(sys.maxsize, attrName, attrIcon)
+            index = self.paramList.InsertItem(self.paramList.GetItemCount(), attrName, attrIcon)
             idNameMap[idCount] = attrName
             self.paramList.SetItemData(index, idCount)
             idCount += 1

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -1,5 +1,3 @@
-import sys
-
 # noinspection PyPackageRequirements
 import wx
 
@@ -147,7 +145,7 @@ class ItemCompare(wx.Panel):
         self.paramList.SetColumnWidth(len(self.attrs) + 1, 60)
 
         for item in self.items:
-            i = self.paramList.InsertItem(sys.maxsize, item.name)
+            i = self.paramList.InsertItem(self.paramList.GetItemCount(), item.name)
             for x, attr in enumerate(self.attrs.keys()):
                 if attr in item.attributes:
                     info = self.attrs[attr]

--- a/gui/builtinItemStatsViews/itemEffects.py
+++ b/gui/builtinItemStatsViews/itemEffects.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import subprocess
 import config
@@ -51,7 +50,7 @@ class ItemEffects(wx.Panel):
         names.sort()
 
         for name in names:
-            index = self.effectList.InsertItem(sys.maxsize, name)
+            index = self.effectList.InsertItem(self.effectList.GetItemCount(), name)
 
             if effects[name].isImplemented:
                 if effects[name].activeByDefault:

--- a/gui/builtinItemStatsViews/itemProperties.py
+++ b/gui/builtinItemStatsViews/itemProperties.py
@@ -1,5 +1,3 @@
-import sys
-
 # noinspection PyPackageRequirements
 import wx
 
@@ -79,7 +77,7 @@ class ItemProperties(wx.Panel):
                     attrName = name.title()
                     value = getattr(self.item, name)
 
-                index = self.paramList.InsertItem(sys.maxsize, attrName)
+                index = self.paramList.InsertItem(self.paramList.GetItemCount(), attrName)
                 # index = self.paramList.InsertImageStringItem(sys.maxint, attrName)
                 idNameMap[idCount] = attrName
                 self.paramList.SetItemData(index, idCount)

--- a/gui/display.py
+++ b/gui/display.py
@@ -17,7 +17,6 @@
 # along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
-import sys
 # noinspection PyPackageRequirements
 import wx
 import gui.mainFrame
@@ -182,13 +181,13 @@ class Display(wx.ListCtrl):
 
             if listItemCount < stuffItemCount:
                 for i in range(stuffItemCount - listItemCount):
-                    self.InsertItem(sys.maxsize, "")
+                    self.InsertItem(self.GetItemCount(), "")
 
             if listItemCount > stuffItemCount:
                 if listItemCount - stuffItemCount > 20 > stuffItemCount:
                     self.DeleteAllItems()
                     for i in range(stuffItemCount):
-                        self.InsertItem(sys.maxsize, "")
+                        self.InsertItem(self.GetItemCount(), "")
                 else:
                     for i in range(listItemCount - stuffItemCount):
                         self.DeleteItem(self.getLastItem())


### PR DESCRIPTION
@blitzmann and I discussed this over Slack and replacing usage of `sys.maxsize` (which varies by system bitness) with this was the conclusion.