### PR TITLE
Bug/1706

### DIFF
--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -24,6 +24,8 @@ from gui.bitmap_loader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
 from service.price import Price
 from service.settings import PriceMenuSettings
+import gui.mainFrame
+import gui.globalEvents as GE
 
 
 class PriceViewFull(StatsView):
@@ -33,6 +35,7 @@ class PriceViewFull(StatsView):
         StatsView.__init__(self)
         self.parent = parent
         self.settings = PriceMenuSettings.getInstance()
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
 
     def getHeaderText(self, fit):
         return "Price"
@@ -160,6 +163,7 @@ class PriceViewFull(StatsView):
         self.labelPriceCharacter.SetToolTip(wx.ToolTip('{:,.2f}'.format(booster_price + implant_price)))
 
     def processPrices(self, prices):
+        wx.PostEvent(self.mainFrame, GE.PriceChanged(fitID=self.mainFrame.getActiveFit()))
         self.refreshPanelPrices(self.fit)
 
         self.labelEMStatus.SetLabel("")

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -24,6 +24,8 @@ from gui.bitmap_loader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
 from service.price import Price
 from service.settings import PriceMenuSettings
+import gui.mainFrame
+import gui.globalEvents as GE
 
 
 class PriceViewMinimal(StatsView):
@@ -33,6 +35,7 @@ class PriceViewMinimal(StatsView):
         StatsView.__init__(self)
         self.parent = parent
         self.settings = PriceMenuSettings.getInstance()
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
 
     def getHeaderText(self, fit):
         return "Price"
@@ -146,6 +149,7 @@ class PriceViewMinimal(StatsView):
         self.labelPriceTotal.SetToolTip(wx.ToolTip('{:,.2f}'.format(total_price)))
 
     def processPrices(self, prices):
+        wx.PostEvent(self.mainFrame, GE.PriceChanged(fitID=self.mainFrame.getActiveFit()))
         self.refreshPanelPrices(self.fit)
 
         self.labelEMStatus.SetLabel("")

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -145,6 +145,7 @@ class FittingView(d.Display):
         d.Display.__init__(self, parent, size=(0, 0), style=wx.BORDER_NONE)
         self.Show(False)
         self.parent = parent
+        self.mainFrame.Bind(GE.PRICE_CHANGED, self.priceChanged)
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
         self.mainFrame.Bind(EVT_FIT_RENAMED, self.fitRenamed)
         self.mainFrame.Bind(EVT_FIT_REMOVED, self.fitRemoved)
@@ -540,8 +541,12 @@ class FittingView(d.Display):
         self.generateMods()
         self.populate(self.mods)
 
-    def fitChanged(self, event):
-        print('====== Fit Changed: {} {} activeFitID: {}, eventFitID: {}'.format(repr(self), str(bool(self)), self.activeFitID, event.fitID))
+    def priceChanged(self, event):
+        # This event does the exact same thing as fitChange but only fittingView is registered to the PRICE_CHANGED event
+        self.fitChanged(event, "Price")
+
+    def fitChanged(self, event, label="Fit"):
+        print('====== {} Changed: {} {} activeFitID: {}, eventFitID: {}'.format(label, repr(self), str(bool(self)), self.activeFitID, event.fitID))
         if not self:
             event.Skip()
             return

--- a/gui/globalEvents.py
+++ b/gui/globalEvents.py
@@ -1,6 +1,7 @@
 # noinspection PyPackageRequirements
 import wx.lib.newevent
 
+PriceChanged, PRICE_CHANGED = wx.lib.newevent.NewEvent()
 FitChanged, FIT_CHANGED = wx.lib.newevent.NewEvent()
 CharListUpdated, CHAR_LIST_UPDATED = wx.lib.newevent.NewEvent()
 CharChanged, CHAR_CHANGED = wx.lib.newevent.NewEvent()

--- a/service/port.py
+++ b/service/port.py
@@ -1064,7 +1064,6 @@ class Port(object):
 
         return fit_list
 
-
     @classmethod
     def exportEft(cls, fit, mutations=False, implants=False):
         # EFT formatted export is split in several sections, each section is


### PR DESCRIPTION
#1706 Adds a new global event, PRICE_CHANGED to use in the Price callbacks so that fittingView knows the price columns need to be updated.   This was used in lieu of FIT_CHANGED so that log messages would be more accurate.  

Changed the call signature of fitChanged to take in extra value which is the log label.  The fitChanged and priceChanged functions were identical so just went for code reuse, I don't think this will have any side effects as its an optional parameter.

I didn't modify port.py, but my tox tests were failing (i branched off upstream master) so I resolved this.