### PR TITLE
Use proxies from Pyfa's "Network settings" for ESI requests

### DIFF
--- a/service/esiAccess.py
+++ b/service/esiAccess.py
@@ -85,7 +85,7 @@ class EsiAccess(object):
                 'pyfa v{}'.format(config.version)
             )
         })
-        self._session.proxies = self.get_requests_proxies()
+        self._session.proxies = NetworkSettings.getInstance().getProxySettingsInRequestsFormat()
 
     @property
     def sso_url(self):
@@ -132,26 +132,6 @@ class EsiAccess(object):
         char.accessTokenExpires = datetime.datetime.fromtimestamp(time.time() + tokenResponse['expires_in'])
         if 'refresh_token' in tokenResponse:
             char.refreshToken = config.cipher.encrypt(tokenResponse['refresh_token'].encode())
-
-    @staticmethod
-    def get_requests_proxies():
-        proxies = {}
-        proxy_settings = NetworkSettings.getInstance().getProxySettings()
-        # proxy_settings is a tuple of (host, port), like  ('192.168.20.1', 3128), or None
-        if proxy_settings is not None:
-            # form proxy address in format "http://host:port
-            proxy_host_port = '{}:{}'.format(proxy_settings[0], proxy_settings[1])
-            proxy_auth_details = NetworkSettings.getInstance().getProxyAuthDetails()
-            # proxy_auth_details is a tuple of (login, password), or None
-            user_pass = ''
-            if proxy_auth_details is not None:
-                # construct prefix in form "user:password@"
-                user_pass = '{}:{}@'.format(proxy_auth_details[0], proxy_auth_details[1])
-            proxies = {
-                'http': 'http://' + user_pass + proxy_host_port,
-                'https': 'http://' + user_pass + proxy_host_port
-            }
-        return proxies
 
     def getLoginURI(self, redirect=None):
         self.state = str(uuid.uuid4())

--- a/service/network.py
+++ b/service/network.py
@@ -93,25 +93,7 @@ class Network(object):
         # or with HTTP Basic auth support: proxies = {'http': 'http://user:pass@10.10.1.10:3128/'}
         # then you do: requests.get('http://example.org', proxies=proxies)
 
-        proxies = None
-        proxy_settings = NetworkSettings.getInstance().getProxySettings()
-        # proxy_settings is a tuple of (host, port), like  ('192.168.20.1', 3128), or None
-
-        if proxy_settings is not None:
-            # form proxy address in format "http://host:port
-            proxy_host_port = '{}:{}'.format(proxy_settings[0], proxy_settings[1])
-            proxy_auth_details = NetworkSettings.getInstance().getProxyAuthDetails()
-            # proxy_auth_details is a tuple of (login, password), or None
-            user_pass = ''
-            if proxy_auth_details is not None:
-                # construct prefix in form "user:password@"
-                user_pass = '{}:{}@'.format(proxy_auth_details[0], proxy_auth_details[1])
-            proxies = {
-                'http': 'http://' + user_pass + proxy_host_port,
-                'https': 'http://' + user_pass + proxy_host_port
-            }
-            # final form: { 'http': 'http://user:password@host:port', ... }, or
-            #             { 'http': 'http://host:port', ... }   if no auth info.
+        proxies = NetworkSettings.getInstance().getProxySettingsInRequestsFormat()
 
         try:
             resp = requests.get(url, headers=headers, proxies=proxies, **kwargs)

--- a/service/settings.py
+++ b/service/settings.py
@@ -284,6 +284,23 @@ class NetworkSettings(object):
         self.serviceNetworkSettings["login"] = login
         self.serviceNetworkSettings["password"] = password
 
+    def getProxySettingsInRequestsFormat(self) -> dict:
+        proxies = {}
+        proxy_settings = self.getProxySettings()
+        if proxy_settings is not None:
+            # form proxy address in format "http://host:port
+            proxy_host_port = '{}:{}'.format(proxy_settings[0], proxy_settings[1])
+            proxy_auth_details = self.getProxyAuthDetails()
+            user_pass = ''
+            if proxy_auth_details is not None:
+                # construct prefix in form "user:password@"
+                user_pass = '{}:{}@'.format(proxy_auth_details[0], proxy_auth_details[1])
+            proxies = {
+                'http': 'http://' + user_pass + proxy_host_port,
+                'https': 'http://' + user_pass + proxy_host_port
+            }
+        return proxies
+
 
 class HTMLExportSettings(object):
     """


### PR DESCRIPTION
Requests session objects already can use proxies for all requests it makes. Just need to provide them to session object