### PR TITLE
adding effects of SW-* and TP-* drones to fitDPSvsRange.py

### DIFF
--- a/eos/graph/fitDpsVsRange.py
+++ b/eos/graph/fitDpsVsRange.py
@@ -55,6 +55,19 @@ class FitDpsVsRangeGraph(SmoothGraph):
                             1 + (mod.getModifiedItemAttr("speedFactor") / 100) *
                             self.calculateModuleMultiplier(mod, distance))
 
+        # add target speed and sig modifiers from fitted drones
+        if distance <= fit.extraAttributes['droneControlRange']:
+            for drone in fit.drones:
+                # SW-* series stasis webifier drones
+                if "remoteWebifierEntity" in drone.item.effects:
+                    # Need to add the effect per individual drone to allow for stacking penalties
+                    for i in range(drone.amountActive):
+                        tgtSpeedMods.append(1 + (drone.getModifiedItemAttr("speedFactor") / 100))
+                # TP-* series target painter drones
+                if "remoteTargetPaintEntity" in drone.item.effects:
+                    for i in range(drone.amountActive):
+                        tgtSigRadMods.append(1 + (drone.getModifiedItemAttr("signatureRadiusBonus") / 100))
+
         tgtSpeed = self.penalizeModChain(tgtSpeed, tgtSpeedMods)
         tgtSigRad = self.penalizeModChain(tgtSigRad, tgtSigRadMods)
         attRad = fit.ship.getModifiedItemAttr('radius', 0)


### PR DESCRIPTION
Closes #1911 

The effects of SW-* and TP-* drones were just not implemented in the DPSvsRange graph. This adds those effects in, so adding 4 SW-900 drones will add 4 * 20% speed penalties to the penalization chain; likewise 4 TP-900 drones will add 4 * 20% sig bloom buffs to the penalization chain.

