### PR TITLE
Typo fix for eos.gamedata.translations["Boolean"]

### DIFF
--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -592,7 +592,7 @@ class Unit(EqBase):
                 lambda d: d * 1000.0,
                 lambda u: u),
             "Boolean": (
-                lambda v, u: "Yes" if v == 1 else "No",
+                lambda v: "Yes" if v == 1 else "No",
                 lambda d: 1.0 if d == "Yes" else 0.0,
                 lambda u: ""),
             "typeID": (


### PR DESCRIPTION
Fix for #1659 
I assume the second argument is a typo given the use case.
If not giving it a default value also works.