### PR TITLE
Support loading images from zip

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ pyfaPath = None
 savePath = None
 saveDB = None
 gameDB = None
+imgsZIP = None
 logPath = None
 loggingLevel = None
 logging_setup = None
@@ -96,6 +97,7 @@ def defPaths(customSavePath=None):
     global savePath
     global saveDB
     global gameDB
+    global imgsZIP
     global saveInRoot
     global logPath
     global cipher
@@ -154,6 +156,10 @@ def defPaths(customSavePath=None):
     gameDB = getattr(configforced, "gameDB", gameDB)
     if not gameDB:
         gameDB = os.path.join(pyfaPath, "eve.db")
+
+    imgsZIP = getattr(configforced, "imgsZIP", imgsZIP)
+    if not imgsZIP:
+        imgsZIP = os.path.join(pyfaPath, "imgs.zip")
 
     if debug:
         logFile = "pyfa_debug.log"

--- a/gui/bitmap_loader.py
+++ b/gui/bitmap_loader.py
@@ -19,6 +19,7 @@
 
 import io
 import os.path
+import zipfile
 from collections import OrderedDict
 
 # noinspection PyPackageRequirements
@@ -32,15 +33,12 @@ pyfalog = Logger(__name__)
 
 
 class BitmapLoader:
-    # try:
-    #     archive = zipfile.ZipFile(os.path.join(config.pyfaPath, 'imgs.zip'), 'r')
-    #     logging.info("Using zipped image files.")
-    # except (IOError, TypeError):
-    #     logging.info("Using local image files.")
-    #     archive = None
-
-    pyfalog.info("Using local image files.")
-    archive = None
+    try:
+        archive = zipfile.ZipFile(config.imgsZIP, 'r')
+        pyfalog.info("Using zipped image files.")
+    except (IOError, TypeError):
+        pyfalog.info("Using local image files.")
+        archive = None
 
     cached_bitmaps = OrderedDict()
     dont_use_cached_bitmaps = False
@@ -131,8 +129,8 @@ class BitmapLoader:
 
             try:
                 img_data = cls.archive.read(path)
-                sbuf = io.StringIO(img_data)
-                return wx.ImageFromStream(sbuf)
+                bbuf = io.BytesIO(img_data)
+                return wx.Image(bbuf)
             except KeyError:
                 pyfalog.warning("Missing icon file from zip: {0}".format(path))
         else:


### PR DESCRIPTION
This commit reenables the ability to load the images from a zip file instead of a directory structure. It is possible to set the location of this file via configforced.py

This possibility was partly present at one time but was commented out and not really ported to python3. I maintain this patch in the Gentoo overlay since I package the images into a zip. It would be great if we could upstream this functionality but no hard feelings if this isn't something you want :wink:  .