### PR TITLE
Logic to enable/disable redo/undo buttons

### DIFF
--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -179,6 +179,21 @@ class MainMenuBar(wx.MenuBar):
         self.Enable(wx.ID_COPY, enable)
         self.Enable(self.exportSkillsNeededId, enable)
 
+        command_history = self.mainFrame.command.GetCommands()
+        current_command = self.mainFrame.command.GetCurrentCommand()
+
+        self.Enable(wx.ID_UNDO, True)
+        self.Enable(wx.ID_REDO, True)
+
+        if len(command_history) == 0:
+            self.Enable(wx.ID_UNDO, False)
+            self.Enable(wx.ID_REDO, False)
+        else:
+            if current_command not in command_history:
+                self.Enable(wx.ID_UNDO, False)
+            if current_command == command_history[len(command_history) - 1]:
+                self.Enable(wx.ID_REDO, False)
+
         sChar = Character.getInstance()
         charID = self.mainFrame.charSelection.getActiveCharacter()
         char = sChar.getCharacter(charID)

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -179,20 +179,14 @@ class MainMenuBar(wx.MenuBar):
         self.Enable(wx.ID_COPY, enable)
         self.Enable(self.exportSkillsNeededId, enable)
 
-        command_history = self.mainFrame.command.GetCommands()
-        current_command = self.mainFrame.command.GetCurrentCommand()
+        command = self.mainFrame.command
+        self.Enable(wx.ID_UNDO, False)
+        self.Enable(wx.ID_REDO, False)
 
-        self.Enable(wx.ID_UNDO, True)
-        self.Enable(wx.ID_REDO, True)
-
-        if len(command_history) == 0:
-            self.Enable(wx.ID_UNDO, False)
-            self.Enable(wx.ID_REDO, False)
-        else:
-            if current_command not in command_history:
-                self.Enable(wx.ID_UNDO, False)
-            if current_command == command_history[len(command_history) - 1]:
-                self.Enable(wx.ID_REDO, False)
+        if command.CanUndo():
+            self.Enable(wx.ID_UNDO, True)
+        if command.CanRedo():
+            self.Enable(wx.ID_REDO, True)
 
         sChar = Character.getInstance()
         charID = self.mainFrame.charSelection.getActiveCharacter()


### PR DESCRIPTION
#1871 
---
- Added some logic to enable and disable the undo and redo buttons depending on the contents of the command history as follows:
    - Disable both buttons if no commands in the history
    - Disable undo if there are commands in the history, but the current command is not (this means we are already at the beginning)
    - Disable redo if there are commands in the history, and the current command is the most recent (we are at the end)
    - Otherwise undo and redo are enabled