### PR TITLE
Make itemStats.closeBtn fire a wx.CloseEvent

### DIFF
--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -102,7 +102,7 @@ class ItemStatsDialog(wx.Dialog):
         if "wxGTK" in wx.PlatformInfo:
             self.closeBtn = wx.Button(self, wx.ID_ANY, "Close", wx.DefaultPosition, wx.DefaultSize, 0)
             self.mainSizer.Add(self.closeBtn, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
-            self.closeBtn.Bind(wx.EVT_BUTTON, self.closeEvent)
+            self.closeBtn.Bind(wx.EVT_BUTTON, (lambda e: self.Close())))
 
         self.SetSizer(self.mainSizer)
 


### PR DESCRIPTION
Fix for #1657
Due to 47016c6 closeEvent no longer directly deletes the window.
Instead we should have the button fire a wx.CloseEvent via wx.Window.Close.
This will cause event.Skip() to actually close the window when called via ItemStatsDialog's CloseEvent bind.