### PR TITLE
improve sizing on esi fit import browser

### DIFF
--- a/gui/esiFittings.py
+++ b/gui/esiFittings.py
@@ -24,7 +24,7 @@ class EveFittings(wx.Frame):
 
     def __init__(self, parent):
         wx.Frame.__init__(self, parent, id=wx.ID_ANY, title="Browse EVE Fittings", pos=wx.DefaultPosition,
-                          size=wx.Size(550, 450), style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL)
+                          size=wx.Size(750, 450), style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL)
 
         self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
@@ -49,6 +49,7 @@ class EveFittings(wx.Frame):
 
         self.fitTree = FittingsTreeView(self)
         browserSizer.Add(self.fitTree, 1, wx.ALL | wx.EXPAND, 5)
+        browserSizer.SetItemMinSize(0, 200, 0)
         contentSizer.Add(browserSizer, 1, wx.EXPAND, 0)
         fitSizer = wx.BoxSizer(wx.VERTICAL)
 


### PR DESCRIPTION
On my machine, using the ESI import feature and clicking "Fetch Fits" gives the appearance of nothing happening. Turns out, this was because by default the tree on the left-hand side of the window has zero width by default and the parent window needs to be resized to see the fits. Fix this by setting a minimum size for the fitting browser tree and increase the default window size to compensate.