### PR TITLE
Fixes the Helios's drone damage bonus.

### DIFF
--- a/eos/effects/shipdronescoutthermaldamagegf2.py
+++ b/eos/effects/shipdronescoutthermaldamagegf2.py
@@ -6,5 +6,5 @@ type = "passive"
 
 
 def handler(fit, ship, context):
-    fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drone Avionics"),
+    fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Light Drone Operation"),
                                  "thermalDamage", ship.getModifiedItemAttr("shipBonusGF2"), skill="Gallente Frigate")


### PR DESCRIPTION
The required skill should be Light Drone Operation as light drones don't require Drone Avionics.
This causes the damage bonus to apply correctly. Thus giving a max skill Hobgoblin II 29.7dps rather than 19.8dps.