### PR TITLE
Copy text from item traits and desription panels

### DIFF
--- a/gui/builtinItemStatsViews/itemDescription.py
+++ b/gui/builtinItemStatsViews/itemDescription.py
@@ -31,3 +31,36 @@ class ItemDescription(wx.Panel):
 
         mainSizer.Add(self.description, 1, wx.ALL | wx.EXPAND, 0)
         self.Layout()
+
+        self.description.Bind(wx.EVT_CONTEXT_MENU, self.onPopupMenu)
+        self.description.Bind(wx.EVT_KEY_DOWN, self.onKeyDown)
+
+        self.popupMenu = wx.Menu()
+        copyItem = wx.MenuItem(self.popupMenu, 1, 'Copy')
+        self.popupMenu.Append(copyItem)
+        self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
+
+    def onPopupMenu(self, event):
+        self.PopupMenu(self.popupMenu)
+
+    def menuClickHandler(self, event):
+        selectedMenuItem = event.GetId()
+        if selectedMenuItem == 1:  # Copy was chosen
+            self.copySelectionToClipboard()
+
+    def onKeyDown(self, event):
+        keyCode = event.GetKeyCode()
+        # Ctrl + C
+        if keyCode == 67 and event.ControlDown():
+            self.copySelectionToClipboard()
+        # Ctrl + A
+        if keyCode == 65 and event.ControlDown():
+            self.description.SelectAll()
+
+    def copySelectionToClipboard(self):
+        selectedText = self.description.SelectionToText()
+        if selectedText == '':  # if no selection, copy all content
+            selectedText = self.description.ToText()
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(wx.TextDataObject(selectedText))
+            wx.TheClipboard.Close()

--- a/gui/builtinItemStatsViews/itemTraits.py
+++ b/gui/builtinItemStatsViews/itemTraits.py
@@ -13,5 +13,38 @@ class ItemTraits(wx.Panel):
         self.traits = wx.html.HtmlWindow(self)
         self.traits.SetPage(item.traits.traitText)
 
+        self.traits.Bind(wx.EVT_CONTEXT_MENU, self.onPopupMenu)
+        self.traits.Bind(wx.EVT_KEY_DOWN, self.onKeyDown)
+
         mainSizer.Add(self.traits, 1, wx.ALL | wx.EXPAND, 0)
         self.Layout()
+
+        self.popupMenu = wx.Menu()
+        copyItem = wx.MenuItem(self.popupMenu, 1, 'Copy')
+        self.popupMenu.Append(copyItem)
+        self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
+
+    def onPopupMenu(self, event):
+        self.PopupMenu(self.popupMenu)
+
+    def menuClickHandler(self, event):
+        selectedMenuItem = event.GetId()
+        if selectedMenuItem == 1:  # Copy was chosen
+            self.copySelectionToClipboard()
+
+    def onKeyDown(self, event):
+        keyCode = event.GetKeyCode()
+        # Ctrl + C
+        if keyCode == 67 and event.ControlDown():
+            self.copySelectionToClipboard()
+        # Ctrl + A
+        if keyCode == 65 and event.ControlDown():
+            self.traits.SelectAll()
+
+    def copySelectionToClipboard(self):
+        selectedText = self.traits.SelectionToText()
+        if selectedText == '':  # if no selection, copy all content
+            selectedText = self.traits.ToText()
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(wx.TextDataObject(selectedText))
+            wx.TheClipboard.Close()


### PR DESCRIPTION
Popup menu with "Copy" command (can work more reliable that shortcuts sometimes)
Select all on Ctrl+A
Copy to clipboard on Ctrl+C
If nothing is selected, whole text is copied.
Fixes #1529