### PR TITLE
Issue #2073: Added ability to add a list of implants from implant view to a new implant set

### DIFF
--- a/gui/builtinAdditionPanes/implantView.py
+++ b/gui/builtinAdditionPanes/implantView.py
@@ -298,8 +298,13 @@ class ImplantDisplay(d.Display):
         fit = Fit.getInstance().getFit(fitID)
         sourceContext1 = "implantItem" if fit.implantSource == ImplantLocation.FIT else "implantItemChar"
         sourceContext2 = "implantItemMisc" if fit.implantSource == ImplantLocation.FIT else "implantItemMiscChar"
+        sourceContext3 = "implantSetAdd"
         itemContext = None if mainImplant is None else Market.getInstance().getCategoryByItem(mainImplant.item).name
-        menu = ContextMenu.getMenu(self, mainImplant, selection, (sourceContext1, itemContext), (sourceContext2, itemContext))
+        menu = ContextMenu.getMenu(self, mainImplant, selection,
+                                   (sourceContext1, itemContext),
+                                   (sourceContext2, itemContext),
+                                   (sourceContext3, itemContext)
+                                   )
         if menu:
             self.PopupMenu(menu)
 

--- a/gui/builtinAdditionPanes/implantView.py
+++ b/gui/builtinAdditionPanes/implantView.py
@@ -298,12 +298,10 @@ class ImplantDisplay(d.Display):
         fit = Fit.getInstance().getFit(fitID)
         sourceContext1 = "implantItem" if fit.implantSource == ImplantLocation.FIT else "implantItemChar"
         sourceContext2 = "implantItemMisc" if fit.implantSource == ImplantLocation.FIT else "implantItemMiscChar"
-        sourceContext3 = "implantSetAdd"
         itemContext = None if mainImplant is None else Market.getInstance().getCategoryByItem(mainImplant.item).name
         menu = ContextMenu.getMenu(self, mainImplant, selection,
                                    (sourceContext1, itemContext),
-                                   (sourceContext2, itemContext),
-                                   (sourceContext3, itemContext)
+                                   (sourceContext2, itemContext)
                                    )
         if menu:
             self.PopupMenu(menu)

--- a/gui/builtinContextMenus/__init__.py
+++ b/gui/builtinContextMenus/__init__.py
@@ -36,6 +36,7 @@ from gui.builtinContextMenus import cargoAdd
 from gui.builtinContextMenus import cargoAddAmmo
 from gui.builtinContextMenus import itemProject
 from gui.builtinContextMenus import ammoToDmgPattern
+from gui.builtinContextMenus import implantSetLoad
 from gui.builtinContextMenus import implantSetAdd
 # Price
 from gui.builtinContextMenus import priceOptions

--- a/gui/builtinContextMenus/implantSetAdd.py
+++ b/gui/builtinContextMenus/implantSetAdd.py
@@ -1,18 +1,15 @@
-# noinspection PyPackageRequirements
-import wx
-
 from gui.contextMenu import ContextMenuUnconditional
-from service.implantSet import ImplantSets as s_ImplantSets
 
 
 class ImplantSetAdd(ContextMenuUnconditional):
 
     def display(self, callingWindow, srcContext):
 
-        sIS = s_ImplantSets.getInstance()
-        implantSets = sIS.getImplantSetList()
+        if not hasattr(callingWindow, 'implants'):
+            return False
 
-        if len(implantSets) == 0:
+        implantList = callingWindow.implants
+        if not implantList or len(implantList) == 0:
             return False
 
         return srcContext in ("implantSetAdd", "implantEditor")
@@ -21,9 +18,8 @@ class ImplantSetAdd(ContextMenuUnconditional):
         return "Add As New Implant Set"
 
     def activate(self, callingWindow, fullContext, i):
-        sIS = s_ImplantSets.getInstance()
-        implantSets = sIS.getImplantSetList()
-        callingWindow.mainFrame.OnShowImplantSetEditor(None, implantSets)
+        implantList = callingWindow.implants
+        callingWindow.mainFrame.OnShowImplantSetEditor(None, implantList)
 
 
 ImplantSetAdd.register()

--- a/gui/builtinContextMenus/implantSetAdd.py
+++ b/gui/builtinContextMenus/implantSetAdd.py
@@ -12,7 +12,7 @@ class ImplantSetAdd(ContextMenuUnconditional):
         if not implantList or len(implantList) == 0:
             return False
 
-        return srcContext in ("implantItemMisc", "implantItemMiscChar", "implantEditor")
+        return srcContext in ("implantItemMisc", "implantItemMiscChar")
 
     def getText(self, callingWindow, context):
         return "Add As New Implant Set"

--- a/gui/builtinContextMenus/implantSetAdd.py
+++ b/gui/builtinContextMenus/implantSetAdd.py
@@ -14,7 +14,7 @@ class ImplantSetAdd(ContextMenuUnconditional):
 
         return srcContext in ("implantItemMisc", "implantItemMiscChar", "implantEditor")
 
-    def getText(self, callingWindow, itmContext):
+    def getText(self, callingWindow, context):
         return "Add As New Implant Set"
 
     def activate(self, callingWindow, fullContext, i):

--- a/gui/builtinContextMenus/implantSetAdd.py
+++ b/gui/builtinContextMenus/implantSetAdd.py
@@ -14,39 +14,16 @@ class ImplantSetAdd(ContextMenuUnconditional):
 
         if len(implantSets) == 0:
             return False
+
         return srcContext in ("implantSetAdd", "implantEditor")
 
     def getText(self, callingWindow, itmContext):
         return "Add As New Implant Set"
 
-    def getSubMenu(self, callingWindow, context, rootMenu, i, pitem):
-        m = wx.Menu()
-        bindmenu = rootMenu if "wxMSW" in wx.PlatformInfo else m
-
+    def activate(self, callingWindow, fullContext, i):
         sIS = s_ImplantSets.getInstance()
         implantSets = sIS.getImplantSetList()
-
-        self.context = context
-        self.callingWindow = callingWindow
-
-        self.idmap = {}
-
-        for set in sorted(implantSets, key=lambda i: i.name):
-            id = ContextMenuUnconditional.nextID()
-            mitem = wx.MenuItem(rootMenu, id, set.name)
-            bindmenu.Bind(wx.EVT_MENU, self.handleSelection, mitem)
-            self.idmap[id] = set
-            m.Append(mitem)
-
-        return m
-
-    def handleSelection(self, event):
-        impSet = self.idmap.get(event.Id, None)
-        if impSet is None:
-            event.Skip()
-            return
-
-        self.callingWindow.addImplantSet(impSet)
+        callingWindow.mainFrame.OnShowImplantSetEditor(None, implantSets)
 
 
 ImplantSetAdd.register()

--- a/gui/builtinContextMenus/implantSetAdd.py
+++ b/gui/builtinContextMenus/implantSetAdd.py
@@ -12,7 +12,7 @@ class ImplantSetAdd(ContextMenuUnconditional):
         if not implantList or len(implantList) == 0:
             return False
 
-        return srcContext in ("implantSetAdd", "implantEditor")
+        return srcContext in ("implantItemMisc", "implantItemMiscChar", "implantEditor")
 
     def getText(self, callingWindow, itmContext):
         return "Add As New Implant Set"

--- a/gui/builtinContextMenus/implantSetLoad.py
+++ b/gui/builtinContextMenus/implantSetLoad.py
@@ -5,7 +5,7 @@ from gui.contextMenu import ContextMenuUnconditional
 from service.implantSet import ImplantSets as s_ImplantSets
 
 
-class ImplantSetAdd(ContextMenuUnconditional):
+class ImplantSetLoad(ContextMenuUnconditional):
 
     def display(self, callingWindow, srcContext):
 
@@ -14,10 +14,10 @@ class ImplantSetAdd(ContextMenuUnconditional):
 
         if len(implantSets) == 0:
             return False
-        return srcContext in ("implantSetAdd", "implantEditor")
+        return srcContext in ("implantItemMisc", "implantEditor")
 
     def getText(self, callingWindow, itmContext):
-        return "Add As New Implant Set"
+        return "Load Implant Set"
 
     def getSubMenu(self, callingWindow, context, rootMenu, i, pitem):
         m = wx.Menu()
@@ -49,4 +49,4 @@ class ImplantSetAdd(ContextMenuUnconditional):
         self.callingWindow.addImplantSet(impSet)
 
 
-ImplantSetAdd.register()
+ImplantSetLoad.register()

--- a/gui/builtinContextMenus/implantSetLoad.py
+++ b/gui/builtinContextMenus/implantSetLoad.py
@@ -14,6 +14,7 @@ class ImplantSetLoad(ContextMenuUnconditional):
 
         if len(implantSets) == 0:
             return False
+
         return srcContext in ("implantItemMisc", "implantEditor")
 
     def getText(self, callingWindow, itmContext):

--- a/gui/builtinContextMenus/implantSetLoad.py
+++ b/gui/builtinContextMenus/implantSetLoad.py
@@ -18,7 +18,7 @@ class ImplantSetLoad(ContextMenuUnconditional):
         return srcContext in ("implantItemMisc", "implantEditor")
 
     def getText(self, callingWindow, context):
-        return "Load Implant Set"
+        return "Apply Implant Set"
 
     def getSubMenu(self, callingWindow, context, rootMenu, i, pitem):
         m = wx.Menu()

--- a/gui/builtinContextMenus/implantSetLoad.py
+++ b/gui/builtinContextMenus/implantSetLoad.py
@@ -17,7 +17,7 @@ class ImplantSetLoad(ContextMenuUnconditional):
 
         return srcContext in ("implantItemMisc", "implantEditor")
 
-    def getText(self, callingWindow, itmContext):
+    def getText(self, callingWindow, context):
         return "Load Implant Set"
 
     def getSubMenu(self, callingWindow, context, rootMenu, i, pitem):

--- a/gui/builtinViews/entityEditor.py
+++ b/gui/builtinViews/entityEditor.py
@@ -178,10 +178,17 @@ class EntityEditor(wx.Panel):
         return True
 
     def checkEntitiesExist(self):
-        if len(self.choices) == 0:
-            self.Parent.Hide()
-            if self.OnNew(None) is False:
-                return False
-            self.Parent.Show()
+        if len(self.choices) > 0:
+            return True
+        else:
+            return self.enterNewEntity()
+
+    def enterNewEntity(self):
+        self.Parent.Hide()
+        if self.OnNew(None) is False:
+            return False
+        self.Parent.Show()
 
         return True
+
+

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -442,8 +442,8 @@ class MainFrame(wx.Frame):
     def OnShowDamagePatternEditor(self, event):
         DmgPatternEditor.openOne(parent=self)
 
-    def OnShowImplantSetEditor(self, event):
-        ImplantSetEditor.openOne(parent=self)
+    def OnShowImplantSetEditor(self, event, dataToAdd=None):
+        ImplantSetEditor.openOne(parent=self, dataToAdd=dataToAdd)
 
     def OnShowExportDialog(self, event):
         """ Export active fit """

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -47,7 +47,7 @@ class ImplantTextValidor(BaseValidator):
             if len(text) == 0:
                 raise ValueError("You must supply a name for the Implant Set!")
             elif text in [x.name for x in entityEditor.choices]:
-                raise ValueError("Imlplant Set name already in use, please choose another.")
+                raise ValueError("Implant Set name already in use, please choose another.")
 
             return True
         except ValueError as e:

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -84,6 +84,14 @@ class ImplantSetEntityEditor(EntityEditor):
         sIS = ImplantSets.getInstance()
         sIS.deleteSet(entity)
 
+    def addExternalDataToSet(self, dataToAdd):
+        """ Add new set and fill it with data from the current fit """
+        if self.enterNewEntity():
+            sIS = ImplantSets.getInstance()
+            set_ = self.Parent.entityEditor.getActiveEntity()
+            for item in dataToAdd:
+                sIS.addImplant(set_.ID, item.item.ID)
+
 
 class ImplantSetEditorView(BaseImplantEditorView):
 
@@ -167,8 +175,8 @@ class ImplantSetEditor(AuxiliaryFrame):
         self.Layout()
 
         if dataToAdd:
-            # add elements passed from outside
-            pass
+            # add an implant set using data passed from outside
+            self.entityEditor.addExternalDataToSet(dataToAdd)
         elif not self.entityEditor.checkEntitiesExist():
             self.Close()
             return

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -117,7 +117,7 @@ class ImplantSetEditorView(BaseImplantEditorView):
 
 class ImplantSetEditor(AuxiliaryFrame):
 
-    def __init__(self, parent):
+    def __init__(self, parent, dataToAdd=None):
         super().__init__(
             parent, id=wx.ID_ANY, title="Implant Set Editor", resizeable=True,
             size=wx.Size(950, 500) if "wxGTK" in wx.PlatformInfo else wx.Size(850, 420))
@@ -166,7 +166,10 @@ class ImplantSetEditor(AuxiliaryFrame):
         self.SetSizer(mainSizer)
         self.Layout()
 
-        if not self.entityEditor.checkEntitiesExist():
+        if dataToAdd:
+            # add elements passed from outside
+            pass
+        elif not self.entityEditor.checkEntitiesExist():
             self.Close()
             return
 


### PR DESCRIPTION
Did two things:
- Added new menu "Add As New Implant Set". After entering the name for the set (and checked that such name is not used), implant set editor is opened with focus on the new set.
- Renamed "Add implant set" to "Load Implant Set" for consistency.
