### PR TITLE
Fix cargo items price increase on refit

### DIFF
--- a/gui/builtinViewColumns/price.py
+++ b/gui/builtinViewColumns/price.py
@@ -51,7 +51,9 @@ class Price(ViewColumn):
             return False
 
         if isinstance(stuff, Drone) or isinstance(stuff, Cargo):
-            price.price *= stuff.amount
+            # Don't set price.price, or it updates the database #1759
+            return formatAmount(price.price * stuff.amount, 3, 3, 9,
+                                currency=True)
 
         return formatAmount(price.price, 3, 3, 9, currency=True)
 


### PR DESCRIPTION
The price attribute of an item is linked to its price in the database,
through SQLAlchemy and the ORM map. Updating a price attribute therefore
updates the database. This patch changes the calculation of the cost of
amounts of items, so that the price in the database no longer occurs.

Fixes #1759