### PR TITLE
Update market.service to reflect new booster market groups.

### DIFF
--- a/service/market.py
+++ b/service/market.py
@@ -527,7 +527,7 @@ class Market(object):
         categories = ['Drone', 'Fighter', 'Implant']
 
         for item in items:
-            if True and item.category.ID == 20 and item.group.ID != 303:  # Implants not Boosters
+            if item.category.ID == 20 and item.group.ID != 303:  # Implants not Boosters
                 implant_remove_list = set()
                 implant_remove_list.add("Low-Grade ")
                 implant_remove_list.add("Low-grade ")
@@ -647,6 +647,12 @@ class Market(object):
     def marketGroupHasTypesCheck(self, mg):
         """If market group has any items, return true"""
         if mg and mg.ID in self.ITEMS_FORCEDMARKETGROUP_R:
+            # This shouldn't occur normally but makes errors more mild when ITEMS_FORCEDMARKETGROUP is outdated.
+            if len(mg.children) > 0 and len(mg.items) == 0:
+                pyfalog.error(("Market group \"{0}\" contains no items and has children. "
+                    "ITEMS_FORCEDMARKETGROUP is likely outdated and will need to be "
+                    "updated for {1} to display correctly.").format(mg, self.ITEMS_FORCEDMARKETGROUP_R[mg.ID]))
+                return False
             return True
         elif len(mg.items) > 0:
             return True

--- a/service/market.py
+++ b/service/market.py
@@ -277,15 +277,8 @@ class Market(object):
         # Dictionary of items with forced market group (service assumes they have no
         # market group assigned in db, otherwise they'll appear in both original and forced groups)
         self.ITEMS_FORCEDMARKETGROUP = {
-            "Advanced Cerebral Accelerator"             : 977,  # Implants & Boosters > Booster
-            "Civilian Damage Control"                   : 615,  # Ship Equipment > Hull & Armor > Damage Controls
-            "Civilian EM Ward Field"                    : 1695,
-            # Ship Equipment > Shield > Shield Hardeners > EM Shield Hardeners
-            "Civilian Explosive Deflection Field"       : 1694,
-            # Ship Equipment > Shield > Shield Hardeners > Explosive Shield Hardeners
+            "Advanced Cerebral Accelerator"             : 2487,  # Implants & Boosters > Booster > Cerebral Accelerators
             "Civilian Hobgoblin"                        : 837,  # Drones > Combat Drones > Light Scout Drones
-            "Civilian Kinetic Deflection Field"         : 1693,
-            # Ship Equipment > Shield > Shield Hardeners > Kinetic Shield Hardeners
             "Civilian Light Missile Launcher"           : 640,
             # Ship Equipment > Turrets & Bays > Missile Launchers > Light Missile Launchers
             "Civilian Scourge Light Missile"            : 920,
@@ -293,8 +286,6 @@ class Market(object):
             "Civilian Small Remote Armor Repairer"      : 1059,
             # Ship Equipment > Hull & Armor > Remote Armor Repairers > Small
             "Civilian Small Remote Shield Booster"      : 603,  # Ship Equipment > Shield > Remote Shield Boosters > Small
-            "Civilian Stasis Webifier"                  : 683,  # Ship Equipment > Electronic Warfare > Stasis Webifiers
-            "Civilian Warp Disruptor"                   : 1935,  # Ship Equipment > Electronic Warfare > Warp Disruptors
             "Hardwiring - Zainou 'Sharpshooter' ZMX10"  : 1493,
             # Implants & Boosters > Implants > Skill Hardwiring > Missile Implants > Implant Slot 06
             "Hardwiring - Zainou 'Sharpshooter' ZMX100" : 1493,
@@ -307,11 +298,9 @@ class Market(object):
             # Implants & Boosters > Implants > Skill Hardwiring > Missile Implants > Implant Slot 06
             "Hardwiring - Zainou 'Sharpshooter' ZMX1100": 1493,
             # Implants & Boosters > Implants > Skill Hardwiring > Missile Implants > Implant Slot 06
-            "Nugoehuvi Synth Blue Pill Booster"         : 977,  # Implants & Boosters > Booster
-            "Prototype Cerebral Accelerator"            : 977,  # Implants & Boosters > Booster
+            "Prototype Cerebral Accelerator"            : 2487,  # Implants & Boosters > Booster > Cerebral Accelerators
             "Prototype Iris Probe Launcher"             : 712,  # Ship Equipment > Turrets & Bays > Scan Probe Launchers
-            "Shadow"                                    : 1310,  # Drones > Combat Drones > Fighter Bombers
-            "Standard Cerebral Accelerator"             : 977,  # Implants & Boosters > Booster
+            "Standard Cerebral Accelerator"             : 2487,  # Implants & Boosters > Booster > Cerebral Accelerators
         }
 
         self.ITEMS_FORCEDMARKETGROUP_R = self.__makeRevDict(self.ITEMS_FORCEDMARKETGROUP)
@@ -538,7 +527,7 @@ class Market(object):
         categories = ['Drone', 'Fighter', 'Implant']
 
         for item in items:
-            if item.category.ID == 20:  # Implants and Boosters
+            if True and item.category.ID == 20 and item.group.ID != 303:  # Implants not Boosters
                 implant_remove_list = set()
                 implant_remove_list.add("Low-Grade ")
                 implant_remove_list.add("Low-grade ")
@@ -552,15 +541,6 @@ class Market(object):
                 implant_remove_list.add(" - Elite")
                 implant_remove_list.add(" - Improved")
                 implant_remove_list.add(" - Standard")
-                implant_remove_list.add("Copper ")
-                implant_remove_list.add("Gold ")
-                implant_remove_list.add("Silver ")
-                implant_remove_list.add("Advanced ")
-                implant_remove_list.add("Improved ")
-                implant_remove_list.add("Prototype ")
-                implant_remove_list.add("Standard ")
-                implant_remove_list.add("Strong ")
-                implant_remove_list.add("Synth ")
 
                 for implant_prefix in ("-6", "-7", "-8", "-9", "-10"):
                     for i in range(50):
@@ -595,6 +575,16 @@ class Market(object):
                 trimmed_variations_list = [variation_item for variation_item in variations_list if limit in variation_item.name]
             if trimmed_variations_list:
                 variations_list = trimmed_variations_list
+
+        # If the items are boosters then filter variations to only include boosters for the same slot.
+        BOOSTER_GROUP_ID = 303
+        if all(map(lambda i: i.group.ID == BOOSTER_GROUP_ID, items)) and len(items) > 0:
+            # 'boosterness' is the database's attribute name for Booster Slot
+            reqSlot = next(items.__iter__()).getAttribute('boosterness')
+            # If the item and it's variation both have a marketGroupID it should match for the variation to be considered valid.
+            marketGroupID = [next(filter(None, map(lambda i: i.marketGroupID, items)), None), None]
+            matchSlotAndMktGrpID = lambda v: v.getAttribute('boosterness') == reqSlot and v.marketGroupID in marketGroupID
+            variations_list = list(filter(matchSlotAndMktGrpID, variations_list))
 
         variations.update(variations_list)
         return variations


### PR DESCRIPTION
Fix for #1683 

Cause of the bug:
service.market.marketGroupHasTypesCheck is used to check if a market group has items and by extension if it has child market groups. 
If ITEMS_FORCEDMARKETGROUP contains a market group's ID then marketGroupHasTypesCheck will return true.
gui.builtinMarketBrowser.marketTree.expandLookup assumes groups with items cannot contain child groups.
Thus the hard coded marketGroupIDs corresponding to the 'Booster' group caused it's children to be ignored after changes by CCP moved boosters to child market groups based on slot and type.


Changes:
Updated booster IDs for ITEMS_FORCEDMARKETGROUP and removed entries that already have identical marketGroupIDs in the database.

Updated getVariationsByItems to correctly handle boosters for the new market groups. Note the variations_limiter system was not suitable for this, I can explain at length why if desired.

Conservatively changed marketGroupHasTypesCheck so similar database changes will only impact the items in ITEMS_FORCEDMARKETGROUP.