### PR TITLE
Have missing icons display as question mark icons

### DIFF
--- a/gui/bitmap_loader.py
+++ b/gui/bitmap_loader.py
@@ -49,7 +49,7 @@ class BitmapLoader(object):
     @classmethod
     def getStaticBitmap(cls, name, parent, location):
         static = wx.StaticBitmap(parent)
-        static.SetBitmap(cls.getBitmap(name, location))
+        static.SetBitmap(cls.getBitmap(name or 0, location))
         return static
 
     @classmethod


### PR DESCRIPTION
Fix for #1673 
This will cause attempts to get non-existent icons via BitmapLoader.getStaticBitmap to return a question mark icon (0.png) rather than fail. This is effectively the same behavior seen under the attributes tab already.
This specific issue was caused by the 'Capacitor Warfare Resistance Bonus' having no icon.
There's a blank space in place of the icon when hovering over an Abyssal Cap Battery in game.