### PR TITLE
Allow drone skill effects to process implants

### DIFF
--- a/eos/effects/skillbonusdronedurability.py
+++ b/eos/effects/skillbonusdronedurability.py
@@ -1,12 +1,14 @@
 # skillBonusDroneDurability
 #
 # Used by:
+# Implant: CreoDron 'Bumblebee' Drone Tuner T10-5D
+# Implant: CreoDron 'Yellowjacket' Drone Tuner D5-10T
 # Skill: Drone Durability
 type = "passive"
 
 
 def handler(fit, src, context):
-    lvl = src.level
+    lvl = src.level if "skill" in context else 1
     fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drones"), "hp",
                                  src.getModifiedItemAttr("hullHpBonus") * lvl)
     fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drones"), "armorHP",

--- a/eos/effects/skillbonusdroneinterfacing.py
+++ b/eos/effects/skillbonusdroneinterfacing.py
@@ -1,12 +1,14 @@
 # skillBonusDroneInterfacing
 #
 # Used by:
+# Implant: CreoDron 'Bumblebee' Drone Tuner T10-5D
+# Implant: CreoDron 'Yellowjacket' Drone Tuner D5-10T
 # Skill: Drone Interfacing
 type = "passive"
 
 
 def handler(fit, src, context):
-    lvl = src.level
+    lvl = src.level if "skill" in context else 1
     fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drones"), "damageMultiplier",
                                  src.getModifiedItemAttr("damageMultiplierBonus") * lvl)
     fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"),

--- a/eos/effects/skillbonusdronenavigation.py
+++ b/eos/effects/skillbonusdronenavigation.py
@@ -6,7 +6,7 @@ type = "passive"
 
 
 def handler(fit, src, context):
-    lvl = src.level
+    lvl = src.level if "skill" in context else 1
     fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drones"), "maxVelocity",
                                  src.getModifiedItemAttr("maxVelocityBonus") * lvl)
     fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "maxVelocity",

--- a/eos/effects/skillbonusdronesharpshooting.py
+++ b/eos/effects/skillbonusdronesharpshooting.py
@@ -6,7 +6,7 @@ type = "passive"
 
 
 def handler(fit, src, context):
-    lvl = src.level
+    lvl = src.level if "skill" in context else 1
     fit.drones.filteredItemBoost(lambda mod: mod.item.requiresSkill("Drones"), "maxRange",
                                  src.getModifiedItemAttr("rangeSkillBonus") * lvl)
     fit.fighters.filteredItemBoost(lambda mod: mod.item.requiresSkill("Fighters"), "fighterAbilityMissilesRange",


### PR DESCRIPTION
This should provide a fix for #1662 and allow similar drone implants to function without additional changes.
I tested the Bumblebee implant in game found it does impact fighters.
Given the descriptions only mention drones not fighters CCP may change that as a bug fix.
For now however the effects are applied to fighters to match actual gameplay.