### PR TITLE
Add keyboard shortcuts to character level editor

### DIFF
--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -428,6 +428,28 @@ class SkillTreeView(wx.Panel):
         # This cuases issues with GTK, see #1866
         # self.Layout()
 
+        # For level keyboard shortcuts
+        self.ChangeLevelEvent, CHANGE_LEVEL_EVENT = wx.lib.newevent.NewEvent()
+        self.Bind(wx.EVT_CHAR_HOOK, self.kbEvent)
+        self.Bind(CHANGE_LEVEL_EVENT, self.changeLevel)
+
+    def kbEvent(self, event):
+        selection = self.skillTreeListCtrl.GetSelection()
+        if not selection:
+            return
+        dataType, skillID = self.skillTreeListCtrl.GetItemData(selection)
+        if dataType != 'skill':
+            return
+        keyCode = event.GetKeyCode()
+        if 48 <= keyCode <= 53 or 324 <= keyCode <= 329:
+            if keyCode <= 53:
+                level = keyCode - 48
+            else:
+                level = keyCode - 324
+            event = self.ChangeLevelEvent()
+            event.SetId(self.idLevels[level])
+            wx.PostEvent(self, event)
+
     def importSkills(self, evt):
 
         with wx.MessageDialog(


### PR DESCRIPTION
This adds the ability to set the level of a skill by pressing a number key, e.g. pressing 1 will set the skill's level to 1, and so on. I didn't add a way to "unlearn" a skill via a shortcut, but I can easily make it respond to `Delete` or something else.

I've never used wxPython before, so sorry if using a custom event isn't the best way to achieve it.