### PR TITLE
Copy text from item traits pane

### DIFF
--- a/gui/builtinItemStatsViews/itemTraits.py
+++ b/gui/builtinItemStatsViews/itemTraits.py
@@ -37,6 +37,9 @@ class ItemTraits(wx.Panel):
         # Ctrl + C
         if keyCode == 67 and event.ControlDown():
             self.copySelectionToClipboard()
+        # Ctrl + A
+        if keyCode == 65 and event.ControlDown():
+            self.traits.SelectAll()
 
     def copySelectionToClipboard(self):
         selectedText = self.traits.SelectionToText()

--- a/gui/builtinItemStatsViews/itemTraits.py
+++ b/gui/builtinItemStatsViews/itemTraits.py
@@ -13,5 +13,24 @@ class ItemTraits(wx.Panel):
         self.traits = wx.html.HtmlWindow(self)
         self.traits.SetPage(item.traits.traitText)
 
+        self.traits.Bind(wx.EVT_CONTEXT_MENU, self.showPopupMenu)
+
         mainSizer.Add(self.traits, 1, wx.ALL | wx.EXPAND, 0)
         self.Layout()
+
+        self.popupMenu = wx.Menu()
+        copyItem = wx.MenuItem(self.popupMenu, 1, 'Copy')
+        self.popupMenu.Append(copyItem)
+        self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
+
+    def showPopupMenu(self, event):
+        self.PopupMenu(self.popupMenu)
+
+    def menuClickHandler(self, event):
+        selectedMenuItem = event.GetId()
+        if selectedMenuItem == 1:  # Copy was chosen
+            selectedText = self.traits.SelectionToText()
+            if len(selectedText) > 0:
+                if wx.TheClipboard.Open():
+                    wx.TheClipboard.SetData(wx.TextDataObject(selectedText))
+                    wx.TheClipboard.Close()

--- a/gui/builtinItemStatsViews/itemTraits.py
+++ b/gui/builtinItemStatsViews/itemTraits.py
@@ -13,7 +13,8 @@ class ItemTraits(wx.Panel):
         self.traits = wx.html.HtmlWindow(self)
         self.traits.SetPage(item.traits.traitText)
 
-        self.traits.Bind(wx.EVT_CONTEXT_MENU, self.showPopupMenu)
+        self.traits.Bind(wx.EVT_CONTEXT_MENU, self.onPopupMenu)
+        self.traits.Bind(wx.EVT_KEY_DOWN, self.onKeyDown)
 
         mainSizer.Add(self.traits, 1, wx.ALL | wx.EXPAND, 0)
         self.Layout()
@@ -23,14 +24,23 @@ class ItemTraits(wx.Panel):
         self.popupMenu.Append(copyItem)
         self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
 
-    def showPopupMenu(self, event):
+    def onPopupMenu(self, event):
         self.PopupMenu(self.popupMenu)
 
     def menuClickHandler(self, event):
         selectedMenuItem = event.GetId()
         if selectedMenuItem == 1:  # Copy was chosen
-            selectedText = self.traits.SelectionToText()
-            if len(selectedText) > 0:
-                if wx.TheClipboard.Open():
-                    wx.TheClipboard.SetData(wx.TextDataObject(selectedText))
-                    wx.TheClipboard.Close()
+            self.copySelectionToClipboard()
+
+    def onKeyDown(self, event):
+        keyCode = event.GetKeyCode()
+        # Ctrl + C
+        if keyCode == 67 and event.ControlDown():
+            self.copySelectionToClipboard()
+
+    def copySelectionToClipboard(self):
+        selectedText = self.traits.SelectionToText()
+        if len(selectedText) > 0:
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject(selectedText))
+                wx.TheClipboard.Close()


### PR DESCRIPTION
Popup menu with "Copy" command (can work more reliable that shortcurs)
Select all on Ctrl+A
Copy to clipboard on Ctrl+C
Fixes #1529 