### PR TITLE
Update the new requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
-wxPython == 4.0.6
+wxPython >= 4.0.7.post2
 logbook >= 1.0.0
 matplotlib >= 3.1.2
 python-dateutil
 requests >= 2.0.0
-sqlalchemy >= 1.3.0
-cryptography >= 2.3
-markdown2 >= 2.3.5
-packaging >= 16.8
-roman >= 2.0.0
-beautifulsoup4 >= 4.6.0
-pyyaml >= 5.1
+cryptography
+diskcache
+markdown2
+packaging
+roman
+beautifulsoup4
+PyYAML
+PyInstaller == 3.3
+SQLAlchemy >= 1.3.13


### PR DESCRIPTION
On WIndows 10 x64 with Python3.8.

For some reasons, we have no way to use old version.

Changed new one.