### PR TITLE
Issue #1695 Prevents modules from being destroyed on change if module type mismatch

### DIFF
--- a/service/fit.py
+++ b/service/fit.py
@@ -640,6 +640,7 @@ class Fit(object):
         # Dummy it out in case the next bit fails
         fit.modules.toDummy(position)
 
+        ret = None
         try:
             m = es_Module(item)
         except ValueError:
@@ -648,7 +649,7 @@ class Fit(object):
         if not module.isEmpty and m.slot != module.slot:
             fit.modules.toModule(position, module)
             # Fits, but we selected wrong slot type, so don't want to overwrite because we will append on failure (none)
-            return None 
+            ret = None
         elif m.fits(fit):
             m.owner = fit
             fit.modules.toModule(position, m)
@@ -663,10 +664,8 @@ class Fit(object):
             fit.fill()
             eos.db.commit()
 
-            return True
-
-        else:
-            return None
+            ret = True
+        return ret
 
     def moveCargoToModule(self, fitID, moduleIdx, cargoIdx, copyMod=False):
         """

--- a/service/fit.py
+++ b/service/fit.py
@@ -626,8 +626,8 @@ class Fit(object):
 
     def changeModule(self, fitID, position, newItemID):
         fit = eos.db.getFit(fitID)
-        module = fit.modules[position] #needed for dummy preservation and ammo check
-        
+        module = fit.modules[position]
+
         # We're trying to add a charge to a slot, which won't work. Instead, try to add the charge to the module in that slot.
         if self.isAmmo(newItemID) and not module.isEmpty:
             self.setAmmo(fitID, newItemID, [module])
@@ -639,15 +639,16 @@ class Fit(object):
 
         # Dummy it out in case the next bit fails
         fit.modules.toDummy(position)
-        
+
         try:
             m = es_Module(item)
         except ValueError:
             pyfalog.warning("Invalid item: {0}", newItemID)
             return False
         if not module.isEmpty and m.slot != module.slot:
-            fit.modules.toModule(position,module)#put the dummy module back if our item doesn't fit
-            return None #fits, but we selected wrong slot type, so don't want to overwrite because we will append on failure (none)
+            fit.modules.toModule(position, module)
+            # Fits, but we selected wrong slot type, so don't want to overwrite because we will append on failure (none)
+            return None 
         elif m.fits(fit):
             m.owner = fit
             fit.modules.toModule(position, m)

--- a/service/fit.py
+++ b/service/fit.py
@@ -626,12 +626,11 @@ class Fit(object):
 
     def changeModule(self, fitID, position, newItemID):
         fit = eos.db.getFit(fitID)
-
+        module = fit.modules[position] #needed for dummy preservation and ammo check
+        
         # We're trying to add a charge to a slot, which won't work. Instead, try to add the charge to the module in that slot.
-        if self.isAmmo(newItemID):
-            module = fit.modules[position]
-            if not module.isEmpty:
-                self.setAmmo(fitID, newItemID, [module])
+        if self.isAmmo(newItemID) and not module.isEmpty:
+            self.setAmmo(fitID, newItemID, [module])
             return True
 
         pyfalog.debug("Changing position of module from position ({0}) for fit ID: {1}", position, fitID)
@@ -640,14 +639,16 @@ class Fit(object):
 
         # Dummy it out in case the next bit fails
         fit.modules.toDummy(position)
-
+        
         try:
             m = es_Module(item)
         except ValueError:
             pyfalog.warning("Invalid item: {0}", newItemID)
             return False
-
-        if m.fits(fit):
+        if not module.isEmpty and m.slot != module.slot:
+            fit.modules.toModule(position,module)#put the dummy module back if our item doesn't fit
+            return None #fits, but we selected wrong slot type, so don't want to overwrite because we will append on failure (none)
+        elif m.fits(fit):
             m.owner = fit
             fit.modules.toModule(position, m)
             if m.isValidState(State.ACTIVE):
@@ -662,6 +663,7 @@ class Fit(object):
             eos.db.commit()
 
             return True
+
         else:
             return None
 


### PR DESCRIPTION
While working on #1690 I discovered that dragging a module on top of a mismatched item slot (ie High onto a Mid) would result in the item that was dragged onto being deleted no regardless.  