### PR TITLE
Remove asterisk next to character name after API refresh

### DIFF
--- a/eos/saveddata/character.py
+++ b/eos/saveddata/character.py
@@ -121,6 +121,7 @@ class Character(object):
     def clearSkills(self):
         del self.__skills[:]
         self.__skillIdMap.clear()
+        self.dirtySkills.clear()
 
     @property
     def ro(self):


### PR DESCRIPTION
For #1599 , When API Refresh is pressed and clearSkills on the character is called in the Update thread, also clear dirty skills.