### PR TITLE
Fixed issue with character name extending into text box

### DIFF
--- a/gui/characterSelection.py
+++ b/gui/characterSelection.py
@@ -46,7 +46,7 @@ class CharacterSelection(wx.Panel):
         self.charCache = None
 
         self.charChoice = wx.Choice(self)
-        mainSizer.Add(self.charChoice, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.LEFT, 3)
+        mainSizer.Add(self.charChoice, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.LEFT, 3)
 
         self.refreshCharacterList()
 


### PR DESCRIPTION
The character selection combo box in the top right of the main window was being cut off on my system. I have resolved that issue. Thanks for the wonderful tool!


Before
![2019-05-20-202256_1920x1080_scrot](https://user-images.githubusercontent.com/1923192/58062020-4d810280-7b3e-11e9-823b-0e5602146f17.png)

After
![2019-05-20-202330_1920x1080_scrot](https://user-images.githubusercontent.com/1923192/58062017-4b1ea880-7b3e-11e9-976e-4c0470bdf571.png)
