### PR TITLE
Add link to Gentoo pyfa overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Apart from the official release, there is also a [Homebrew](http://brew.sh) opti
 $ brew install Caskroom/cask/pyfa
 ```
 
-### Linux Distro-specific Packages
+### Linux and BSD Distro-specific Packages
 The following is a list of pyfa packages available for certain distributions. Please note that these packages are maintained by third-parties and are not evaluated by the pyfa developers.
 
 * Debian/Ubuntu/derivatives: https://github.com/AdamMajer/Pyfa/releases
 * Arch: https://aur.archlinux.org/packages/pyfa/
 * openSUSE: https://build.opensuse.org/package/show/home:rmk2/pyfa
 * FreeBSD: http://www.freshports.org/games/pyfa/ (see [#484](https://github.com/pyfa-org/Pyfa/issues/484) for instructions)
+* Gentoo: https://github.com/ZeroPointEnergy/gentoo-pyfa-overlay
 
 ### Dependencies
 If you wish to help with development or simply need to run pyfa through a Python interpreter, the following software is required:


### PR DESCRIPTION
Do to the situation in Gentoo where there is still no wxpython-4 ebuild I had to look for another solution. Luckily there is an ebuild from a third-party available but that will probably never make it upstream as it is because it still needs a lot of work and none of the original package maintainers seem interested in doing it. Even the pull requests for the dependencies are moving very slowly. But it works for Pyfa and that is enough for me to be able to make a working Pyfa ebuild again.

So for now I created this overlay which should probably be easier to keep updated to deliver the most recent Pyfa versions and all required dependencies for Gentoo users.

I will also try to get this registered so it can be easily installed with the "layman" tool and keep the install instructions updated on the overlay README.

P.S. FreeBSD is UNIX not Linux :wink: 