### PR TITLE
Remove extra (α) from clone name when renaming

### DIFF
--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -129,7 +129,12 @@ class CharacterEntityEditor(EntityEditor):
 
     def DoRename(self, entity, name):
         sChar = Character.getInstance()
-        sChar.rename(entity, name)
+
+        if entity.alphaCloneID:
+            trimmed_name = re.sub('[ \(\u03B1\)]+$', '', name)
+            sChar.rename(entity, trimmed_name)
+        else:
+            sChar.rename(entity, name)
 
     def DoCopy(self, entity, name):
         sChar = Character.getInstance()


### PR DESCRIPTION
In characterEditor.py DoRename() apply some regex to remove superfluous (α) from the end of clone names if the clone is an alpha clone.