### PR TITLE
i18n: annotate Preferences, update zh_CN translations

### DIFF
--- a/graphs/gui/lists.py
+++ b/graphs/gui/lists.py
@@ -32,7 +32,7 @@ from gui.contextMenu import ContextMenu
 from service.const import GraphCacheCleanupReason
 from service.fit import Fit
 from .stylePickers import ColorPickerPopup, LightnessPickerPopup, LineStylePickerPopup
-
+_t = wx.GetTranslation
 
 class BaseWrapperList(gui.display.Display):
 
@@ -302,7 +302,7 @@ class SourceWrapperList(BaseWrapperList):
         selection = self.getSelectedWrappers()
         mainItem = self.getWrapper(clickedPos)
 
-        itemContext = None if mainItem is None else 'Fit'
+        itemContext = None if mainItem is None else _t('Fit')
         menu = ContextMenu.getMenu(self, mainItem, selection, ('graphFitList', itemContext), ('graphFitListMisc', itemContext))
         if menu:
             self.PopupMenu(menu)
@@ -355,7 +355,7 @@ class TargetWrapperList(BaseWrapperList):
         selection = self.getSelectedWrappers()
         mainItem = self.getWrapper(clickedPos)
 
-        itemContext = None if mainItem is None else 'Target'
+        itemContext = None if mainItem is None else _t('Target')
         menu = ContextMenu.getMenu(self, mainItem, selection, ('graphTgtList', itemContext), ('graphTgtListMisc', itemContext))
         if menu:
             self.PopupMenu(menu)

--- a/gui/builtinAdditionPanes/boosterView.py
+++ b/gui/builtinAdditionPanes/boosterView.py
@@ -29,7 +29,7 @@ from gui.contextMenu import ContextMenu
 from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 from service.market import Market
-
+_t = wx.GetTranslation
 
 class BoosterViewDrop(wx.DropTarget):
     def __init__(self, dropFn, *args, **kwargs):
@@ -212,7 +212,7 @@ class BoosterView(d.Display):
             else:
                 if booster in self.original:
                     mainBooster = booster
-        itemContext = None if mainBooster is None else "Booster"
+        itemContext = None if mainBooster is None else _t("Booster")
         menu = ContextMenu.getMenu(self, mainBooster, selection, ("boosterItem", itemContext), ("boosterItemMisc", itemContext))
         if menu:
             self.PopupMenu(menu)

--- a/gui/builtinAdditionPanes/commandView.py
+++ b/gui/builtinAdditionPanes/commandView.py
@@ -30,6 +30,7 @@ from gui.contextMenu import ContextMenu
 from gui.utils.staticHelpers import DragDropHelper
 from service.fit import Fit
 
+_t = wx.GetTranslation
 
 class DummyItem:
 
@@ -197,7 +198,7 @@ class CommandView(d.Display):
                 pass
         contexts = []
         if mainCommandFit is not None:
-            contexts.append(('commandFit', 'Command Fit'))
+            contexts.append(('commandFit', _t('Command Fit')))
         contexts.append(('commandView',))
         menu = ContextMenu.getMenu(self, mainCommandFit, selection, *contexts)
         if menu:

--- a/gui/builtinAdditionPanes/projectedView.py
+++ b/gui/builtinAdditionPanes/projectedView.py
@@ -41,7 +41,7 @@ from service.market import Market
 
 
 pyfalog = Logger(__name__)
-
+_t = wx.GetTranslation
 
 class DummyItem:
     def __init__(self, txt):
@@ -303,7 +303,7 @@ class ProjectedView(d.Display):
 
             if isinstance(mainItem, EosModule):
                 modSrcContext = 'projectedModule'
-                modItemContext = 'Projected Item'
+                modItemContext = _t('Projected Item')
                 modFullContext = (modSrcContext, modItemContext)
                 contexts.append(modFullContext)
                 if mainItem.charge is not None:
@@ -313,17 +313,17 @@ class ProjectedView(d.Display):
                     contexts.append(chargeFullContext)
             elif isinstance(mainItem, EosDrone):
                 srcContext = 'projectedDrone'
-                itemContext = 'Projected Item'
+                itemContext = _t('Projected Item')
                 droneFullContext = (srcContext, itemContext)
                 contexts.append(droneFullContext)
             elif isinstance(mainItem, EosFighter):
                 srcContext = 'projectedFighter'
-                itemContext = 'Projected Item'
+                itemContext = _t('Projected Item')
                 fighterFullContext = (srcContext, itemContext)
                 contexts.append(fighterFullContext)
             else:
                 fitSrcContext = 'projectedFit'
-                fitItemContext = 'Projected Item'
+                fitItemContext = _t('Projected Item')
                 fitFullContext = (fitSrcContext, fitItemContext)
                 contexts.append(fitFullContext)
         contexts.append(('projected',))

--- a/gui/builtinContextMenus/additionsExportAll.py
+++ b/gui/builtinContextMenus/additionsExportAll.py
@@ -1,44 +1,46 @@
+import wx
+
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from gui.utils.clipboard import toClipboard
 from service.fit import Fit
-from service.port.eft import exportDrones, exportFighters, exportCargo, exportImplants, exportBoosters
+from service.port.eft import exportBoosters, exportCargo, exportDrones, exportFighters, exportImplants
 
-
-viewSpecMap = {
-    'droneItemMisc': ('Drones', lambda cw: cw.drones, exportDrones),
-    'fighterItemMisc': ('Fighters', lambda cw: cw.fighters, exportFighters),
-    'cargoItemMisc': ('Cargo Items', lambda cw: cw.cargo, exportCargo),
-    'implantItemMisc': ('Implants', lambda cw: cw.implants, exportImplants),
-    'implantItemMiscChar': ('Implants', lambda cw: cw.implants, exportImplants),
-    'boosterItemMisc': ('Boosters', lambda cw: cw.boosters, exportBoosters)}
+_t = wx.GetTranslation
 
 
 class AdditionsExportAll(ContextMenuUnconditional):
-
     visibilitySetting = 'additionsCopyPaste'
 
     def __init__(self):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self.viewSpecMap = {
+            'droneItemMisc': (_t('Drones'), lambda cw: cw.drones, exportDrones),
+            'fighterItemMisc': (_t('Fighters'), lambda cw: cw.fighters, exportFighters),
+            'cargoItemMisc': (_t('Cargo Items'), lambda cw: cw.cargo, exportCargo),
+            'implantItemMisc': (_t('Implants'), lambda cw: cw.implants, exportImplants),
+            'implantItemMiscChar': (_t('Implants'), lambda cw: cw.implants, exportImplants),
+            'boosterItemMisc': (_t('Boosters'), lambda cw: cw.boosters, exportBoosters)
+        }
 
     def display(self, callingWindow, srcContext):
-        if srcContext not in viewSpecMap:
+        if srcContext not in self.viewSpecMap:
             return False
         fit = Fit.getInstance().getFit(self.mainFrame.getActiveFit())
         if fit is None:
             return False
-        if not viewSpecMap[srcContext][1](callingWindow):
+        if not self.viewSpecMap[srcContext][1](callingWindow):
             return False
 
         self.srcContext = srcContext
         return True
 
     def getText(self, callingWindow, itmContext):
-        return 'Copy All {}'.format(viewSpecMap[self.srcContext][0])
+        return _t('Copy All {}').format(self.viewSpecMap[self.srcContext][0])
 
     def activate(self, callingWindow, fullContext, i):
-        items = viewSpecMap[self.srcContext][1](callingWindow)
-        export = viewSpecMap[self.srcContext][2](items)
+        items = self.viewSpecMap[self.srcContext][1](callingWindow)
+        export = self.viewSpecMap[self.srcContext][2](items)
         if export:
             toClipboard(export)
 

--- a/gui/builtinContextMenus/additionsExportSelection.py
+++ b/gui/builtinContextMenus/additionsExportSelection.py
@@ -1,28 +1,30 @@
+import wx
+
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSelection
 from gui.utils.clipboard import toClipboard
 from service.fit import Fit
-from service.port.eft import exportDrones, exportFighters, exportCargo, exportImplants, exportBoosters
+from service.port.eft import exportBoosters, exportCargo, exportDrones, exportFighters, exportImplants
 
-
-viewSpecMap = {
-    'droneItemMisc': ('Drones', exportDrones),
-    'fighterItemMisc': ('Fighters', exportFighters),
-    'cargoItemMisc': ('Cargo Items', exportCargo),
-    'implantItemMisc': ('Implants', exportImplants),
-    'implantItemMiscChar': ('Implants', exportImplants),
-    'boosterItemMisc': ('Boosters', exportBoosters)}
+_t = wx.GetTranslation
 
 
 class AdditionsExportAll(ContextMenuSelection):
-
     visibilitySetting = 'additionsCopyPaste'
 
     def __init__(self):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self.viewSpecMap = {
+            'droneItemMisc': (_t('Drones'), exportDrones),
+            'fighterItemMisc': (_t('Fighters'), exportFighters),
+            'cargoItemMisc': (_t('Cargo Items'), exportCargo),
+            'implantItemMisc': (_t('Implants'), exportImplants),
+            'implantItemMiscChar': (_t('Implants'), exportImplants),
+            'boosterItemMisc': (_t('Boosters'), exportBoosters)
+        }
 
     def display(self, callingWindow, srcContext, selection):
-        if srcContext not in viewSpecMap:
+        if srcContext not in self.viewSpecMap:
             return False
         if not selection:
             return False
@@ -34,10 +36,10 @@ class AdditionsExportAll(ContextMenuSelection):
         return True
 
     def getText(self, callingWindow, itmContext, selection):
-        return 'Copy Selected {}'.format(viewSpecMap[self.srcContext][0])
+        return _t('Copy Selected {}').format(self.viewSpecMap[self.srcContext][0])
 
     def activate(self, callingWindow, fullContext, selection, i):
-        export = viewSpecMap[self.srcContext][1](selection)
+        export = self.viewSpecMap[self.srcContext][1](selection)
         if export:
             toClipboard(export)
 

--- a/gui/builtinContextMenus/additionsImport.py
+++ b/gui/builtinContextMenus/additionsImport.py
@@ -1,3 +1,5 @@
+import wx
+
 import gui.mainFrame
 from gui import fitCommands as cmd
 from gui.contextMenu import ContextMenuUnconditional
@@ -5,25 +7,25 @@ from gui.utils.clipboard import fromClipboard
 from service.fit import Fit
 from service.port.eft import parseAdditions
 
-
-viewSpecMap = {
-    'droneItemMisc': ('Drones', lambda i: i.isDrone, cmd.GuiImportLocalDronesCommand),
-    'fighterItemMisc': ('Fighters', lambda i: i.isFighter, cmd.GuiImportLocalFightersCommand),
-    'cargoItemMisc': ('Cargo Items', lambda i: not i.isAbyssal, cmd.GuiImportCargosCommand),
-    'implantItemMisc': ('Implants', lambda i: i.isImplant, cmd.GuiImportImplantsCommand),
-    'implantItemMiscChar': ('Implants', lambda i: i.isImplant, cmd.GuiImportImplantsCommand),
-    'boosterItemMisc': ('Boosters', lambda i: i.isBooster, cmd.GuiImportBoostersCommand)}
+_t = wx.GetTranslation
 
 
 class AdditionsImport(ContextMenuUnconditional):
-
     visibilitySetting = 'additionsCopyPaste'
 
     def __init__(self):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self.viewSpecMap = {
+            'droneItemMisc': (_t('Drones'), lambda i: i.isDrone, cmd.GuiImportLocalDronesCommand),
+            'fighterItemMisc': (_t('Fighters'), lambda i: i.isFighter, cmd.GuiImportLocalFightersCommand),
+            'cargoItemMisc': (_t('Cargo Items'), lambda i: not i.isAbyssal, cmd.GuiImportCargosCommand),
+            'implantItemMisc': (_t('Implants'), lambda i: i.isImplant, cmd.GuiImportImplantsCommand),
+            'implantItemMiscChar': (_t('Implants'), lambda i: i.isImplant, cmd.GuiImportImplantsCommand),
+            'boosterItemMisc': (_t('Boosters'), lambda i: i.isBooster, cmd.GuiImportBoostersCommand)
+        }
 
     def display(self, callingWindow, srcContext):
-        if srcContext not in viewSpecMap:
+        if srcContext not in self.viewSpecMap:
             return False
         fit = Fit.getInstance().getFit(self.mainFrame.getActiveFit())
         if fit is None:
@@ -35,16 +37,16 @@ class AdditionsImport(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, itmContext):
-        return 'Paste {}'.format(viewSpecMap[self.srcContext][0])
+        return _t('Paste {}').format(self.viewSpecMap[self.srcContext][0])
 
     def activate(self, callingWindow, fullContext, i):
         text = fromClipboard()
         items = parseAdditions(text)
-        filterFunc = viewSpecMap[self.srcContext][1]
+        filterFunc = self.viewSpecMap[self.srcContext][1]
         items = [(i.ID, a) for i, a in items if filterFunc(i)]
         if not items:
             return
-        command = viewSpecMap[self.srcContext][2]
+        command = self.viewSpecMap[self.srcContext][2]
         self.mainFrame.command.Submit(command(self.mainFrame.getActiveFit(), items))
 
 

--- a/gui/builtinContextMenus/ammoToDmgPattern.py
+++ b/gui/builtinContextMenus/ammoToDmgPattern.py
@@ -6,9 +6,10 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class AmmoToDmgPattern(ContextMenuSingle):
-
     visibilitySetting = 'ammoPattern'
 
     def __init__(self):
@@ -28,7 +29,7 @@ class AmmoToDmgPattern(ContextMenuSingle):
         return False
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Set {} as Damage Pattern".format(itmContext if itmContext is not None else "Item")
+        return _t("Set {} as Damage Pattern").format(itmContext if itmContext is not None else _t("Item"))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()

--- a/gui/builtinContextMenus/boosterSideEffects.py
+++ b/gui/builtinContextMenus/boosterSideEffects.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui import fitCommands as cmd
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class BoosterSideEffects(ContextMenuSingle):
@@ -28,7 +31,7 @@ class BoosterSideEffects(ContextMenuSingle):
         return False
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Side Effects"
+        return _t("Side Effects")
 
     def addEffect(self, menu, ability):
         label = ability.name
@@ -67,7 +70,7 @@ class BoosterSideEffects(ContextMenuSingle):
         if booster in fit.boosters:
             index = fit.boosters.index(booster)
             self.mainFrame.command.Submit(cmd.GuiToggleBoosterSideEffectStateCommand(
-                fitID=fitID, position=index, effectID=effect.effectID))
+                    fitID=fitID, position=index, effectID=effect.effectID))
 
 
 BoosterSideEffects.register()

--- a/gui/builtinContextMenus/cargoAdd.py
+++ b/gui/builtinContextMenus/cargoAdd.py
@@ -1,7 +1,11 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class AddToCargo(ContextMenuSingle):
@@ -26,7 +30,7 @@ class AddToCargo(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Add {} to Cargo".format(itmContext)
+        return _t("Add {} to Cargo").format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()

--- a/gui/builtinContextMenus/cargoAddAmmo.py
+++ b/gui/builtinContextMenus/cargoAddAmmo.py
@@ -1,6 +1,10 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
+
+_t = wx.GetTranslation
 
 
 class AddToCargoAmmo(ContextMenuSingle):
@@ -21,7 +25,7 @@ class AddToCargoAmmo(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Add {0} to Cargo (x1000)".format(itmContext)
+        return _t("Add {0} to Cargo (x1000)").format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()

--- a/gui/builtinContextMenus/commandFitAdd.py
+++ b/gui/builtinContextMenus/commandFitAdd.py
@@ -7,9 +7,10 @@ from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
 from service.market import Market
 
+_t = wx.GetTranslation
+
 
 class AddCommandFit(ContextMenuUnconditional):
-
     # Get list of items that define a command fit
     sMkt = Market.getInstance()
     grp = sMkt.getGroup(1770)  # Command burst group
@@ -47,7 +48,7 @@ class AddCommandFit(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, itmContext):
-        return "Command Fits"
+        return _t("Command Fits")
 
     def addFit(self, menu, fit, includeShip=False):
         label = fit.name if not includeShip else "({}) {}".format(fit.ship.item.name, fit.name)

--- a/gui/builtinContextMenus/damagePatternChange.py
+++ b/gui/builtinContextMenus/damagePatternChange.py
@@ -35,8 +35,8 @@ class ChangeDamagePattern(ContextMenuUnconditional):
         # Order here is important: patterns with duplicate names from the latter will overwrite
         # patterns from the former
         self.patterns = sorted(
-            chain(builtinPatterns, userPatterns),
-            key=lambda p: p.fullName not in ["Uniform", "Selected Ammo"])
+                chain(builtinPatterns, userPatterns),
+                key=lambda p: p.fullName not in ["Uniform", "Selected Ammo"])
 
         self.patternEventMap = {}
         self.items = (OrderedDict(), OrderedDict())

--- a/gui/builtinContextMenus/droneAddStack.py
+++ b/gui/builtinContextMenus/droneAddStack.py
@@ -1,8 +1,12 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from gui.fitCommands.helpers import droneStackLimit
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class DroneAddStack(ContextMenuSingle):
@@ -33,14 +37,14 @@ class DroneAddStack(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return 'Add {} to Drone Bay{}'.format(
-            itmContext, '' if self.amount == 1 else ' (x{})'.format(self.amount))
+        return _t('Add {} to Drone Bay{}').format(
+                itmContext, '' if self.amount == 1 else ' (x{})'.format(self.amount))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         command = cmd.GuiAddLocalDroneCommand(
-            fitID=self.mainFrame.getActiveFit(),
-            itemID=int(mainItem.ID),
-            amount=self.amount)
+                fitID=self.mainFrame.getActiveFit(),
+                itemID=int(mainItem.ID),
+                amount=self.amount)
         if self.mainFrame.command.Submit(command):
             self.mainFrame.additionsPane.select('Drones', focus=False)
 

--- a/gui/builtinContextMenus/droneSplitStack.py
+++ b/gui/builtinContextMenus/droneSplitStack.py
@@ -8,6 +8,8 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class DroneSplitStack(ContextMenuSingle):
 
@@ -24,7 +26,7 @@ class DroneSplitStack(ContextMenuSingle):
         return mainItem.amount > 1
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Split {} Stack".format(itmContext)
+        return _t("Split {} Stack").format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         with DroneStackSplit(self.mainFrame, mainItem.amount) as dlg:
@@ -41,7 +43,7 @@ class DroneSplitStack(ContextMenuSingle):
                 if mainItem in fit.drones:
                     position = fit.drones.index(mainItem)
                     self.mainFrame.command.Submit(cmd.GuiSplitLocalDroneStackCommand(
-                        fitID=fitID, position=position, amount=int(cleanInput)))
+                            fitID=fitID, position=position, amount=int(cleanInput)))
 
 
 DroneSplitStack.register()

--- a/gui/builtinContextMenus/envEffectAdd.py
+++ b/gui/builtinContextMenus/envEffectAdd.py
@@ -10,6 +10,8 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.market import Market
 
+_t = wx.GetTranslation
+
 
 class Group:
 
@@ -32,9 +34,7 @@ class Entry:
         self.shortName = shortName
 
 
-
 class AddEnvironmentEffect(ContextMenuUnconditional):
-
     # CCP doesn't currently provide a mapping between the general Environment, and the specific environment effect
     # (which can be random when going into Abyssal space). This is how we currently define it:
     # environment type: specific type name prefix
@@ -53,7 +53,7 @@ class AddEnvironmentEffect(ContextMenuUnconditional):
         return srcContext == "projected"
 
     def getText(self, callingWindow, itmContext):
-        return "Add Environmental Effect"
+        return _t("Add Environmental Effect")
 
     def _addGroup(self, parentMenu, name):
         id = ContextMenuUnconditional.nextID()
@@ -103,8 +103,8 @@ class AddEnvironmentEffect(ContextMenuUnconditional):
     def getData(self):
         data = Group()
         data.groups['Wormhole'] = self.getEffectBeacons(
-            'Black Hole', 'Cataclysmic Variable', 'Magnetar',
-            'Pulsar', 'Red Giant', 'Wolf Rayet')
+                'Black Hole', 'Cataclysmic Variable', 'Magnetar',
+                'Pulsar', 'Red Giant', 'Wolf Rayet')
         data.groups['Sansha Incursion'] = self.getEffectBeacons('Sansha Incursion')
         data.groups['Triglavian Invasion'] = self.getEffectBeacons('Triglavian Invasion')
         data.groups['Triglavian Invasion'].groups['Destructible Beacons'] = self.getDestructibleBeacons()
@@ -165,8 +165,8 @@ class AddEnvironmentEffect(ContextMenuUnconditional):
 
         environments = {x.ID: x for x in sMkt.getGroup("Abyssal Environment").items}
         items = chain(
-            sMkt.getGroup("MassiveEnvironments").items,
-            sMkt.getGroup("Non-Interactable Object").items)
+                sMkt.getGroup("MassiveEnvironments").items,
+                sMkt.getGroup("Non-Interactable Object").items)
         for beacon in items:
             if not beacon.isType('projected'):
                 continue
@@ -209,5 +209,6 @@ class AddEnvironmentEffect(ContextMenuUnconditional):
             data.items.append(Entry(item.ID, item.name, item.name))
         data.sort()
         return data
+
 
 AddEnvironmentEffect.register()

--- a/gui/builtinContextMenus/factorReload.py
+++ b/gui/builtinContextMenus/factorReload.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class FactorReload(ContextMenuUnconditional):
@@ -20,7 +23,7 @@ class FactorReload(ContextMenuUnconditional):
         return self.mainFrame.getActiveFit() is not None
 
     def getText(self, callingWindow, itmContext):
-        return "Factor in Reload Time"
+        return _t("Factor in Reload Time")
 
     def activate(self, callingWindow, fullContext, i):
         fitIDs = Fit.getInstance().toggleFactorReload()

--- a/gui/builtinContextMenus/fighterAbilities.py
+++ b/gui/builtinContextMenus/fighterAbilities.py
@@ -1,11 +1,14 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui import fitCommands as cmd
-from gui.fitCommands.helpers import getSimilarFighters
 from gui.contextMenu import ContextMenuCombined
+from gui.fitCommands.helpers import getSimilarFighters
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class FighterAbilities(ContextMenuCombined):
@@ -27,7 +30,7 @@ class FighterAbilities(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return "Abilities"
+        return _t("Abilities")
 
     def addAbility(self, menu, ability):
         label = ability.name
@@ -78,10 +81,10 @@ class FighterAbilities(ContextMenuCombined):
                 if fighter in container:
                     positions.append(container.index(fighter))
             self.mainFrame.command.Submit(command(
-                fitID=fitID,
-                mainPosition=mainPosition,
-                positions=positions,
-                effectID=ability.effectID))
+                    fitID=fitID,
+                    mainPosition=mainPosition,
+                    positions=positions,
+                    effectID=ability.effectID))
 
 
 FighterAbilities.register()

--- a/gui/builtinContextMenus/fitAddBrowse.py
+++ b/gui/builtinContextMenus/fitAddBrowse.py
@@ -1,8 +1,11 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
+
+_t = wx.GetTranslation
 
 
 class AddBrowsedFits(ContextMenuUnconditional):
@@ -16,7 +19,7 @@ class AddBrowsedFits(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, itmContext):
-        return 'Add Fit...'
+        return _t('Add Fit...')
 
     def activate(self, callingWindow, fullContext, i):
         from gui.fitBrowserLite import FitBrowserLiteDialog
@@ -24,7 +27,8 @@ class AddBrowsedFits(ContextMenuUnconditional):
             'projected': 'Add Projected Fits',
             'commandView': 'Add Command Fits',
             'graphFitList': 'Add Fits to Graph',
-            'graphTgtList': 'Add Targets to Graph'}
+            'graphTgtList': 'Add Targets to Graph'
+        }
         excludedFitIDs = callingWindow.getExistingFitIDs()
         with FitBrowserLiteDialog(self.mainFrame, title=titles[fullContext[0]], excludedFitIDs=excludedFitIDs) as dlg:
             if dlg.ShowModal() == wx.ID_OK:

--- a/gui/builtinContextMenus/fitAddCurrentlyOpen.py
+++ b/gui/builtinContextMenus/fitAddCurrentlyOpen.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui.builtinViews.emptyView import BlankPage
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class AddCurrentlyOpenFit(ContextMenuUnconditional):
@@ -23,7 +26,7 @@ class AddCurrentlyOpenFit(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, itmContext):
-        return 'Add Currently Open Fit'
+        return _t('Add Currently Open Fit')
 
     def getSubMenu(self, callingWindow, context, rootMenu, i, pitem):
         self.fitLookup = {}

--- a/gui/builtinContextMenus/fitOpenNewTab.py
+++ b/gui/builtinContextMenus/fitOpenNewTab.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from graphs.wrapper import BaseWrapper
 from gui.builtinShipBrowser.events import FitSelected
 from gui.contextMenu import ContextMenuSingle
+
+_t = wx.GetTranslation
 
 
 class OpenFitInNewTab(ContextMenuSingle):
@@ -31,7 +34,7 @@ class OpenFitInNewTab(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Open Fit in New Tab"
+        return _t("Open Fit in New Tab")
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         if isinstance(mainItem, BaseWrapper):

--- a/gui/builtinContextMenus/fitSystemSecurity.py
+++ b/gui/builtinContextMenus/fitSystemSecurity.py
@@ -8,6 +8,7 @@ from eos.const import FitSystemSecurity
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
 
+_t = wx.GetTranslation
 
 optionMap = OrderedDict((
     ('High Security', FitSystemSecurity.HISEC),
@@ -34,7 +35,7 @@ class FitSystemSecurityMenu(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, itmContext):
-        return "Citadel System Security"
+        return _t("Citadel System Security")
 
     def addOption(self, menu, optionLabel):
         id = ContextMenuUnconditional.nextID()
@@ -60,8 +61,8 @@ class FitSystemSecurityMenu(ContextMenuUnconditional):
         optionLabel = self.optionIds[event.Id]
         optionValue = optionMap[optionLabel]
         self.mainFrame.command.Submit(cmd.GuiChangeFitSystemSecurityCommand(
-            fitID=self.mainFrame.getActiveFit(),
-            secStatus=optionValue))
+                fitID=self.mainFrame.getActiveFit(),
+                secStatus=optionValue))
 
 
 FitSystemSecurityMenu.register()

--- a/gui/builtinContextMenus/graphDmgApplyProjected.py
+++ b/gui/builtinContextMenus/graphDmgApplyProjected.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.settings import GraphSettings
+
+_t = wx.GetTranslation
 
 
 class GraphDmgApplyProjectedMenu(ContextMenuUnconditional):
@@ -17,7 +20,7 @@ class GraphDmgApplyProjectedMenu(ContextMenuUnconditional):
         return srcContext == 'dmgStatsGraph'
 
     def getText(self, callingWindow, itmContext):
-        return 'Apply Projected Items'
+        return _t('Apply Projected Items')
 
     def activate(self, callingWindow, fullContext, i):
         self.settings.set('applyProjected', not self.settings.get('applyProjected'))

--- a/gui/builtinContextMenus/graphDmgDroneMode.py
+++ b/gui/builtinContextMenus/graphDmgDroneMode.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.globalEvents as GE
@@ -8,6 +7,10 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.const import GraphDpsDroneMode
 from service.settings import GraphSettings
+
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 
 class GraphDmgDroneModeMenu(ContextMenuUnconditional):
@@ -20,7 +23,7 @@ class GraphDmgDroneModeMenu(ContextMenuUnconditional):
         return srcContext == 'dmgStatsGraph'
 
     def getText(self, callingWindow, itmContext):
-        return 'Drone Mode'
+        return _t('Drone Mode')
 
     def handleModeSwitch(self, event):
         option = self.idOptionMap[event.Id]

--- a/gui/builtinContextMenus/graphDmgIgnoreResists.py
+++ b/gui/builtinContextMenus/graphDmgIgnoreResists.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.settings import GraphSettings
+
+_t = wx.GetTranslation
 
 
 class GraphDmgIgnoreResistsMenu(ContextMenuUnconditional):
@@ -17,7 +20,7 @@ class GraphDmgIgnoreResistsMenu(ContextMenuUnconditional):
         return srcContext == 'dmgStatsGraph'
 
     def getText(self, callingWindow, itmContext):
-        return 'Ignore Target Resists'
+        return _t('Ignore Target Resists')
 
     def activate(self, callingWindow, fullContext, i):
         self.settings.set('ignoreResists', not self.settings.get('ignoreResists'))

--- a/gui/builtinContextMenus/graphDroneControlRange.py
+++ b/gui/builtinContextMenus/graphDroneControlRange.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.settings import GraphSettings
+
+_t = wx.GetTranslation
 
 
 class GraphIgnoreDcrMenu(ContextMenuUnconditional):
@@ -17,7 +20,7 @@ class GraphIgnoreDcrMenu(ContextMenuUnconditional):
         return srcContext in ('dmgStatsGraph', 'remoteRepsGraph', 'ewarStatsGraph')
 
     def getText(self, callingWindow, itmContext):
-        return 'Ignore Drone Control Range'
+        return _t('Ignore Drone Control Range')
 
     def activate(self, callingWindow, fullContext, i):
         self.settings.set('ignoreDCR', not self.settings.get('ignoreDCR'))

--- a/gui/builtinContextMenus/graphFitAmmoPicker.py
+++ b/gui/builtinContextMenus/graphFitAmmoPicker.py
@@ -1,4 +1,5 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
@@ -6,6 +7,8 @@ from gui.auxWindow import AuxiliaryDialog
 from gui.contextMenu import ContextMenuSingle
 from service.ammo import Ammo
 from service.market import Market
+
+_t = wx.GetTranslation
 
 
 class GraphFitAmmoPicker(ContextMenuSingle):
@@ -23,7 +26,7 @@ class GraphFitAmmoPicker(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return 'Plot with Different Ammo...'
+        return _t('Plot with Different Ammo...')
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         AmmoPickerFrame.openOne(callingWindow, mainItem.item, forceReopen=True)
@@ -73,7 +76,6 @@ class AmmoPickerFrame(AuxiliaryDialog):
 
 
 class AmmoPickerContents(wx.ScrolledCanvas):
-
     indent = 15
 
     def __init__(self, parent, fit):

--- a/gui/builtinContextMenus/graphLockRange.py
+++ b/gui/builtinContextMenus/graphLockRange.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.settings import GraphSettings
+
+_t = wx.GetTranslation
 
 
 class GraphIgnoreLockRangeMenu(ContextMenuUnconditional):
@@ -17,7 +20,7 @@ class GraphIgnoreLockRangeMenu(ContextMenuUnconditional):
         return srcContext in ('dmgStatsGraph', 'remoteRepsGraph', 'ewarStatsGraph')
 
     def getText(self, callingWindow, itmContext):
-        return 'Ignore Lock Range'
+        return _t('Ignore Lock Range')
 
     def activate(self, callingWindow, fullContext, i):
         self.settings.set('ignoreLockRange', not self.settings.get('ignoreLockRange'))

--- a/gui/builtinContextMenus/implantSetApply.py
+++ b/gui/builtinContextMenus/implantSetApply.py
@@ -1,10 +1,12 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 from gui.contextMenu import ContextMenuUnconditional
-from service.market import Market
 from service.implantSet import ImplantSets as UserImplantSets
 from service.precalcImplantSet import PrecalcedImplantSets
+
+_t = wx.GetTranslation
 
 
 class ImplantSetApply(ContextMenuUnconditional):
@@ -20,7 +22,7 @@ class ImplantSetApply(ContextMenuUnconditional):
         return srcContext in ("implantItemMisc", "implantEditor")
 
     def getText(self, callingWindow, context):
-        return "Apply Implant Set"
+        return _t("Apply Implant Set")
 
     def _addSeparator(self, m, text):
         id_ = ContextMenuUnconditional.nextID()

--- a/gui/builtinContextMenus/implantSetSave.py
+++ b/gui/builtinContextMenus/implantSetSave.py
@@ -4,6 +4,8 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class ImplantSetSave(ContextMenuUnconditional):
 
@@ -22,7 +24,7 @@ class ImplantSetSave(ContextMenuUnconditional):
         return True
 
     def getText(self, callingWindow, context):
-        return 'Save as New Implant Set'
+        return _t('Save as New Implant Set')
 
     def activate(self, callingWindow, fullContext, i):
         with NameDialog(self.mainFrame, '') as dlg:
@@ -40,13 +42,13 @@ ImplantSetSave.register()
 class NameDialog(wx.Dialog):
 
     def __init__(self, parent, value):
-        super().__init__(parent, title='New Implant Set', style=wx.DEFAULT_DIALOG_STYLE)
+        super().__init__(parent, title=_t('New Implant Set'), style=wx.DEFAULT_DIALOG_STYLE)
         self.SetMinSize((346, 156))
 
         bSizer1 = wx.BoxSizer(wx.VERTICAL)
 
         bSizer2 = wx.BoxSizer(wx.VERTICAL)
-        text = wx.StaticText(self, wx.ID_ANY, 'Enter a name for your new Implant Set:')
+        text = wx.StaticText(self, wx.ID_ANY, _t('Enter a name for your new Implant Set:'))
         bSizer2.Add(text, 0)
 
         bSizer1.Add(bSizer2, 0, wx.ALL, 10)

--- a/gui/builtinContextMenus/itemAmountChange.py
+++ b/gui/builtinContextMenus/itemAmountChange.py
@@ -1,6 +1,5 @@
 import re
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.fitCommands as cmd
@@ -11,6 +10,10 @@ from eos.saveddata.fighter import Fighter as es_Fighter
 from eos.saveddata.fit import Fit as es_Fit
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
+
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 
 class ChangeItemAmount(ContextMenuSingle):
@@ -28,7 +31,7 @@ class ChangeItemAmount(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Change {0} Quantity".format(itmContext)
+        return _t("Change {0} Quantity").format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()
@@ -54,30 +57,30 @@ class ChangeItemAmount(ContextMenuSingle):
 
                 if isinstance(mainItem, es_Cargo):
                     self.mainFrame.command.Submit(cmd.GuiChangeCargoAmountCommand(
-                        fitID=fitID, itemID=mainItem.itemID, amount=cleanInput))
+                            fitID=fitID, itemID=mainItem.itemID, amount=cleanInput))
                 elif isinstance(mainItem, Drone):
                     if srcContext == "projectedDrone":
                         self.mainFrame.command.Submit(cmd.GuiChangeProjectedDroneAmountCommand(
-                            fitID=fitID, itemID=mainItem.itemID, amount=cleanInput))
+                                fitID=fitID, itemID=mainItem.itemID, amount=cleanInput))
                     else:
                         if mainItem in fit.drones:
                             position = fit.drones.index(mainItem)
                             self.mainFrame.command.Submit(cmd.GuiChangeLocalDroneAmountCommand(
-                                fitID=fitID, position=position, amount=cleanInput))
+                                    fitID=fitID, position=position, amount=cleanInput))
                 elif isinstance(mainItem, es_Fit):
                     self.mainFrame.command.Submit(cmd.GuiChangeProjectedFitAmountCommand(
-                        fitID=fitID, projectedFitID=mainItem.ID, amount=cleanInput))
+                            fitID=fitID, projectedFitID=mainItem.ID, amount=cleanInput))
                 elif isinstance(mainItem, es_Fighter):
                     if srcContext == "projectedFighter":
                         if mainItem in fit.projectedFighters:
                             position = fit.projectedFighters.index(mainItem)
                             self.mainFrame.command.Submit(cmd.GuiChangeProjectedFighterAmountCommand(
-                                fitID=fitID, position=position, amount=cleanInput))
+                                    fitID=fitID, position=position, amount=cleanInput))
                     else:
                         if mainItem in fit.fighters:
                             position = fit.fighters.index(mainItem)
                             self.mainFrame.command.Submit(cmd.GuiChangeLocalFighterAmountCommand(
-                                fitID=fitID, position=position, amount=cleanInput))
+                                    fitID=fitID, position=position, amount=cleanInput))
 
 
 ChangeItemAmount.register()
@@ -86,13 +89,13 @@ ChangeItemAmount.register()
 class AmountChanger(wx.Dialog):
 
     def __init__(self, parent, value, limits=None):
-        super().__init__(parent, title="Change Amount", style=wx.DEFAULT_DIALOG_STYLE)
+        super().__init__(parent, title=_t("Change Amount"), style=wx.DEFAULT_DIALOG_STYLE)
         self.SetMinSize((346, 156))
 
         bSizer1 = wx.BoxSizer(wx.VERTICAL)
 
         bSizer2 = wx.BoxSizer(wx.VERTICAL)
-        text = wx.StaticText(self, wx.ID_ANY, "New Amount:" if limits is None else "New Amount ({}-{})".format(*limits))
+        text = wx.StaticText(self, wx.ID_ANY, _t("New Amount:") if limits is None else _t("New Amount ({}-{})").format(*limits))
         bSizer2.Add(text, 0)
 
         bSizer1.Add(bSizer2, 0, wx.ALL, 10)

--- a/gui/builtinContextMenus/itemFill.py
+++ b/gui/builtinContextMenus/itemFill.py
@@ -1,10 +1,13 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 
+_t = wx.GetTranslation
+
 
 class FillWithItem(ContextMenuSingle):
-
     visibilitySetting = 'moduleFill'
 
     def __init__(self):
@@ -26,12 +29,12 @@ class FillWithItem(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Fill With Module"
+        return _t("Fill With Module")
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         self.mainFrame.command.Submit(cmd.GuiFillWithNewLocalModulesCommand(
-            fitID=self.mainFrame.getActiveFit(),
-            itemID=int(mainItem.ID)))
+                fitID=self.mainFrame.getActiveFit(),
+                itemID=int(mainItem.ID)))
 
 
 FillWithItem.register()

--- a/gui/builtinContextMenus/itemMarketJump.py
+++ b/gui/builtinContextMenus/itemMarketJump.py
@@ -1,6 +1,10 @@
+import wx
+
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.market import Market
+
+_t = wx.GetTranslation
 
 
 class JumpToMarketItem(ContextMenuSingle):
@@ -37,7 +41,7 @@ class JumpToMarketItem(ContextMenuSingle):
         return doit
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "{0} Market Group".format(itmContext if itmContext is not None else "Item")
+        return _t("{0} Market Group").format(itmContext if itmContext is not None else _t("Item"))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         srcContext = fullContext[0]

--- a/gui/builtinContextMenus/itemProject.py
+++ b/gui/builtinContextMenus/itemProject.py
@@ -1,11 +1,14 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class ProjectItem(ContextMenuSingle):
-
     visibilitySetting = 'project'
 
     def __init__(self):
@@ -28,7 +31,7 @@ class ProjectItem(ContextMenuSingle):
         return mainItem.isType("projected")
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Project {0} onto Fit".format(itmContext)
+        return _t("Project {0} onto Fit").format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()

--- a/gui/builtinContextMenus/itemProjectionRange.py
+++ b/gui/builtinContextMenus/itemProjectionRange.py
@@ -1,6 +1,5 @@
 import re
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.fitCommands as cmd
@@ -11,6 +10,10 @@ from eos.saveddata.module import Module as EosModule
 from gui.contextMenu import ContextMenuCombined
 from gui.fitCommands.helpers import getSimilarFighters, getSimilarModPositions
 from service.fit import Fit
+
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 
 class ChangeItemProjectionRange(ContextMenuCombined):
@@ -28,7 +31,7 @@ class ChangeItemProjectionRange(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return 'Change {} Range'.format(itmContext)
+        return _t('Change {} Range').format(itmContext)
 
     def activate(self, callingWindow, fullContext, mainItem, selection, i):
         fitID = self.mainFrame.getActiveFit()
@@ -63,7 +66,7 @@ class ChangeItemProjectionRange(ContextMenuCombined):
                         fit = Fit.getInstance().getFit(fitID)
                         items = getSimilarFighters(fit.projectedFighters, mainItem)
                 self.mainFrame.command.Submit(cmd.GuiChangeProjectedItemsProjectionRangeCommand(
-                    fitID=fitID, items=items, projectionRange=newRange))
+                        fitID=fitID, items=items, projectionRange=newRange))
 
 
 ChangeItemProjectionRange.register()

--- a/gui/builtinContextMenus/itemRemove.py
+++ b/gui/builtinContextMenus/itemRemove.py
@@ -12,6 +12,8 @@ from gui.contextMenu import ContextMenuCombined
 from gui.fitCommands.helpers import getSimilarFighters, getSimilarModPositions
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class RemoveItem(ContextMenuCombined):
 
@@ -20,13 +22,13 @@ class RemoveItem(ContextMenuCombined):
 
     def display(self, callingWindow, srcContext, mainItem, selection):
         if srcContext not in (
-            "fittingModule", "droneItem",
-            "implantItem", "boosterItem",
-            "projectedModule", "cargoItem",
-            "projectedFit", "projectedDrone",
-            "fighterItem", "projectedFighter",
-            "commandFit", "graphFitList",
-            "graphTgtList"
+                "fittingModule", "droneItem",
+                "implantItem", "boosterItem",
+                "projectedModule", "cargoItem",
+                "projectedFit", "projectedDrone",
+                "fighterItem", "projectedFighter",
+                "commandFit", "graphFitList",
+                "graphTgtList"
         ):
             return False
 
@@ -37,9 +39,9 @@ class RemoveItem(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return 'Remove {}{}'.format(
-            itmContext if itmContext is not None else 'Item',
-            ' Stack' if self.srcContext in ('droneItem', 'projectedDrone', 'cargoItem', 'projectedFit') else '')
+        return _t('Remove {}{}').format(
+                itmContext if itmContext is not None else _t('Item'),
+                _t(' Stack') if self.srcContext in ('droneItem', 'projectedDrone', 'cargoItem', 'projectedFit') else '')
 
     def activate(self, callingWindow, fullContext, mainItem, selection, i):
         handlerMap = {
@@ -55,7 +57,8 @@ class RemoveItem(ContextMenuCombined):
             'projectedFighter': self.__handleProjectedItem,
             'commandFit': self.__handleCommandFit,
             'graphFitList': self.__handleGraphItem,
-            'graphTgtList': self.__handleGraphItem}
+            'graphTgtList': self.__handleGraphItem
+        }
         srcContext = fullContext[0]
         handler = handlerMap.get(srcContext)
         if handler is None:
@@ -73,7 +76,7 @@ class RemoveItem(ContextMenuCombined):
                 if mod in fit.modules:
                     positions.append(fit.modules.index(mod))
         self.mainFrame.command.Submit(cmd.GuiRemoveLocalModuleCommand(
-            fitID=fitID, positions=positions))
+                fitID=fitID, positions=positions))
 
     def __handleDrone(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
@@ -83,7 +86,7 @@ class RemoveItem(ContextMenuCombined):
             if drone in fit.drones:
                 positions.append(fit.drones.index(drone))
         self.mainFrame.command.Submit(cmd.GuiRemoveLocalDronesCommand(
-            fitID=fitID, positions=positions, amount=math.inf))
+                fitID=fitID, positions=positions, amount=math.inf))
 
     def __handleFighter(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
@@ -97,7 +100,7 @@ class RemoveItem(ContextMenuCombined):
             if fighter in fit.fighters:
                 positions.append(fit.fighters.index(fighter))
         self.mainFrame.command.Submit(cmd.GuiRemoveLocalFightersCommand(
-            fitID=fitID, positions=positions))
+                fitID=fitID, positions=positions))
 
     def __handleImplant(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
@@ -107,7 +110,7 @@ class RemoveItem(ContextMenuCombined):
             if implant in fit.implants:
                 positions.append(fit.implants.index(implant))
         self.mainFrame.command.Submit(cmd.GuiRemoveImplantsCommand(
-            fitID=fitID, positions=positions))
+                fitID=fitID, positions=positions))
 
     def __handleBooster(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
@@ -117,19 +120,19 @@ class RemoveItem(ContextMenuCombined):
             if booster in fit.boosters:
                 positions.append(fit.boosters.index(booster))
         self.mainFrame.command.Submit(cmd.GuiRemoveBoostersCommand(
-            fitID=fitID, positions=positions))
+                fitID=fitID, positions=positions))
 
     def __handleCargo(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
         itemIDs = [c.itemID for c in selection]
         self.mainFrame.command.Submit(cmd.GuiRemoveCargosCommand(
-            fitID=fitID, itemIDs=itemIDs))
+                fitID=fitID, itemIDs=itemIDs))
 
     def __handleProjectedItem(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
         if isinstance(mainItem, EosFit):
             self.mainFrame.command.Submit(cmd.GuiRemoveProjectedItemsCommand(
-                fitID=fitID, items=selection, amount=math.inf))
+                    fitID=fitID, items=selection, amount=math.inf))
         elif isinstance(mainItem, EosModule):
             if wx.GetMouseState().GetModifiers() in (wx.MOD_ALT, wx.MOD_CONTROL):
                 fit = Fit.getInstance().getFit(fitID)
@@ -138,10 +141,10 @@ class RemoveItem(ContextMenuCombined):
             else:
                 items = selection
             self.mainFrame.command.Submit(cmd.GuiRemoveProjectedItemsCommand(
-                fitID=fitID, items=items, amount=math.inf))
+                    fitID=fitID, items=items, amount=math.inf))
         elif isinstance(mainItem, EosDrone):
             self.mainFrame.command.Submit(cmd.GuiRemoveProjectedItemsCommand(
-                fitID=fitID, items=selection, amount=math.inf))
+                    fitID=fitID, items=selection, amount=math.inf))
         elif isinstance(mainItem, EosFighter):
             if wx.GetMouseState().GetModifiers() in (wx.MOD_ALT, wx.MOD_CONTROL):
                 fit = Fit.getInstance().getFit(fitID)
@@ -149,16 +152,16 @@ class RemoveItem(ContextMenuCombined):
             else:
                 items = selection
             self.mainFrame.command.Submit(cmd.GuiRemoveProjectedItemsCommand(
-                fitID=fitID, items=items, amount=math.inf))
+                    fitID=fitID, items=items, amount=math.inf))
         else:
             self.mainFrame.command.Submit(cmd.GuiRemoveProjectedItemsCommand(
-                fitID=fitID, items=selection, amount=math.inf))
+                    fitID=fitID, items=selection, amount=math.inf))
 
     def __handleCommandFit(self, callingWindow, mainItem, selection):
         fitID = self.mainFrame.getActiveFit()
         commandFitIDs = [cf.ID for cf in selection]
         self.mainFrame.command.Submit(cmd.GuiRemoveCommandFitsCommand(
-            fitID=fitID, commandFitIDs=commandFitIDs))
+                fitID=fitID, commandFitIDs=commandFitIDs))
 
     def __handleGraphItem(self, callingWindow, mainItem, selection):
         callingWindow.removeWrappers(selection)

--- a/gui/builtinContextMenus/itemStats.py
+++ b/gui/builtinContextMenus/itemStats.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from gui.itemStats import ItemStatsFrame
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class ItemStats(ContextMenuSingle):
@@ -13,16 +16,16 @@ class ItemStats(ContextMenuSingle):
 
     def display(self, callingWindow, srcContext, mainItem):
         if srcContext not in (
-            "marketItemGroup", "marketItemMisc",
-            "fittingModule", "fittingCharge",
-            "fittingShip", "baseShip",
-            "cargoItem", "droneItem",
-            "implantItem", "boosterItem",
-            "skillItem", "projectedModule",
-            "projectedDrone", "projectedCharge",
-            "itemStats", "fighterItem",
-            "implantItemChar", "projectedFighter",
-            "fittingMode"
+                "marketItemGroup", "marketItemMisc",
+                "fittingModule", "fittingCharge",
+                "fittingShip", "baseShip",
+                "cargoItem", "droneItem",
+                "implantItem", "boosterItem",
+                "skillItem", "projectedModule",
+                "projectedDrone", "projectedCharge",
+                "itemStats", "fighterItem",
+                "implantItemChar", "projectedFighter",
+                "fittingMode"
         ):
             return False
 
@@ -32,7 +35,7 @@ class ItemStats(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "{} Stats".format(itmContext if itmContext is not None else "Item")
+        return _t("{} Stats").format(itmContext if itmContext is not None else _t("Item"))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         srcContext = fullContext[0]

--- a/gui/builtinContextMenus/itemVariationChange.py
+++ b/gui/builtinContextMenus/itemVariationChange.py
@@ -1,16 +1,18 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuCombined
-from gui.fitCommands.helpers import getSimilarModPositions, getSimilarFighters
+from gui.fitCommands.helpers import getSimilarFighters, getSimilarModPositions
 from service.fit import Fit
 from service.market import Market
 
+_t = wx.GetTranslation
+
 
 class ChangeItemToVariation(ContextMenuCombined):
-
     visibilitySetting = 'metaSwap'
 
     def __init__(self):
@@ -18,15 +20,15 @@ class ChangeItemToVariation(ContextMenuCombined):
 
     def display(self, callingWindow, srcContext, mainItem, selection):
         if self.mainFrame.getActiveFit() is None or srcContext not in (
-            'fittingModule',
-            'droneItem',
-            'fighterItem',
-            'boosterItem',
-            'implantItem',
-            'cargoItem',
-            'projectedModule',
-            'projectedDrone',
-            'projectedFighter'
+                'fittingModule',
+                'droneItem',
+                'fighterItem',
+                'boosterItem',
+                'implantItem',
+                'cargoItem',
+                'projectedModule',
+                'projectedDrone',
+                'projectedFighter'
         ):
             return False
 
@@ -44,7 +46,7 @@ class ChangeItemToVariation(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return 'Variations'
+        return _t('Variations')
 
     def getSubMenu(self, callingWindow, context, mainItem, selection, rootMenu, i, pitem):
         self.moduleLookup = {}
@@ -60,7 +62,8 @@ class ChangeItemToVariation(ContextMenuCombined):
                 # We want deadspace before officer mods
                 5: 6, 6: 5,
                 # For structures we want t1-t2-faction
-                54: 52, 52: 54}
+                54: 52, 52: 54
+            }
             metaGroup = sMkt.getMetaGroupByItem(x)
             return remap.get(metaGroup.ID, metaGroup.ID) if metaGroup is not None else 0
 
@@ -86,8 +89,8 @@ class ChangeItemToVariation(ContextMenuCombined):
 
         # Do not show abyssal items
         items = list(
-            i for i in self.mainVariations
-            if sMkt.getMetaGroupByItem(i) is None or sMkt.getMetaGroupByItem(i).ID != 15)
+                i for i in self.mainVariations
+                if sMkt.getMetaGroupByItem(i) is None or sMkt.getMetaGroupByItem(i).ID != 15)
         # Sort items by metalevel, and group within that metalevel
         # Sort all items by name first
         items.sort(key=lambda x: x.name)
@@ -143,7 +146,8 @@ class ChangeItemToVariation(ContextMenuCombined):
             'boosterItem': self.__handleBooster,
             'projectedModule': self.__handleProjectedModule,
             'projectedDrone': self.__handleProjectedDrone,
-            'projectedFighter': self.__handleProjectedFighter}
+            'projectedFighter': self.__handleProjectedFighter
+        }
         handler = handlerMap.get(context)
         if handler is None:
             return
@@ -169,7 +173,7 @@ class ChangeItemToVariation(ContextMenuCombined):
                 if modVariations == self.mainVariations:
                     positions.append(fit.modules.index(mod))
         self.mainFrame.command.Submit(cmd.GuiChangeLocalModuleMetasCommand(
-            fitID=fitID, positions=positions, newItemID=varItem.ID))
+                fitID=fitID, positions=positions, newItemID=varItem.ID))
 
     def __handleDrone(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -186,7 +190,7 @@ class ChangeItemToVariation(ContextMenuCombined):
             if droneVariations == self.mainVariations:
                 positions.append(fit.drones.index(drone))
         self.mainFrame.command.Submit(cmd.GuiChangeLocalDroneMetasCommand(
-            fitID=fitID, positions=positions, newItemID=varItem.ID))
+                fitID=fitID, positions=positions, newItemID=varItem.ID))
 
     def __handleFighter(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -207,7 +211,7 @@ class ChangeItemToVariation(ContextMenuCombined):
             if fighterVariations == self.mainVariations:
                 positions.append(fit.fighters.index(fighter))
         self.mainFrame.command.Submit(cmd.GuiChangeLocalFighterMetasCommand(
-            fitID=fitID, positions=positions, newItemID=varItem.ID))
+                fitID=fitID, positions=positions, newItemID=varItem.ID))
 
     def __handleCargo(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -221,7 +225,7 @@ class ChangeItemToVariation(ContextMenuCombined):
             if cargoVariations == self.mainVariations:
                 itemIDs.append(cargo.itemID)
         self.mainFrame.command.Submit(cmd.GuiChangeCargoMetasCommand(
-            fitID=fitID, itemIDs=itemIDs, newItemID=varItem.ID))
+                fitID=fitID, itemIDs=itemIDs, newItemID=varItem.ID))
 
     def __handleImplant(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -230,7 +234,7 @@ class ChangeItemToVariation(ContextMenuCombined):
         if implant in fit.implants:
             position = fit.implants.index(implant)
             self.mainFrame.command.Submit(cmd.GuiChangeImplantMetaCommand(
-                fitID=fitID, position=position, newItemID=varItem.ID))
+                    fitID=fitID, position=position, newItemID=varItem.ID))
 
     def __handleBooster(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -239,7 +243,7 @@ class ChangeItemToVariation(ContextMenuCombined):
         if booster in fit.boosters:
             position = fit.boosters.index(booster)
             self.mainFrame.command.Submit(cmd.GuiChangeBoosterMetaCommand(
-                fitID=fitID, position=position, newItemID=varItem.ID))
+                    fitID=fitID, position=position, newItemID=varItem.ID))
 
     def __handleProjectedModule(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -259,7 +263,7 @@ class ChangeItemToVariation(ContextMenuCombined):
                 if modVariations == self.mainVariations:
                     positions.append(fit.projectedModules.index(mod))
         self.mainFrame.command.Submit(cmd.GuiChangeProjectedModuleMetasCommand(
-            fitID=fitID, positions=positions, newItemID=varItem.ID))
+                fitID=fitID, positions=positions, newItemID=varItem.ID))
 
     def __handleProjectedDrone(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -276,7 +280,7 @@ class ChangeItemToVariation(ContextMenuCombined):
             if droneVariations == self.mainVariations:
                 itemIDs.append(drone.itemID)
         self.mainFrame.command.Submit(cmd.GuiChangeProjectedDroneMetasCommand(
-            fitID=fitID, itemIDs=itemIDs, newItemID=varItem.ID))
+                fitID=fitID, itemIDs=itemIDs, newItemID=varItem.ID))
 
     def __handleProjectedFighter(self, varItem):
         fitID = self.mainFrame.getActiveFit()
@@ -297,7 +301,7 @@ class ChangeItemToVariation(ContextMenuCombined):
             if fighterVariations == self.mainVariations:
                 positions.append(fit.projectedFighters.index(fighter))
         self.mainFrame.command.Submit(cmd.GuiChangeProjectedFighterMetasCommand(
-            fitID=fitID, positions=positions, newItemID=varItem.ID))
+                fitID=fitID, positions=positions, newItemID=varItem.ID))
 
 
 ChangeItemToVariation.register()

--- a/gui/builtinContextMenus/moduleAmmoChange.py
+++ b/gui/builtinContextMenus/moduleAmmoChange.py
@@ -1,4 +1,5 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.fitCommands as cmd
@@ -8,6 +9,8 @@ from gui.contextMenu import ContextMenuCombined
 from gui.fitCommands.helpers import getSimilarModPositions
 from service.ammo import Ammo
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class ChangeModuleAmmo(ContextMenuCombined):
@@ -34,7 +37,7 @@ class ChangeModuleAmmo(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return 'Charge'
+        return _t('Charge')
 
     def _getAmmo(self, mod):
         if mod.itemID is None:
@@ -129,9 +132,9 @@ class ChangeModuleAmmo(ContextMenuCombined):
                 return
             positions = getSimilarModPositions(modContainer, self.module)
             self.mainFrame.command.Submit(command(
-                fitID=fitID,
-                positions=positions,
-                chargeItemID=charge.ID if charge is not None else None))
+                    fitID=fitID,
+                    positions=positions,
+                    chargeItemID=charge.ID if charge is not None else None))
         else:
             if self.srcContext == 'fittingModule':
                 command = cmd.GuiChangeLocalModuleChargesCommand
@@ -148,9 +151,9 @@ class ChangeModuleAmmo(ContextMenuCombined):
                     if modCharges.issubset(self.mainCharges):
                         positions.append(position)
             self.mainFrame.command.Submit(command(
-                fitID=fitID,
-                positions=positions,
-                chargeItemID=charge.ID if charge is not None else None))
+                    fitID=fitID,
+                    positions=positions,
+                    chargeItemID=charge.ID if charge is not None else None))
 
 
 ChangeModuleAmmo.register()

--- a/gui/builtinContextMenus/moduleFill.py
+++ b/gui/builtinContextMenus/moduleFill.py
@@ -1,11 +1,14 @@
+import wx
+
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class FillWithModule(ContextMenuSingle):
-
     visibilitySetting = 'moduleFill'
 
     def __init__(self):
@@ -18,7 +21,7 @@ class FillWithModule(ContextMenuSingle):
         return srcContext == "fittingModule"
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Fill With {0}".format(itmContext if itmContext is not None else "Module")
+        return _t("Fill With {0}").format(itmContext if itmContext is not None else _t("Module"))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
 
@@ -30,7 +33,7 @@ class FillWithModule(ContextMenuSingle):
             if mainItem in fit.modules:
                 position = fit.modules.index(mainItem)
                 self.mainFrame.command.Submit(cmd.GuiFillWithClonedLocalModulesCommand(
-                    fitID=fitID, position=position))
+                        fitID=fitID, position=position))
 
 
 FillWithModule.register()

--- a/gui/builtinContextMenus/moduleMutatedExport.py
+++ b/gui/builtinContextMenus/moduleMutatedExport.py
@@ -1,7 +1,11 @@
+import wx
+
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from gui.utils.clipboard import toClipboard
 from service.port.muta import renderMutant
+
+_t = wx.GetTranslation
 
 
 class ExportMutatedModule(ContextMenuSingle):
@@ -21,7 +25,7 @@ class ExportMutatedModule(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return 'Copy Module to Clipboard'
+        return _t('Copy Module to Clipboard')
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         export = renderMutant(mainItem, prefix='  ')

--- a/gui/builtinContextMenus/moduleMutations.py
+++ b/gui/builtinContextMenus/moduleMutations.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui.contextMenu import ContextMenuSingle
 from gui.fitCommands import GuiConvertMutatedLocalModuleCommand, GuiRevertMutatedLocalModuleCommand
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class ChangeModuleMutation(ContextMenuSingle):
@@ -27,7 +30,7 @@ class ChangeModuleMutation(ContextMenuSingle):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Apply Mutaplasmid" if not mainItem.isMutated else "Revert to {}".format(mainItem.baseItem.name)
+        return _t("Apply Mutaplasmid") if not mainItem.isMutated else _t("Revert to {}").format(mainItem.baseItem.name)
 
     def getSubMenu(self, callingWindow, context, mainItem, rootMenu, i, pitem):
         if mainItem.isMutated:
@@ -56,7 +59,7 @@ class ChangeModuleMutation(ContextMenuSingle):
         if mod in fit.modules:
             position = fit.modules.index(mod)
             self.mainFrame.command.Submit(GuiConvertMutatedLocalModuleCommand(
-                fitID=fitID, position=position, mutaplasmid=mutaplasmid))
+                    fitID=fitID, position=position, mutaplasmid=mutaplasmid))
 
     def activate(self, callingWindow, fullContext, mainItem, i):
         fitID = self.mainFrame.getActiveFit()
@@ -64,7 +67,7 @@ class ChangeModuleMutation(ContextMenuSingle):
         if mainItem in fit.modules:
             position = fit.modules.index(mainItem)
             self.mainFrame.command.Submit(GuiRevertMutatedLocalModuleCommand(
-                fitID=fitID, position=position))
+                    fitID=fitID, position=position))
 
     def getBitmap(self, callingWindow, context, mainItem):
         return None

--- a/gui/builtinContextMenus/moduleSpool.py
+++ b/gui/builtinContextMenus/moduleSpool.py
@@ -1,18 +1,20 @@
 import math
 
-# noinspection PyPackageRequirements
 import wx
 
 import eos.config
 import gui.fitCommands as cmd
 import gui.mainFrame
-from eos.utils.spoolSupport import SpoolType, SpoolOptions
+from eos.utils.spoolSupport import SpoolOptions, SpoolType
 from gui.contextMenu import ContextMenuSingle
 from service.fit import Fit
 
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
+
 
 class ChangeModuleSpool(ContextMenuSingle):
-
     visibilitySetting = 'spoolup'
 
     def __init__(self):
@@ -32,7 +34,7 @@ class ChangeModuleSpool(ContextMenuSingle):
         return self.mod.item.group.name in ("Precursor Weapon", "Mutadaptive Remote Armor Repairer")
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Spoolup Cycles"
+        return _t("Spoolup Cycles")
 
     def getSubMenu(self, callingWindow, context, mainItem, rootMenu, i, pitem):
         m = wx.Menu()
@@ -78,7 +80,7 @@ class ChangeModuleSpool(ContextMenuSingle):
 
             # Show default only for current value and when not overriden
             if not isNotDefault and cycle == cycleDefault:
-                text = "{} (default)".format(cycle)
+                text = _t("{} (default)").format(cycle)
             # Always show current selection and stuff which we decided to show via the cycles function
             elif cycle == cycleCurrent or cycle in cyclesToShow:
                 text = "{}".format(cycle)
@@ -93,7 +95,7 @@ class ChangeModuleSpool(ContextMenuSingle):
             self.cycleMap[menuId] = cycle
 
         self.resetId = ContextMenuSingle.nextID()
-        item = wx.MenuItem(m, self.resetId, "Reset")
+        item = wx.MenuItem(m, self.resetId, _t("Reset"))
         bindmenu.Bind(wx.EVT_MENU, self.handleSpoolChange, item)
         m.Append(item)
 
@@ -114,12 +116,12 @@ class ChangeModuleSpool(ContextMenuSingle):
             if self.mod in fit.modules:
                 position = fit.modules.index(self.mod)
                 self.mainFrame.command.Submit(cmd.GuiChangeLocalModuleSpoolCommand(
-                    fitID=fitID, position=position, spoolType=spoolType, spoolAmount=spoolAmount))
+                        fitID=fitID, position=position, spoolType=spoolType, spoolAmount=spoolAmount))
         elif self.context == 'projectedModule':
             if self.mod in fit.projectedModules:
                 position = fit.projectedModules.index(self.mod)
                 self.mainFrame.command.Submit(cmd.GuiChangeProjectedModuleSpoolCommand(
-                    fitID=fitID, position=position, spoolType=spoolType, spoolAmount=spoolAmount))
+                        fitID=fitID, position=position, spoolType=spoolType, spoolAmount=spoolAmount))
 
 
 ChangeModuleSpool.register()

--- a/gui/builtinContextMenus/priceOptions.py
+++ b/gui/builtinContextMenus/priceOptions.py
@@ -7,6 +7,8 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.settings import MarketPriceSettings
 
+_t = wx.GetTranslation
+
 
 class ItemGroupPrice(ContextMenuUnconditional, metaclass=ABCMeta):
 
@@ -16,19 +18,11 @@ class ItemGroupPrice(ContextMenuUnconditional, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def label(self):
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
     def optionName(self):
         raise NotImplementedError()
 
     def display(self, callingWindow, srcContext):
         return srcContext in ("priceViewFull", "priceViewMinimal")
-
-    def getText(self, callingWindow, itmContext):
-        return self.label
 
     def activate(self, callingWindow, fullContext, i):
         self.settings.set(self.optionName, not self.settings.get(self.optionName))
@@ -40,21 +34,24 @@ class ItemGroupPrice(ContextMenuUnconditional, metaclass=ABCMeta):
 
 
 class DronesPrice(ItemGroupPrice):
-
-    label = 'Drones'
     optionName = 'drones'
+
+    def getText(self, callingWindow, itmContext):
+        return _t('Drones')
 
 
 class CargoPrice(ItemGroupPrice):
-
-    label = 'Cargo'
     optionName = 'cargo'
+
+    def getText(self, callingWindow, itmContext):
+        return _t('Cargo')
 
 
 class ImplantBoosterPrice(ItemGroupPrice):
-
-    label = 'Implants && Boosters'
     optionName = 'character'
+
+    def getText(self, callingWindow, itmContext):
+        return _t('Implants && Boosters')
 
 
 DronesPrice.register()

--- a/gui/builtinContextMenus/resistMode.py
+++ b/gui/builtinContextMenus/resistMode.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.mainFrame
@@ -10,6 +9,9 @@ from gui.contextMenu import ContextMenuCombined
 from service.const import TargetResistMode
 from service.settings import GraphSettings
 
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 optionMap = OrderedDict((
     ('Auto', TargetResistMode.auto),
@@ -36,7 +38,7 @@ class TargetWrapperResists(ContextMenuCombined):
         return True
 
     def getText(self, callingWindow, itmContext, mainItem, selection):
-        return 'Resist Mode'
+        return _t('Resist Mode')
 
     def addOption(self, menu, optionLabel):
         id = ContextMenuCombined.nextID()

--- a/gui/builtinContextMenus/shipJump.py
+++ b/gui/builtinContextMenus/shipJump.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.mainFrame
 from gui.builtinShipBrowser.events import Stage3Selected
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class JumpToShip(ContextMenuUnconditional):
@@ -29,7 +32,7 @@ class JumpToShip(ContextMenuUnconditional):
         return False
 
     def getText(self, callingWindow, itmContext):
-        return "Open in Fitting Browser"
+        return _t("Open in Fitting Browser")
 
     def activate(self, callingWindow, fullContext, i):
         fitID = self.mainFrame.getActiveFit()

--- a/gui/builtinContextMenus/shipModeChange.py
+++ b/gui/builtinContextMenus/shipModeChange.py
@@ -1,10 +1,13 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.fitCommands as cmd
 import gui.mainFrame
 from gui.contextMenu import ContextMenuUnconditional
 from service.fit import Fit
+
+_t = wx.GetTranslation
 
 
 class ChangeShipTacticalMode(ContextMenuUnconditional):
@@ -26,7 +29,7 @@ class ChangeShipTacticalMode(ContextMenuUnconditional):
         return srcContext == "fittingShip" and self.modes is not None
 
     def getText(self, callingWindow, itmContext):
-        return "Tactical Mode"
+        return _t("Tactical Mode")
 
     def addMode(self, menu, mode):
         label = mode.item.name.rsplit()[-2]

--- a/gui/builtinContextMenus/skillAffectors.py
+++ b/gui/builtinContextMenus/skillAffectors.py
@@ -1,4 +1,5 @@
 # noinspection PyPackageRequirements
+
 import wx
 
 import gui.globalEvents as GE
@@ -9,9 +10,10 @@ from gui.contextMenu import ContextMenuSingle
 from service.character import Character
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class ChangeAffectingSkills(ContextMenuSingle):
-
     visibilitySetting = 'changeAffectingSkills'
 
     def __init__(self):
@@ -19,9 +21,9 @@ class ChangeAffectingSkills(ContextMenuSingle):
 
     def display(self, callingWindow, srcContext, mainItem):
         if srcContext not in (
-            "fittingModule", "fittingCharge",
-            "fittingShip", "droneItem",
-            "fighterItem"
+                "fittingModule", "fittingCharge",
+                "fittingShip", "droneItem",
+                "fighterItem"
         ):
             return False
 
@@ -68,7 +70,7 @@ class ChangeAffectingSkills(ContextMenuSingle):
         return len(self.skills) > 0
 
     def getText(self, callingWindow, itmContext, mainItem):
-        return "Change %s Skills" % itmContext
+        return _t("Change %s Skills") % itmContext
 
     def addSkill(self, rootMenu, skill, i):
         if i < 0:

--- a/gui/builtinContextMenus/targetProfile/adder.py
+++ b/gui/builtinContextMenus/targetProfile/adder.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from itertools import chain
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.mainFrame
@@ -9,6 +8,10 @@ from eos.saveddata.targetProfile import TargetProfile
 from gui.contextMenu import ContextMenuUnconditional
 from gui.utils.sorter import smartSort
 from service.targetProfile import TargetProfile as svc_TargetProfile
+
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 
 class TargetProfileAdder(ContextMenuUnconditional):

--- a/gui/builtinContextMenus/targetProfile/editor.py
+++ b/gui/builtinContextMenus/targetProfile/editor.py
@@ -1,7 +1,11 @@
+import wx
+
 import gui.mainFrame
 from graphs.wrapper import TargetWrapper
 from gui.contextMenu import ContextMenuSingle
 from gui.targetProfileEditor import TargetProfileEditor
+
+_t = wx.GetTranslation
 
 
 class TargetProfileEditorMenu(ContextMenuSingle):

--- a/gui/builtinContextMenus/targetProfile/switcher.py
+++ b/gui/builtinContextMenus/targetProfile/switcher.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from itertools import chain
 
-# noinspection PyPackageRequirements
 import wx
 
 import gui.globalEvents as GE
@@ -10,6 +9,10 @@ from gui.contextMenu import ContextMenuUnconditional
 from gui.utils.sorter import smartSort
 from service.fit import Fit
 from service.targetProfile import TargetProfile as svc_TargetProfile
+
+# noinspection PyPackageRequirements
+
+_t = wx.GetTranslation
 
 
 class TargetProfileSwitcher(ContextMenuUnconditional):

--- a/gui/builtinItemStatsViews/itemAffectedBy.py
+++ b/gui/builtinItemStatsViews/itemAffectedBy.py
@@ -17,6 +17,8 @@ import gui.mainFrame
 from gui.contextMenu import ContextMenu
 from gui.bitmap_loader import BitmapLoader
 
+_t = wx.GetTranslation
+
 
 def formatOperator(operator, stackingGroup, preResAmount, postResAmount):
     opMap = {
@@ -24,7 +26,8 @@ def formatOperator(operator, stackingGroup, preResAmount, postResAmount):
         Operator.PREINCREASE: '+',
         Operator.MULTIPLY: '*',
         Operator.POSTINCREASE: '+',
-        Operator.FORCE: '\u2263'}
+        Operator.FORCE: '\u2263'
+    }
     prefix = ''
     if stackingGroup is not None:
         prefix += 's'
@@ -61,17 +64,17 @@ class ItemAffectedBy(wx.Panel):
         mainSizer.Add(self.m_staticline, 0, wx.EXPAND)
         bSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.toggleExpandBtn = wx.ToggleButton(self, wx.ID_ANY, "Expand All", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.toggleExpandBtn = wx.ToggleButton(self, wx.ID_ANY, _t("Expand All"), wx.DefaultPosition, wx.DefaultSize, 0)
         bSizer.Add(self.toggleExpandBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self.toggleNameBtn = wx.ToggleButton(self, wx.ID_ANY, "Toggle Names", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.toggleNameBtn = wx.ToggleButton(self, wx.ID_ANY, _t("Toggle Names"), wx.DefaultPosition, wx.DefaultSize, 0)
         bSizer.Add(self.toggleNameBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, "Toggle View", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, _t("Toggle View"), wx.DefaultPosition, wx.DefaultSize, 0)
         bSizer.Add(self.toggleViewBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
         if stuff is not None:
-            self.refreshBtn = wx.Button(self, wx.ID_ANY, "Refresh", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
+            self.refreshBtn = wx.Button(self, wx.ID_ANY, _t("Refresh"), wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
             bSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL)
             self.refreshBtn.Bind(wx.EVT_BUTTON, self.RefreshTree)
 

--- a/gui/builtinItemStatsViews/itemAttributes.py
+++ b/gui/builtinItemStatsViews/itemAttributes.py
@@ -115,7 +115,7 @@ class ItemParams(wx.Panel):
 
         with wx.FileDialog(
                 self, _t("Save CSV file"), "", exportFileName,
-                _t("CSV files (*.csv)|*.csv"), wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
+                _t("CSV files") + " (*.csv)|*.csv", wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
         ) as dlg:
 
             if dlg.ShowModal() == wx.ID_CANCEL:

--- a/gui/builtinItemStatsViews/itemAttributes.py
+++ b/gui/builtinItemStatsViews/itemAttributes.py
@@ -11,6 +11,8 @@ from enum import IntEnum
 from gui.builtinItemStatsViews.attributeGrouping import *
 from service.const import GuiAttrGroup
 
+_t = wx.GetTranslation
+
 
 class AttributeView(IntEnum):
     NORMAL = 1
@@ -25,7 +27,8 @@ class ItemParams(wx.Panel):
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.paramList = wx.lib.agw.hypertreelist.HyperTreeList(self, wx.ID_ANY, agwStyle=wx.TR_HIDE_ROOT | wx.TR_NO_LINES | wx.TR_FULL_ROW_HIGHLIGHT | wx.TR_HAS_BUTTONS)
+        self.paramList = wx.lib.agw.hypertreelist.HyperTreeList(self, wx.ID_ANY,
+                                                                agwStyle=wx.TR_HIDE_ROOT | wx.TR_NO_LINES | wx.TR_FULL_ROW_HIGHLIGHT | wx.TR_HAS_BUTTONS)
         self.paramList.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW))
 
         mainSizer.Add(self.paramList, 1, wx.ALL | wx.EXPAND, 0)
@@ -38,25 +41,25 @@ class ItemParams(wx.Panel):
         self.attrValues = {}
         self._fetchValues()
 
-        self.paramList.AddColumn("Attribute")
-        self.paramList.AddColumn("Current Value")
+        self.paramList.AddColumn(_t("Attribute"))
+        self.paramList.AddColumn(_t("Current Value"))
         if self.stuff is not None:
-            self.paramList.AddColumn("Base Value")
+            self.paramList.AddColumn(_t("Base Value"))
 
         self.m_staticline = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
         mainSizer.Add(self.m_staticline, 0, wx.EXPAND)
         bSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, "View Raw Data", wx.DefaultPosition, wx.DefaultSize,
+        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, _t("View Raw Data"), wx.DefaultPosition, wx.DefaultSize,
                                              0)
         bSizer.Add(self.toggleViewBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self.exportStatsBtn = wx.ToggleButton(self, wx.ID_ANY, "Export Item Stats", wx.DefaultPosition, wx.DefaultSize,
+        self.exportStatsBtn = wx.ToggleButton(self, wx.ID_ANY, _t("Export Item Stats"), wx.DefaultPosition, wx.DefaultSize,
                                               0)
         bSizer.Add(self.exportStatsBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
         if stuff is not None:
-            self.refreshBtn = wx.Button(self, wx.ID_ANY, "Refresh", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
+            self.refreshBtn = wx.Button(self, wx.ID_ANY, _t("Refresh"), wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT)
             bSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL)
             self.refreshBtn.Bind(wx.EVT_BUTTON, self.RefreshValues)
 
@@ -111,8 +114,8 @@ class ItemParams(wx.Panel):
         exportFileName = self.item.name + " (" + str(self.item.ID) + ").csv"
 
         with wx.FileDialog(
-            self, "Save CSV file", "", exportFileName,
-            "CSV files (*.csv)|*.csv", wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
+                self, _t("Save CSV file"), "", exportFileName,
+                _t("CSV files (*.csv)|*.csv"), wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
         ) as dlg:
 
             if dlg.ShowModal() == wx.ID_CANCEL:
@@ -266,7 +269,7 @@ class ItemParams(wx.Panel):
         for i in range(self.paramList.GetMainWindow().GetColumnCount()):
             self.paramList.SetColumnWidth(i, wx.LIST_AUTOSIZE)
 
-    def GetData(self, attr, displayOveride = None):
+    def GetData(self, attr, displayOveride=None):
         info = self.attrInfo.get(attr)
         att = self.attrValues[attr]
 
@@ -285,7 +288,8 @@ class ItemParams(wx.Panel):
         val = getattr(att, "value", None)
         value = val if val is not None else att
 
-        if self.toggleView == AttributeView.NORMAL and ((attr not in GroupedAttributes and not (value or valueDefault)) or info is None or not info.published or attr in RequiredSkillAttrs):
+        if self.toggleView == AttributeView.NORMAL and (
+                (attr not in GroupedAttributes and not (value or valueDefault)) or info is None or not info.published or attr in RequiredSkillAttrs):
             return None
 
         if info and info.displayName and self.toggleView == AttributeView.NORMAL:

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -7,6 +7,8 @@ from service.market import Market
 from service.attribute import Attribute
 from gui.utils.numberFormatter import formatAmount
 
+_t = wx.GetTranslation
+
 
 def defaultSort(item):
     return (item.metaLevel or 0, item.name)
@@ -70,11 +72,11 @@ class ItemCompare(wx.Panel):
         self.totalAttrsLabel = wx.StaticText(self, wx.ID_ANY, " ", wx.DefaultPosition, wx.DefaultSize, 0)
         bSizer.Add(self.totalAttrsLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT)
 
-        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, "Toggle view mode", wx.DefaultPosition,
+        self.toggleViewBtn = wx.ToggleButton(self, wx.ID_ANY, _t("Toggle view mode"), wx.DefaultPosition,
                                              wx.DefaultSize, 0)
         bSizer.Add(self.toggleViewBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self.refreshBtn = wx.Button(self, wx.ID_ANY, "Refresh", wx.DefaultPosition, wx.DefaultSize,
+        self.refreshBtn = wx.Button(self, wx.ID_ANY, _t("Refresh"), wx.DefaultPosition, wx.DefaultSize,
                                     wx.BU_EXACTFIT)
         bSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL)
         self.refreshBtn.Bind(wx.EVT_BUTTON, self.RefreshValues)
@@ -142,7 +144,7 @@ class ItemCompare(wx.Panel):
 
             self.items = sorted(self.items, key=func, reverse=self.sortReverse)
 
-        self.paramList.InsertColumn(0, "Item")
+        self.paramList.InsertColumn(0, _t("Item"))
         self.paramList.SetColumnWidth(0, 200)
 
         for i, attr in enumerate(self.attrs.keys()):
@@ -150,7 +152,7 @@ class ItemCompare(wx.Panel):
             self.paramList.InsertColumn(i + 1, name)
             self.paramList.SetColumnWidth(i + 1, 120)
 
-        self.paramList.InsertColumn(len(self.attrs) + 1, "Price")
+        self.paramList.InsertColumn(len(self.attrs) + 1, _t("Price"))
         self.paramList.SetColumnWidth(len(self.attrs) + 1, 60)
 
         for item in self.items:
@@ -189,16 +191,16 @@ class ItemCompare(wx.Panel):
             return "%s (%d)" % (attribute.name.capitalize(), value)
 
         trans = {
-            "Inverse Absolute Percent" : (lambda: (1 - value) * 100, unitName),
+            "Inverse Absolute Percent": (lambda: (1 - value) * 100, unitName),
             "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
-            "Modifier Percent"         : (lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
-            "Volume"                   : (lambda: value, "m\u00B3"),
-            "Sizeclass"                : (lambda: value, ""),
-            "Absolute Percent"         : (lambda: (value * 100), unitName),
-            "Milliseconds"             : (lambda: value / 1000.0, unitName),
-            "typeID"                   : (itemIDCallback, ""),
-            "groupID"                  : (groupIDCallback, ""),
-            "attributeID"              : (attributeIDCallback, "")
+            "Modifier Percent": (lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
+            "Volume": (lambda: value, "m\u00B3"),
+            "Sizeclass": (lambda: value, ""),
+            "Absolute Percent": (lambda: (value * 100), unitName),
+            "Milliseconds": (lambda: value / 1000.0, unitName),
+            "typeID": (itemIDCallback, ""),
+            "groupID": (groupIDCallback, ""),
+            "attributeID": (attributeIDCallback, "")
         }
 
         override = trans.get(unitDisplayName)

--- a/gui/builtinItemStatsViews/itemDependants.py
+++ b/gui/builtinItemStatsViews/itemDependants.py
@@ -3,6 +3,8 @@ import wx
 
 from gui.bitmap_loader import BitmapLoader
 
+_t = wx.GetTranslation
+
 
 class ItemDependents(wx.Panel):
     def __init__(self, parent, stuff, item):
@@ -41,7 +43,7 @@ class ItemDependents(wx.Panel):
             items = levelToItems[x]
             items.sort(key=lambda x: x.name)
 
-            child = self.reqTree.AppendItem(parent, "Level {}".format(self.romanNb[int(x)]), sbIconId)
+            child = self.reqTree.AppendItem(parent, _t("Level {}").format(self.romanNb[int(x)]), sbIconId)
             for item in items:
 
                 if item.iconID:

--- a/gui/builtinItemStatsViews/itemDescription.py
+++ b/gui/builtinItemStatsViews/itemDescription.py
@@ -4,6 +4,8 @@ import wx
 import wx.html
 import re
 
+_t = wx.GetTranslation
+
 
 class ItemDescription(wx.Panel):
     def __init__(self, parent, stuff, item):
@@ -24,9 +26,9 @@ class ItemDescription(wx.Panel):
         # Strip URLs
         desc = re.sub("<( *)a(.*?)>(?P<inside>.*?)<( *)/( *)a( *)>", "\g<inside>", desc)
         desc = "<body style='background-color: {}; color: {}'>{}</body>".format(
-            bgcolor.GetAsString(wx.C2S_CSS_SYNTAX),
-            fgcolor.GetAsString(wx.C2S_CSS_SYNTAX),
-            desc
+                bgcolor.GetAsString(wx.C2S_CSS_SYNTAX),
+                fgcolor.GetAsString(wx.C2S_CSS_SYNTAX),
+                desc
         )
 
         self.description.SetPage(desc)
@@ -38,7 +40,7 @@ class ItemDescription(wx.Panel):
         self.description.Bind(wx.EVT_KEY_UP, self.onKeyUp)
 
         self.popupMenu = wx.Menu()
-        copyItem = wx.MenuItem(self.popupMenu, 1, 'Copy')
+        copyItem = wx.MenuItem(self.popupMenu, 1, _t('Copy'))
         self.popupMenu.Append(copyItem)
         self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
 

--- a/gui/builtinItemStatsViews/itemEffects.py
+++ b/gui/builtinItemStatsViews/itemEffects.py
@@ -7,6 +7,7 @@ import wx
 
 from .helpers import AutoListCtrl
 
+_t = wx.GetTranslation
 
 class ItemEffects(wx.Panel):
     def __init__(self, parent, stuff, item):
@@ -26,12 +27,12 @@ class ItemEffects(wx.Panel):
 
     def PopulateList(self):
 
-        self.effectList.InsertColumn(0, "Name")
-        self.effectList.InsertColumn(1, "Active")
-        self.effectList.InsertColumn(2, "Type")
+        self.effectList.InsertColumn(0, _t("Name"))
+        self.effectList.InsertColumn(1, _t("Active"))
+        self.effectList.InsertColumn(2, _t("Type"))
         if config.debug:
-            self.effectList.InsertColumn(3, "Run Time")
-            self.effectList.InsertColumn(4, "ID")
+            self.effectList.InsertColumn(3, _t("Run Time"))
+            self.effectList.InsertColumn(4, _t("ID"))
 
         # self.effectList.SetColumnWidth(0,385)
 
@@ -52,9 +53,9 @@ class ItemEffects(wx.Panel):
 
             if effects[name].isImplemented:
                 if effects[name].activeByDefault:
-                    activeByDefault = "Yes"
+                    activeByDefault = _t("Yes")
                 else:
-                    activeByDefault = "No"
+                    activeByDefault = _t("No")
             else:
                 activeByDefault = ""
 

--- a/gui/builtinItemStatsViews/itemMutator.py
+++ b/gui/builtinItemStatsViews/itemMutator.py
@@ -14,7 +14,7 @@ from .itemAttributes import ItemParams
 
 
 pyfalog = Logger(__name__)
-
+_t = wx.GetTranslation
 
 class ItemMutatorPanel(wx.Panel):
 
@@ -48,13 +48,13 @@ class ItemMutatorPanel(wx.Panel):
 
         mainSizer.Add(wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL), 0, wx.EXPAND, 0)
         footerSizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.refreshBtn = wx.Button(self, wx.ID_ANY, "Reset defaults", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.refreshBtn = wx.Button(self, wx.ID_ANY, _t("Reset defaults"), wx.DefaultPosition, wx.DefaultSize, 0)
         footerSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         self.refreshBtn.Bind(wx.EVT_BUTTON, self.mutaList.resetMutatedValues)
-        self.randomBtn = wx.Button(self, wx.ID_ANY, "Random stats", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.randomBtn = wx.Button(self, wx.ID_ANY, _t("Random stats"), wx.DefaultPosition, wx.DefaultSize, 0)
         footerSizer.Add(self.randomBtn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         self.randomBtn.Bind(wx.EVT_BUTTON, self.mutaList.randomMutatedValues)
-        self.revertBtn = wx.Button(self, wx.ID_ANY, "Revert changes", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.revertBtn = wx.Button(self, wx.ID_ANY, _t("Revert changes"), wx.DefaultPosition, wx.DefaultSize, 0)
         footerSizer.Add(self.revertBtn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         self.revertBtn.Bind(wx.EVT_BUTTON, self.mutaList.revertChanges)
         mainSizer.Add(footerSizer, 0, wx.ALL | wx.EXPAND, 5)

--- a/gui/builtinItemStatsViews/itemProperties.py
+++ b/gui/builtinItemStatsViews/itemProperties.py
@@ -2,7 +2,7 @@
 import wx
 
 from .helpers import AutoListCtrl
-
+_t = wx.GetTranslation
 
 class ItemProperties(wx.Panel):
     def __init__(self, parent, stuff, item, context=None):
@@ -53,8 +53,8 @@ class ItemProperties(wx.Panel):
             return
 
     def PopulateList(self):
-        self.paramList.InsertColumn(0, "Attribute")
-        self.paramList.InsertColumn(1, "Current Value")
+        self.paramList.InsertColumn(0, _t("Attribute"))
+        self.paramList.InsertColumn(1, _t("Current Value"))
         self.paramList.SetColumnWidth(0, 110)
         self.paramList.SetColumnWidth(1, 1500)
         self.paramList.setResizeColumn(0)
@@ -95,5 +95,5 @@ class ItemProperties(wx.Panel):
 
         self.paramList.SortItems(lambda id1, id2: (idNameMap[id1] > idNameMap[id2]) - (idNameMap[id1] < idNameMap[id2]))
         self.paramList.RefreshRows()
-        self.totalAttrsLabel.SetLabel("%d attributes. " % idCount)
+        self.totalAttrsLabel.SetLabel(_t("%d attribute.", "%d attributes.", idCount) % idCount)
         self.Layout()

--- a/gui/builtinItemStatsViews/itemTraits.py
+++ b/gui/builtinItemStatsViews/itemTraits.py
@@ -3,6 +3,8 @@ import wx
 # noinspection PyPackageRequirements
 import wx.html
 
+_t = wx.GetTranslation
+
 
 class ItemTraits(wx.Panel):
     def __init__(self, parent, stuff, item):
@@ -20,7 +22,7 @@ class ItemTraits(wx.Panel):
         self.Layout()
 
         self.popupMenu = wx.Menu()
-        copyItem = wx.MenuItem(self.popupMenu, 1, 'Copy')
+        copyItem = wx.MenuItem(self.popupMenu, 1, _t('Copy'))
         self.popupMenu.Append(copyItem)
         self.popupMenu.Bind(wx.EVT_MENU, self.menuClickHandler, copyItem)
 

--- a/gui/builtinPreferenceViews/pyfaContextMenuPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaContextMenuPreferences.py
@@ -9,9 +9,9 @@ _t = wx.GetTranslation
 
 
 class PFContextMenuPref(PreferenceView):
-    title = _t("Context Menus")
 
     def populatePanel(self, panel):
+        self.title = _t("Context Menus")
         self.settings = ContextMenuSettings.getInstance()
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
 

--- a/gui/builtinPreferenceViews/pyfaContextMenuPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaContextMenuPreferences.py
@@ -5,9 +5,11 @@ from gui.bitmap_loader import BitmapLoader
 import gui.mainFrame
 from service.settings import ContextMenuSettings
 
+_t = wx.GetTranslation
+
 
 class PFContextMenuPref(PreferenceView):
-    title = "Context Menus"
+    title = _t("Context Menus")
 
     def populatePanel(self, panel):
         self.settings = ContextMenuSettings.getInstance()
@@ -22,11 +24,11 @@ class PFContextMenuPref(PreferenceView):
         mainSizer.Add(self.stTitle, 0, wx.EXPAND | wx.ALL, 5)
 
         self.stSubTitle = wx.StaticText(
-            panel, wx.ID_ANY,
-            'Disabling context menus can improve responsiveness.\n'
-            'You can hold {} key + right-click to show all menu items regardless of these settings.'.format(
-                'Command' if 'wxMac' in wx.PlatformInfo else 'Control'),
-            wx.DefaultPosition, wx.DefaultSize, 0)
+                panel, wx.ID_ANY,
+                _t('Disabling context menus can improve responsiveness.\n'
+                   'You can hold {} key + right-click to show all menu items regardless of these settings.').format(
+                        'Command' if 'wxMac' in wx.PlatformInfo else 'Control'),
+                wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSubTitle.Wrap(-1)
         mainSizer.Add(self.stSubTitle, 0, wx.ALL, 5)
 
@@ -36,17 +38,17 @@ class PFContextMenuPref(PreferenceView):
 
         rbSizerRow1 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbBox1 = wx.RadioBox(panel, -1, "Set as Damage Pattern", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox1 = wx.RadioBox(panel, -1, _t("Set as Damage Pattern"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox1.SetSelection(self.settings.get('ammoPattern'))
         rbSizerRow1.Add(self.rbBox1, 1, wx.ALL, 5)
         self.rbBox1.Bind(wx.EVT_RADIOBOX, self.OnSetting1Change)
 
-        self.rbBox2 = wx.RadioBox(panel, -1, "Change Skills", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox2 = wx.RadioBox(panel, -1, _t("Change Skills"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox2.SetSelection(self.settings.get('changeAffectingSkills'))
         rbSizerRow1.Add(self.rbBox2, 1, wx.ALL, 5)
         self.rbBox2.Bind(wx.EVT_RADIOBOX, self.OnSetting2Change)
 
-        self.rbBox3 = wx.RadioBox(panel, -1, "Variations", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox3 = wx.RadioBox(panel, -1, _t("Variations"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox3.SetSelection(self.settings.get('metaSwap'))
         rbSizerRow1.Add(self.rbBox3, 1, wx.ALL, 5)
         self.rbBox3.Bind(wx.EVT_RADIOBOX, self.OnSetting3Change)
@@ -56,12 +58,12 @@ class PFContextMenuPref(PreferenceView):
         # Row 2
         rbSizerRow2 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbBox4 = wx.RadioBox(panel, -1, "Project onto Fit", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox4 = wx.RadioBox(panel, -1, _t("Project onto Fit"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox4.SetSelection(self.settings.get('project'))
         rbSizerRow2.Add(self.rbBox4, 1, wx.ALL, 5)
         self.rbBox4.Bind(wx.EVT_RADIOBOX, self.OnSetting4Change)
 
-        self.rbBox5 = wx.RadioBox(panel, -1, "Fill with module", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox5 = wx.RadioBox(panel, -1, _t("Fill with module"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox5.SetSelection(self.settings.get('moduleFill'))
         rbSizerRow2.Add(self.rbBox5, 1, wx.ALL, 5)
         self.rbBox5.Bind(wx.EVT_RADIOBOX, self.OnSetting5Change)
@@ -71,12 +73,13 @@ class PFContextMenuPref(PreferenceView):
         # Row 3
         rbSizerRow3 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbBox6 = wx.RadioBox(panel, -1, "Spoolup", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox6 = wx.RadioBox(panel, -1, _t("Spoolup"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1, wx.RA_SPECIFY_COLS)
         self.rbBox6.SetSelection(self.settings.get('spoolup'))
         rbSizerRow3.Add(self.rbBox6, 1, wx.ALL, 5)
         self.rbBox6.Bind(wx.EVT_RADIOBOX, self.OnSetting6Change)
 
-        self.rbBox7 = wx.RadioBox(panel, -1, "Additions Panel Copy/Paste", wx.DefaultPosition, wx.DefaultSize, ['Disabled', 'Enabled'], 1, wx.RA_SPECIFY_COLS)
+        self.rbBox7 = wx.RadioBox(panel, -1, _t("Additions Panel Copy/Paste"), wx.DefaultPosition, wx.DefaultSize, [_t('Disabled'), _t('Enabled')], 1,
+                                  wx.RA_SPECIFY_COLS)
         self.rbBox7.SetSelection(self.settings.get('additionsCopyPaste'))
         rbSizerRow3.Add(self.rbBox7, 1, wx.ALL, 5)
         self.rbBox7.Bind(wx.EVT_RADIOBOX, self.OnSetting7Change)

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -6,9 +6,11 @@ from gui.bitmap_loader import BitmapLoader
 from gui.preferenceView import PreferenceView
 from gui.utils import helpers_wxPython as wxHelpers
 
+_t = wx.GetTranslation
+
 
 class PFGeneralPref(PreferenceView):
-    title = "Database"
+    title = _t("Database")
 
     def populatePanel(self, panel):
         self.dirtySettings = False
@@ -20,7 +22,7 @@ class PFGeneralPref(PreferenceView):
         self.stTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
         mainSizer.Add(self.stTitle, 0, wx.EXPAND | wx.ALL, 5)
 
-        self.stSubTitle = wx.StaticText(panel, wx.ID_ANY, "(Cannot be changed while pyfa is running. Set via command line switches.)",
+        self.stSubTitle = wx.StaticText(panel, wx.ID_ANY, _t("(Cannot be changed while pyfa is running. Set via command line switches.)"),
                                         wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSubTitle.Wrap(-1)
         mainSizer.Add(self.stSubTitle, 0, wx.ALL, 3)
@@ -29,11 +31,11 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         # Save in Root
-        self.cbsaveInRoot = wx.CheckBox(panel, wx.ID_ANY, "Using Executable Path for Saved Fit Database and Settings", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbsaveInRoot = wx.CheckBox(panel, wx.ID_ANY, _t("Using Executable Path for Saved Fit Database and Settings"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbsaveInRoot, 0, wx.ALL | wx.EXPAND, 5)
 
         # Database path
-        self.stSetUserPath = wx.StaticText(panel, wx.ID_ANY, "pyfa User Path:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stSetUserPath = wx.StaticText(panel, wx.ID_ANY, _t("pyfa User Path:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSetUserPath.Wrap(-1)
         mainSizer.Add(self.stSetUserPath, 0, wx.ALL, 5)
         self.inputUserPath = wx.TextCtrl(panel, wx.ID_ANY, config.savePath, wx.DefaultPosition, wx.DefaultSize, 0)
@@ -42,7 +44,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.inputUserPath, 0, wx.ALL | wx.EXPAND, 5)
 
         # Save DB
-        self.stFitDB = wx.StaticText(panel, wx.ID_ANY, "Fitting Database:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stFitDB = wx.StaticText(panel, wx.ID_ANY, _t("Fitting Database:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stFitDB.Wrap(-1)
         mainSizer.Add(self.stFitDB, 0, wx.ALL, 5)
 
@@ -52,7 +54,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.inputFitDB, 0, wx.ALL | wx.EXPAND, 5)
 
         # Game Data DB
-        self.stGameDB = wx.StaticText(panel, wx.ID_ANY, "Game Database:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stGameDB = wx.StaticText(panel, wx.ID_ANY, _t("Game Database:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stGameDB.Wrap(-1)
         mainSizer.Add(self.stGameDB, 0, wx.ALL, 5)
 
@@ -74,37 +76,36 @@ class PFGeneralPref(PreferenceView):
         btnSizer = wx.BoxSizer(wx.VERTICAL)
         btnSizer.AddStretchSpacer()
 
-        self.btnDeleteDamagePatterns = wx.Button(panel, wx.ID_ANY, "Delete All Damage Pattern Profiles", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnDeleteDamagePatterns = wx.Button(panel, wx.ID_ANY, _t("Delete All Damage Pattern Profiles"), wx.DefaultPosition, wx.DefaultSize, 0)
         btnSizer.Add(self.btnDeleteDamagePatterns, 0, wx.ALL, 5)
         self.btnDeleteDamagePatterns.Bind(wx.EVT_BUTTON, self.DeleteDamagePatterns)
 
-        self.btnDeleteTargetProfiles = wx.Button(panel, wx.ID_ANY, "Delete All Target Profiles", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnDeleteTargetProfiles = wx.Button(panel, wx.ID_ANY, _t("Delete All Target Profiles"), wx.DefaultPosition, wx.DefaultSize, 0)
         btnSizer.Add(self.btnDeleteTargetProfiles, 0, wx.ALL, 5)
         self.btnDeleteTargetProfiles.Bind(wx.EVT_BUTTON, self.DeleteTargetProfiles)
 
-        self.btnPrices = wx.Button(panel, wx.ID_ANY, "Delete All Prices", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnPrices = wx.Button(panel, wx.ID_ANY, _t("Delete All Prices"), wx.DefaultPosition, wx.DefaultSize, 0)
         btnSizer.Add(self.btnPrices, 0, wx.ALL, 5)
         self.btnPrices.Bind(wx.EVT_BUTTON, self.DeletePrices)
 
         mainSizer.Add(btnSizer, 0, wx.EXPAND, 5)
 
-
         panel.SetSizer(mainSizer)
         panel.Layout()
 
     def DeleteDamagePatterns(self, event):
-        question = "This is a destructive action that will delete all damage pattern profiles.\nAre you sure you want to do this?"
-        if wxHelpers.YesNoDialog(question, "Confirm"):
+        question = _t("This is a destructive action that will delete all damage pattern profiles.\nAre you sure you want to do this?")
+        if wxHelpers.YesNoDialog(question, _t("Confirm")):
             clearDamagePatterns()
 
     def DeleteTargetProfiles(self, event):
-        question = "This is a destructive action that will delete all target profiles.\nAre you sure you want to do this?"
-        if wxHelpers.YesNoDialog(question, "Confirm"):
+        question = _t("This is a destructive action that will delete all target profiles.\nAre you sure you want to do this?")
+        if wxHelpers.YesNoDialog(question, _t("Confirm")):
             clearTargetProfiles()
 
     def DeletePrices(self, event):
-        question = "This is a destructive action that will delete all cached prices out of the database.\nAre you sure you want to do this?"
-        if wxHelpers.YesNoDialog(question, "Confirm"):
+        question = _t("This is a destructive action that will delete all cached prices out of the database.\nAre you sure you want to do this?")
+        if wxHelpers.YesNoDialog(question, _t("Confirm")):
             clearPrices()
 
     def onCBsaveInRoot(self, event):

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -10,9 +10,9 @@ _t = wx.GetTranslation
 
 
 class PFGeneralPref(PreferenceView):
-    title = _t("Database")
 
     def populatePanel(self, panel):
+        self.title = _t("Database")
         self.dirtySettings = False
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -12,9 +12,11 @@ from wx.lib.intctrl import IntCtrl
 
 logger = logging.getLogger(__name__)
 
+_t = wx.GetTranslation
+
 
 class PFFittingEnginePref(PreferenceView):
-    title = "Fitting Engine"
+    title = _t("Fitting Engine")
 
     def __init__(self):
         self.dirtySettings = False
@@ -40,41 +42,40 @@ class PFFittingEnginePref(PreferenceView):
         self.m_staticline1 = wx.StaticLine(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        self.cbGlobalForceReload = wx.CheckBox(panel, wx.ID_ANY, "Factor in reload time when calculating capacitor usage, damage, and tank.",
+        self.cbGlobalForceReload = wx.CheckBox(panel, wx.ID_ANY, _t("Factor in reload time when calculating capacitor usage, damage, and tank."),
                                                wx.DefaultPosition, wx.DefaultSize, 0)
 
         mainSizer.Add(self.cbGlobalForceReload, 0, wx.ALL | wx.EXPAND, 5)
 
         self.cbStrictSkillLevels = wx.CheckBox(panel, wx.ID_ANY,
-                                               "Enforce strict skill level requirements",
+                                               _t("Enforce strict skill level requirements"),
                                                wx.DefaultPosition, wx.DefaultSize, 0)
         self.cbStrictSkillLevels.SetCursor(helpCursor)
         self.cbStrictSkillLevels.SetToolTip(wx.ToolTip(
-            'When enabled, skills will check their dependencies\' requirements when their levels change and reset ' +
-            'skills that no longer meet the requirement.\neg: Setting Drones from level V to IV will reset the Heavy ' +
-            'Drone Operation skill, as that requires Drones V'))
+                _t('When enabled, skills will check their dependencies\' requirements when their levels change and reset '
+                   'skills that no longer meet the requirement.\neg: Setting Drones from level V to IV will reset the Heavy '
+                   'Drone Operation skill, as that requires Drones V')))
 
         mainSizer.Add(self.cbStrictSkillLevels, 0, wx.ALL | wx.EXPAND, 5)
 
         self.cbUniversalAdaptiveArmorHardener = wx.CheckBox(panel, wx.ID_ANY,
-                                                            "When damage profile is Uniform, set Reactive Armor " +
-                                                            "Hardener to match (old behavior).",
+                                                            _t("When damage profile is Uniform, set Reactive Armor "
+                                                               "Hardener to match (old behavior)."),
                                                             wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbUniversalAdaptiveArmorHardener, 0, wx.ALL | wx.EXPAND, 5)
 
-
         spoolup_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.spool_up_label = wx.StaticText(panel, wx.ID_ANY, "Global Default Spoolup Percentage:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.spool_up_label = wx.StaticText(panel, wx.ID_ANY, _t("Global Default Spoolup Percentage:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.spool_up_label.Wrap(-1)
         self.spool_up_label.SetCursor(helpCursor)
         self.spool_up_label.SetToolTip(
-            wx.ToolTip('The amount of spoolup to use by default on module which support it. Can be changed on a per-module basis'))
+                wx.ToolTip(_t('The amount of spoolup to use by default on module which support it. Can be changed on a per-module basis')))
 
         spoolup_sizer.Add(self.spool_up_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         self.spoolup_value = IntCtrl(panel, min=0, max=100, limited=True)
-        spoolup_sizer.Add(self.spoolup_value , 0, wx.ALL, 5)
+        spoolup_sizer.Add(self.spoolup_value, 0, wx.ALL, 5)
 
         mainSizer.Add(spoolup_sizer, 0, wx.ALL | wx.EXPAND, 0)
 

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -16,8 +16,6 @@ _t = wx.GetTranslation
 
 
 class PFFittingEnginePref(PreferenceView):
-    title = _t("Fitting Engine")
-
     def __init__(self):
         self.dirtySettings = False
 
@@ -26,6 +24,7 @@ class PFFittingEnginePref(PreferenceView):
 
     # noinspection PyAttributeOutsideInit
     def populatePanel(self, panel):
+        self.title = _t("Fitting Engine")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)

--- a/gui/builtinPreferenceViews/pyfaEsiPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEsiPreferences.py
@@ -6,12 +6,12 @@ from gui.bitmap_loader import BitmapLoader
 from gui.preferenceView import PreferenceView
 from service.settings import EsiSettings
 
-
 # noinspection PyPackageRequirements
+_t = wx.GetTranslation
 
 
 class PFEsiPref(PreferenceView):
-    title = "EVE SSO"
+    title = _t("EVE SSO")
 
     def populatePanel(self, panel):
 
@@ -30,25 +30,25 @@ class PFEsiPref(PreferenceView):
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         self.stInfo = wx.StaticText(panel, wx.ID_ANY,
-                                    "Please see the pyfa wiki on GitHub for information regarding these options.",
+                                    _t("Please see the pyfa wiki on GitHub for information regarding these options."),
                                     wx.DefaultPosition, wx.DefaultSize, 0)
         self.stInfo.Wrap(dlgWidth - 50)
         mainSizer.Add(self.stInfo, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         rbSizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.rbMode = wx.RadioBox(panel, -1, "Login Authentication Method", wx.DefaultPosition, wx.DefaultSize,
-                                  ['Local Server', 'Manual'], 1, wx.RA_SPECIFY_COLS)
-        self.rbMode.SetItemToolTip(0, "This options starts a local webserver that the web application will call back to"
-                                      " with information about the character login.")
-        self.rbMode.SetItemToolTip(1, "This option prompts users to copy and paste information from the web application "
-                                      "to allow for character login. Use this if having issues with the local server.")
+        self.rbMode = wx.RadioBox(panel, -1, _t("Login Authentication Method"), wx.DefaultPosition, wx.DefaultSize,
+                                  [_t('Local Server'), _t('Manual')], 1, wx.RA_SPECIFY_COLS)
+        self.rbMode.SetItemToolTip(0, _t("This options starts a local webserver that the web application will call back to"
+                                         " with information about the character login."))
+        self.rbMode.SetItemToolTip(1, _t("This option prompts users to copy and paste information from the web application "
+                                         "to allow for character login. Use this if having issues with the local server."))
 
-        self.rbSsoMode = wx.RadioBox(panel, -1, "SSO Mode", wx.DefaultPosition, wx.DefaultSize,
-                                     ['pyfa.io', 'Custom application'], 1, wx.RA_SPECIFY_COLS)
-        self.rbSsoMode.SetItemToolTip(0, "This options routes SSO Logins through pyfa.io, allowing you to easily login "
-                                         "without any configuration. When in doubt, use this option.")
-        self.rbSsoMode.SetItemToolTip(1, "This option goes through EVE SSO directly, but requires more configuration. Use "
-                                         "this is pyfa.io is blocked for some reason, or if you do not wish to route data throguh pyfa.io.")
+        self.rbSsoMode = wx.RadioBox(panel, -1, _t("SSO Mode"), wx.DefaultPosition, wx.DefaultSize,
+                                     [_t('pyfa.io'), _t('Custom application')], 1, wx.RA_SPECIFY_COLS)
+        self.rbSsoMode.SetItemToolTip(0, _t("This options routes SSO Logins through pyfa.io, allowing you to easily login "
+                                            "without any configuration. When in doubt, use this option."))
+        self.rbSsoMode.SetItemToolTip(1, _t("This option goes through EVE SSO directly, but requires more configuration. Use "
+                                            "this is pyfa.io is blocked for some reason, or if you do not wish to route data throguh pyfa.io."))
 
         self.rbMode.SetSelection(self.settings.get('loginMode'))
         self.rbSsoMode.SetSelection(self.settings.get('ssoMode'))
@@ -61,7 +61,7 @@ class PFEsiPref(PreferenceView):
 
         mainSizer.Add(rbSizer, 1, wx.ALL | wx.EXPAND, 0)
 
-        detailsTitle = wx.StaticText(panel, wx.ID_ANY, "Custom Application", wx.DefaultPosition, wx.DefaultSize, 0)
+        detailsTitle = wx.StaticText(panel, wx.ID_ANY, _t("Custom Application"), wx.DefaultPosition, wx.DefaultSize, 0)
         detailsTitle.Wrap(-1)
         detailsTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
 
@@ -74,7 +74,7 @@ class PFEsiPref(PreferenceView):
         fgAddrSizer.SetFlexibleDirection(wx.BOTH)
         fgAddrSizer.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
 
-        self.stSetID = wx.StaticText(panel, wx.ID_ANY, "Client ID:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stSetID = wx.StaticText(panel, wx.ID_ANY, _t("Client ID:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSetID.Wrap(-1)
         fgAddrSizer.Add(self.stSetID, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
@@ -83,7 +83,7 @@ class PFEsiPref(PreferenceView):
 
         fgAddrSizer.Add(self.inputClientID, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
 
-        self.stSetSecret = wx.StaticText(panel, wx.ID_ANY, "Client Secret:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stSetSecret = wx.StaticText(panel, wx.ID_ANY, _t("Client Secret:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSetSecret.Wrap(-1)
 
         fgAddrSizer.Add(self.stSetSecret, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)

--- a/gui/builtinPreferenceViews/pyfaEsiPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEsiPreferences.py
@@ -11,10 +11,9 @@ _t = wx.GetTranslation
 
 
 class PFEsiPref(PreferenceView):
-    title = _t("EVE SSO")
 
     def populatePanel(self, panel):
-
+        self.title = _t("EVE SSO")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.settings = EsiSettings.getInstance()
         self.dirtySettings = False

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -8,10 +8,11 @@ from gui.preferenceView import PreferenceView
 from service.fit import Fit
 from service.settings import SettingsProvider, LocaleSettings
 
+_t = wx.GetTranslation
+
 
 class PFGeneralPref(PreferenceView):
-
-    title = "General"
+    title = _t("General")
 
     def populatePanel(self, panel):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
@@ -31,68 +32,68 @@ class PFGeneralPref(PreferenceView):
         self.m_staticline1 = wx.StaticLine(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        self.cbGlobalChar = wx.CheckBox(panel, wx.ID_ANY, "Use global character", wx.DefaultPosition, wx.DefaultSize,
+        self.cbGlobalChar = wx.CheckBox(panel, wx.ID_ANY, _t("Use global character"), wx.DefaultPosition, wx.DefaultSize,
                                         0)
         mainSizer.Add(self.cbGlobalChar, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbDefaultCharImplants = wx.CheckBox(panel, wx.ID_ANY, "Use character implants by default for new fits",
+        self.cbDefaultCharImplants = wx.CheckBox(panel, wx.ID_ANY, _t("Use character implants by default for new fits"),
                                                  wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbDefaultCharImplants, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbGlobalDmgPattern = wx.CheckBox(panel, wx.ID_ANY, "Use global damage pattern", wx.DefaultPosition,
+        self.cbGlobalDmgPattern = wx.CheckBox(panel, wx.ID_ANY, _t("Use global damage pattern"), wx.DefaultPosition,
                                               wx.DefaultSize, 0)
         mainSizer.Add(self.cbGlobalDmgPattern, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbCompactSkills = wx.CheckBox(panel, wx.ID_ANY, "Compact skills needed tooltip", wx.DefaultPosition,
+        self.cbCompactSkills = wx.CheckBox(panel, wx.ID_ANY, _t("Compact skills needed tooltip"), wx.DefaultPosition,
                                            wx.DefaultSize, 0)
         mainSizer.Add(self.cbCompactSkills, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbFitColorSlots = wx.CheckBox(panel, wx.ID_ANY, "Color fitting view by slot", wx.DefaultPosition,
+        self.cbFitColorSlots = wx.CheckBox(panel, wx.ID_ANY, _t("Color fitting view by slot"), wx.DefaultPosition,
                                            wx.DefaultSize, 0)
         mainSizer.Add(self.cbFitColorSlots, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbReopenFits = wx.CheckBox(panel, wx.ID_ANY, "Reopen previous fits on startup", wx.DefaultPosition,
+        self.cbReopenFits = wx.CheckBox(panel, wx.ID_ANY, _t("Reopen previous fits on startup"), wx.DefaultPosition,
                                         wx.DefaultSize, 0)
         mainSizer.Add(self.cbReopenFits, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbRackSlots = wx.CheckBox(panel, wx.ID_ANY, "Separate Racks", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbRackSlots = wx.CheckBox(panel, wx.ID_ANY, _t("Separate Racks"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbRackSlots, 0, wx.ALL | wx.EXPAND, 5)
 
         labelSizer = wx.BoxSizer(wx.VERTICAL)
-        self.cbRackLabels = wx.CheckBox(panel, wx.ID_ANY, "Show Rack Labels", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbRackLabels = wx.CheckBox(panel, wx.ID_ANY, _t("Show Rack Labels"), wx.DefaultPosition, wx.DefaultSize, 0)
         labelSizer.Add(self.cbRackLabels, 0, wx.ALL | wx.EXPAND, 5)
         mainSizer.Add(labelSizer, 0, wx.LEFT | wx.EXPAND, 30)
 
-        self.cbShowTooltip = wx.CheckBox(panel, wx.ID_ANY, "Show fitting tab tooltips", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbShowTooltip = wx.CheckBox(panel, wx.ID_ANY, _t("Show fitting tab tooltips"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbShowTooltip, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbGaugeAnimation = wx.CheckBox(panel, wx.ID_ANY, "Animate gauges", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbGaugeAnimation = wx.CheckBox(panel, wx.ID_ANY, _t("Animate gauges"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbGaugeAnimation, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbOpenFitInNew = wx.CheckBox(panel, wx.ID_ANY, "Open fittings in a new page by default",
+        self.cbOpenFitInNew = wx.CheckBox(panel, wx.ID_ANY, _t("Open fittings in a new page by default"),
                                           wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbOpenFitInNew, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbShowShipBrowserTooltip = wx.CheckBox(panel, wx.ID_ANY, "Show ship browser tooltip",
-                                          wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbShowShipBrowserTooltip = wx.CheckBox(panel, wx.ID_ANY, _t("Show ship browser tooltip"),
+                                                    wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbShowShipBrowserTooltip, 0, wx.ALL | wx.EXPAND, 5)
 
-
-        self.cbReloadAll = wx.CheckBox(panel, wx.ID_ANY, "Change charge in all modules of the same type",
+        self.cbReloadAll = wx.CheckBox(panel, wx.ID_ANY, _t("Change charge in all modules of the same type"),
                                        wx.DefaultPosition, wx.DefaultSize, 0)
         if "wxGTK" not in wx.PlatformInfo:
             self.cbReloadAll.SetCursor(helpCursor)
         self.cbReloadAll.SetToolTip(wx.ToolTip(
-            'When disabled, reloads charges just in selected modules. Action can be reversed by holding Ctrl or Alt key while changing charge.'))
+                _t('When disabled, reloads charges just in selected modules. Action can be reversed by holding Ctrl or Alt key while changing charge.')))
         mainSizer.Add(self.cbReloadAll, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.rbAddLabels = wx.RadioBox(panel, -1, "Extra info in Additions panel tab names", wx.DefaultPosition, wx.DefaultSize, ["None", "Quantity of active items", "Quantity of all items"], 1, wx.RA_SPECIFY_COLS)
+        self.rbAddLabels = wx.RadioBox(panel, -1, _t("Extra info in Additions panel tab names"), wx.DefaultPosition, wx.DefaultSize,
+                                       [_t("None"), _t("Quantity of active items"), _t("Quantity of all items")], 1, wx.RA_SPECIFY_COLS)
         mainSizer.Add(self.rbAddLabels, 0, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 10)
         self.rbAddLabels.Bind(wx.EVT_RADIOBOX, self.OnAddLabelsChange)
 
         langSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.stLangLabel = wx.StaticText(panel, wx.ID_ANY, "Language (restart required): ", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stLangLabel = wx.StaticText(panel, wx.ID_ANY, _t("Language (restart required): "), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stLangLabel.Wrap(-1)
         langSizer.Add(self.stLangLabel, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -12,9 +12,9 @@ _t = wx.GetTranslation
 
 
 class PFGeneralPref(PreferenceView):
-    title = _t("General")
 
     def populatePanel(self, panel):
+        self.title = _t("General")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.dirtySettings = False
         self.openFitsSettings = SettingsProvider.getInstance().getSettings("pyfaPrevOpenFits",
@@ -93,7 +93,7 @@ class PFGeneralPref(PreferenceView):
 
         langSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.stLangLabel = wx.StaticText(panel, wx.ID_ANY, _t("Language (restart required): "), wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stLangLabel = wx.StaticText(panel, wx.ID_ANY, _t("Language (restart required):"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stLangLabel.Wrap(-1)
         langSizer.Add(self.stLangLabel, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 

--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -10,14 +10,16 @@ import gui.mainFrame
 from service.settings import HTMLExportSettings
 import wx.lib.agw.hyperlink
 
+_t = wx.GetTranslation
+
 
 class PFHTMLExportPref(PreferenceView):
-    title = "HTML Export"
-    desc = ("HTML Export (File > Export HTML) allows you to export your entire fitting "
-            "database into an HTML file at the specified location. This file can be "
-            "used to easily open your fits in a web-based fitting program")
-    desc4 = ("Export Fittings in a minimal HTML Version, just containing the fittings links "
-             "without any visual styling")
+    title = _t("HTML Export")
+    desc = _t("HTML Export (File > Export HTML) allows you to export your entire fitting "
+              "database into an HTML file at the specified location. This file can be "
+              "used to easily open your fits in a web-based fitting program")
+    desc4 = _t("Export Fittings in a minimal HTML Version, just containing the fittings links "
+               "without any visual styling")
 
     def populatePanel(self, panel):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
@@ -39,16 +41,16 @@ class PFHTMLExportPref(PreferenceView):
         mainSizer.Add(self.stDesc, 0, wx.ALL, 5)
 
         self.PathLinkCtrl = wx.lib.agw.hyperlink.HyperLinkCtrl(panel, wx.ID_ANY, self.HTMLExportSettings.getPath(),
-                                             wx.DefaultPosition, wx.DefaultSize,
-                                             URL='file:///{}'.format(self.HTMLExportSettings.getPath()),)
+                                                               wx.DefaultPosition, wx.DefaultSize,
+                                                               URL='file:///{}'.format(self.HTMLExportSettings.getPath()), )
         mainSizer.Add(self.PathLinkCtrl, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.fileSelectDialog = wx.FileDialog(None, "Save Fitting As...",
-                                              wildcard="EVE IGB HTML fitting file (*.html)|*.html", style=wx.FD_SAVE)
+        self.fileSelectDialog = wx.FileDialog(None, _t("Save Fitting As..."),
+                                              wildcard=_t("EVE IGB HTML fitting file (*.html)|*.html"), style=wx.FD_SAVE)
         self.fileSelectDialog.SetPath(self.HTMLExportSettings.getPath())
         self.fileSelectDialog.SetFilename(os.path.basename(self.HTMLExportSettings.getPath()))
 
-        self.fileSelectButton = wx.Button(panel, -1, "Set export destination", pos=(0, 0))
+        self.fileSelectButton = wx.Button(panel, -1, _t("Set export destination"), pos=(0, 0))
         self.fileSelectButton.Bind(wx.EVT_BUTTON, self.selectHTMLExportFilePath)
         mainSizer.Add(self.fileSelectButton, 0, wx.ALL, 5)
 
@@ -56,7 +58,7 @@ class PFHTMLExportPref(PreferenceView):
         self.stDesc4.Wrap(dlgWidth - 50)
         mainSizer.Add(self.stDesc4, 0, wx.ALL, 5)
 
-        self.exportMinimal = wx.CheckBox(panel, wx.ID_ANY, "Enable minimal format", wx.DefaultPosition,
+        self.exportMinimal = wx.CheckBox(panel, wx.ID_ANY, _t("Enable minimal format"), wx.DefaultPosition,
                                          wx.DefaultSize, 0)
         self.exportMinimal.SetValue(self.HTMLExportSettings.getMinimalEnabled())
         self.exportMinimal.Bind(wx.EVT_CHECKBOX, self.OnMinimalEnabledChange)

--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -46,7 +46,7 @@ class PFHTMLExportPref(PreferenceView):
         mainSizer.Add(self.PathLinkCtrl, 0, wx.ALL | wx.EXPAND, 5)
 
         self.fileSelectDialog = wx.FileDialog(None, _t("Save Fitting As..."),
-                                              wildcard=_t("EVE IGB HTML fitting file (*.html)|*.html"), style=wx.FD_SAVE)
+                                              wildcard=_t("EVE IGB HTML fitting file") + " (*.html)|*.html", style=wx.FD_SAVE)
         self.fileSelectDialog.SetPath(self.HTMLExportSettings.getPath())
         self.fileSelectDialog.SetFilename(os.path.basename(self.HTMLExportSettings.getPath()))
 

--- a/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py
@@ -14,14 +14,14 @@ _t = wx.GetTranslation
 
 
 class PFHTMLExportPref(PreferenceView):
-    title = _t("HTML Export")
-    desc = _t("HTML Export (File > Export HTML) allows you to export your entire fitting "
-              "database into an HTML file at the specified location. This file can be "
-              "used to easily open your fits in a web-based fitting program")
-    desc4 = _t("Export Fittings in a minimal HTML Version, just containing the fittings links "
-               "without any visual styling")
 
     def populatePanel(self, panel):
+        self.title = _t("HTML Export")
+        self.desc = _t("HTML Export (File > Export HTML) allows you to export your entire fitting "
+                       "database into an HTML file at the specified location. This file can be "
+                       "used to easily open your fits in a web-based fitting program")
+        self.desc4 = _t("Export Fittings in a minimal HTML Version, just containing the fittings links "
+                        "without any visual styling")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.HTMLExportSettings = HTMLExportSettings.getInstance()
         self.dirtySettings = False

--- a/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
@@ -14,9 +14,9 @@ def OnDumpLogs(event):
 
 
 class PFGeneralPref(PreferenceView):
-    title = _t("Logging")
 
     def populatePanel(self, panel):
+        self.title = _t("Logging")
         self.dirtySettings = False
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)

--- a/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
@@ -6,6 +6,7 @@ import config
 from logbook import Logger
 
 pyfalog = Logger(__name__)
+_t = wx.GetTranslation
 
 
 def OnDumpLogs(event):
@@ -13,7 +14,7 @@ def OnDumpLogs(event):
 
 
 class PFGeneralPref(PreferenceView):
-    title = "Logging"
+    title = _t("Logging")
 
     def populatePanel(self, panel):
         self.dirtySettings = False
@@ -25,7 +26,7 @@ class PFGeneralPref(PreferenceView):
         self.stTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
         mainSizer.Add(self.stTitle, 0, wx.EXPAND | wx.ALL, 5)
 
-        self.stSubTitle = wx.StaticText(panel, wx.ID_ANY, "(Cannot be changed while pyfa is running. Set via command line switches.)",
+        self.stSubTitle = wx.StaticText(panel, wx.ID_ANY, _t("(Cannot be changed while pyfa is running. Set via command line switches.)"),
                                         wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSubTitle.Wrap(-1)
         mainSizer.Add(self.stSubTitle, 0, wx.ALL, 3)
@@ -34,7 +35,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         # Database path
-        self.stLogPath = wx.StaticText(panel, wx.ID_ANY, "Log file location:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stLogPath = wx.StaticText(panel, wx.ID_ANY, _t("Log file location:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stLogPath.Wrap(-1)
         mainSizer.Add(self.stLogPath, 0, wx.ALL, 5)
         self.inputLogPath = wx.TextCtrl(panel, wx.ID_ANY, config.logPath, wx.DefaultPosition, wx.DefaultSize, 0)
@@ -43,8 +44,8 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.inputLogPath, 0, wx.ALL | wx.EXPAND, 5)
 
         import requests
-        self.certPath = wx.StaticText(panel, wx.ID_ANY, "Cert Path:", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.certPath .Wrap(-1)
+        self.certPath = wx.StaticText(panel, wx.ID_ANY, _t("Cert Path:"), wx.DefaultPosition, wx.DefaultSize, 0)
+        self.certPath.Wrap(-1)
         mainSizer.Add(self.certPath, 0, wx.ALL, 5)
         self.certPathCtrl = wx.TextCtrl(panel, wx.ID_ANY, requests.certs.where(), wx.DefaultPosition, wx.DefaultSize, 0)
         self.certPathCtrl.SetEditable(False)
@@ -52,13 +53,13 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.certPathCtrl, 0, wx.ALL | wx.EXPAND, 5)
 
         # Debug Logging
-        self.cbdebugLogging = wx.CheckBox(panel, wx.ID_ANY, "Debug Logging Enabled", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbdebugLogging = wx.CheckBox(panel, wx.ID_ANY, _t("Debug Logging Enabled"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbdebugLogging, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.stDumpLogs = wx.StaticText(panel, wx.ID_ANY, "Pressing this button will cause all logs in memory to write to the log file:",
+        self.stDumpLogs = wx.StaticText(panel, wx.ID_ANY, _t("Pressing this button will cause all logs in memory to write to the log file:"),
                                         wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.stDumpLogs, 0, wx.ALL, 5)
-        self.btnDumpLogs = wx.Button(panel, wx.ID_ANY, "Dump All Logs", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnDumpLogs = wx.Button(panel, wx.ID_ANY, _t("Dump All Logs"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.btnDumpLogs.Bind(wx.EVT_BUTTON, OnDumpLogs)
         mainSizer.Add(self.btnDumpLogs, 0, wx.ALIGN_LEFT, 5)
 

--- a/gui/builtinPreferenceViews/pyfaMarketPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaMarketPreferences.py
@@ -11,9 +11,11 @@ from service.settings import MarketPriceSettings
 from service.fit import Fit
 from service.price import Price
 
+_t = wx.GetTranslation
+
 
 class PFMarketPref(PreferenceView):
-    title = "Market & Prices"
+    title = _t("Market & Prices")
 
     def __init__(self):
         self.priceSettings = MarketPriceSettings.getInstance()
@@ -25,7 +27,7 @@ class PFMarketPref(PreferenceView):
         helpCursor = wx.Cursor(wx.CURSOR_QUESTION_ARROW)
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.stTitle = wx.StaticText(panel, wx.ID_ANY, "Market && Prices", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stTitle = wx.StaticText(panel, wx.ID_ANY, _t("Market && Prices"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stTitle.Wrap(-1)
         self.stTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
         mainSizer.Add(self.stTitle, 0, wx.EXPAND | wx.ALL, 5)
@@ -34,11 +36,12 @@ class PFMarketPref(PreferenceView):
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         delayTimer = wx.BoxSizer(wx.HORIZONTAL)
-        self.stMarketDelay = wx.StaticText(panel, wx.ID_ANY, "Market Search Delay (ms):", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stMarketDelay = wx.StaticText(panel, wx.ID_ANY, _t("Market Search Delay (ms):"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stMarketDelay.Wrap(-1)
         if "wxGTK" not in wx.PlatformInfo:
             self.stMarketDelay.SetCursor(helpCursor)
-        self.stMarketDelay.SetToolTip(wx.ToolTip('The delay between a keystroke and the market search. Can help reduce lag when typing fast in the market search box.'))
+        self.stMarketDelay.SetToolTip(wx.ToolTip(
+                _t('The delay between a keystroke and the market search. Can help reduce lag when typing fast in the market search box.')))
         delayTimer.Add(self.stMarketDelay, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.intDelay = IntCtrl(panel, max=1000, limited=True)
         delayTimer.Add(self.intDelay, 0, wx.ALL, 5)
@@ -46,20 +49,20 @@ class PFMarketPref(PreferenceView):
         self.intDelay.SetValue(self.sFit.serviceFittingOptions["marketSearchDelay"])
         self.intDelay.Bind(wx.lib.intctrl.EVT_INT, self.onMarketDelayChange)
 
-        self.cbMarketShortcuts = wx.CheckBox(panel, wx.ID_ANY, "Show market shortcuts", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbMarketShortcuts = wx.CheckBox(panel, wx.ID_ANY, _t("Show market shortcuts"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbMarketShortcuts, 0, wx.EXPAND | wx.TOP | wx.RIGHT, 10)
         self.cbMarketShortcuts.SetValue(self.sFit.serviceFittingOptions["showMarketShortcuts"] or False)
         self.cbMarketShortcuts.Bind(wx.EVT_CHECKBOX, self.onCBShowShortcuts)
 
         priceSizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.stDefaultSystem = wx.StaticText(panel, wx.ID_ANY, "Default Market Prices:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stDefaultSystem = wx.StaticText(panel, wx.ID_ANY, _t("Default Market Prices:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stDefaultSystem.Wrap(-1)
         priceSizer.Add(self.stDefaultSystem, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         if "wxGTK" not in wx.PlatformInfo:
             self.stDefaultSystem.SetCursor(helpCursor)
         self.stDefaultSystem.SetToolTip(wx.ToolTip(
-            'The source you choose will be tried first, but subsequent sources will be used if the preferred source fails. '
-            'The system you choose will also be tried first, and if no data is available, global price will be used.'))
+                _t('The source you choose will be tried first, but subsequent sources will be used if the preferred source fails. '
+                   'The system you choose will also be tried first, and if no data is available, global price will be used.')))
         self.chPriceSource = wx.Choice(panel, choices=sorted(Price.sources.keys()))
         self.chPriceSystem = wx.Choice(panel, choices=list(Price.systemsList.keys()))
         priceSizer.Add(self.chPriceSource, 1, wx.ALL | wx.EXPAND, 5)
@@ -70,37 +73,45 @@ class PFMarketPref(PreferenceView):
         self.chPriceSystem.SetStringSelection(self.sFit.serviceFittingOptions["priceSystem"])
         self.chPriceSystem.Bind(wx.EVT_CHOICE, self.onPriceSelection)
 
-        self.tbTotalPriceBox = wx.StaticBoxSizer(wx.VERTICAL, panel, "Total Price Includes")
-        self.tbTotalPriceDrones = wx.CheckBox(panel, -1, "Drones", wx.DefaultPosition, wx.DefaultSize, 1)
+        self.tbTotalPriceBox = wx.StaticBoxSizer(wx.VERTICAL, panel, _t("Total Price Includes"))
+        self.tbTotalPriceDrones = wx.CheckBox(panel, -1, _t("Drones"), wx.DefaultPosition, wx.DefaultSize, 1)
         self.tbTotalPriceDrones.SetValue(self.priceSettings.get("drones"))
         self.tbTotalPriceDrones.Bind(wx.EVT_CHECKBOX, self.OnTotalPriceDroneChange)
         self.tbTotalPriceBox.Add(self.tbTotalPriceDrones, 0, wx.LEFT | wx.RIGHT | wx.TOP, 5)
-        self.tbTotalPriceCargo = wx.CheckBox(panel, -1, "Cargo", wx.DefaultPosition, wx.DefaultSize, 1)
+        self.tbTotalPriceCargo = wx.CheckBox(panel, -1, _t("Cargo"), wx.DefaultPosition, wx.DefaultSize, 1)
         self.tbTotalPriceCargo.SetValue(self.priceSettings.get("cargo"))
         self.tbTotalPriceCargo.Bind(wx.EVT_CHECKBOX, self.OnTotalPriceCargoChange)
         self.tbTotalPriceBox.Add(self.tbTotalPriceCargo, 0, wx.LEFT | wx.RIGHT, 5)
-        self.tbTotalPriceCharacter = wx.CheckBox(panel, -1, "Implants && Boosters", wx.DefaultPosition, wx.DefaultSize, 1)
+        self.tbTotalPriceCharacter = wx.CheckBox(panel, -1, _t("Implants && Boosters"), wx.DefaultPosition, wx.DefaultSize, 1)
         self.tbTotalPriceCharacter.SetValue(self.priceSettings.get("character"))
         self.tbTotalPriceCharacter.Bind(wx.EVT_CHECKBOX, self.OnTotalPriceCharacterChange)
         self.tbTotalPriceBox.Add(self.tbTotalPriceCharacter, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
         mainSizer.Add(self.tbTotalPriceBox, 0, wx.EXPAND | wx.TOP | wx.RIGHT, 10)
 
-        self.rbMarketSearch = wx.RadioBox(panel, -1, "Market Search && Recent Items", wx.DefaultPosition, wx.DefaultSize, ["No changes to meta buttons", "Enable all meta buttons for a duration of search / recents", "Enable all meta buttons"], 1, wx.RA_SPECIFY_COLS)
+        self.rbMarketSearch = wx.RadioBox(panel, -1, _t("Market Search && Recent Items"), wx.DefaultPosition, wx.DefaultSize,
+                                          [_t("No changes to meta buttons"), _t("Enable all meta buttons for a duration of search / recents"),
+                                           _t("Enable all meta buttons")], 1,
+                                          wx.RA_SPECIFY_COLS)
         self.rbMarketSearch.SetSelection(self.priceSettings.get('marketMGSearchMode'))
         mainSizer.Add(self.rbMarketSearch, 0, wx.RIGHT | wx.TOP | wx.EXPAND, 10)
         self.rbMarketSearch.Bind(wx.EVT_RADIOBOX, self.OnMarketSearchChange)
 
-        self.rbMarketEmpty = wx.RadioBox(panel, -1, "Market Group Selection", wx.DefaultPosition, wx.DefaultSize, ["No changes to meta buttons", "Enable all meta buttons"], 1, wx.RA_SPECIFY_COLS)
+        self.rbMarketEmpty = wx.RadioBox(panel, -1, _t("Market Group Selection"), wx.DefaultPosition, wx.DefaultSize,
+                                         [_t("No changes to meta buttons"), _t("Enable all meta buttons")], 1, wx.RA_SPECIFY_COLS)
         self.rbMarketEmpty.SetSelection(self.priceSettings.get('marketMGMarketSelectMode'))
         mainSizer.Add(self.rbMarketEmpty, 0, wx.EXPAND | wx.TOP | wx.RIGHT, 10)
         self.rbMarketEmpty.Bind(wx.EVT_RADIOBOX, self.OnMarketGroupSelectionChange)
 
-        self.rbMarketEmpty = wx.RadioBox(panel, -1, "Empty Market View", wx.DefaultPosition, wx.DefaultSize, ["No changes to meta buttons", "Enable leftmost available meta button", "Enable all available meta buttons"], 1, wx.RA_SPECIFY_COLS)
+        self.rbMarketEmpty = wx.RadioBox(panel, -1, _t("Empty Market View"), wx.DefaultPosition, wx.DefaultSize,
+                                         [_t("No changes to meta buttons"), _t("Enable leftmost available meta button"), _t("Enable all available meta buttons")], 1,
+                                         wx.RA_SPECIFY_COLS)
         self.rbMarketEmpty.SetSelection(self.priceSettings.get('marketMGEmptyMode'))
         mainSizer.Add(self.rbMarketEmpty, 0, wx.EXPAND | wx.TOP | wx.RIGHT, 10)
         self.rbMarketEmpty.Bind(wx.EVT_RADIOBOX, self.OnMarketEmptyChange)
 
-        self.rbMarketJump = wx.RadioBox(panel, -1, "Item Market Group Jump", wx.DefaultPosition, wx.DefaultSize, ["No changes to meta buttons", "Enable item's meta button", "Enable item's meta button, disable others", "Enable all meta buttons"], 1, wx.RA_SPECIFY_COLS)
+        self.rbMarketJump = wx.RadioBox(panel, -1, _t("Item Market Group Jump"), wx.DefaultPosition, wx.DefaultSize,
+                                        [_t("No changes to meta buttons"), _t("Enable item's meta button"), _t("Enable item's meta button, disable others"),
+                                         _t("Enable all meta buttons")], 1, wx.RA_SPECIFY_COLS)
         self.rbMarketJump.SetSelection(self.priceSettings.get('marketMGJumpMode'))
         mainSizer.Add(self.rbMarketJump, 0, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 10)
         self.rbMarketJump.Bind(wx.EVT_RADIOBOX, self.OnMarketJumpChange)

--- a/gui/builtinPreferenceViews/pyfaMarketPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaMarketPreferences.py
@@ -15,12 +15,12 @@ _t = wx.GetTranslation
 
 
 class PFMarketPref(PreferenceView):
-    title = _t("Market & Prices")
 
     def __init__(self):
         self.priceSettings = MarketPriceSettings.getInstance()
 
     def populatePanel(self, panel):
+        self.title = _t("Market & Prices")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.sFit = Fit.getInstance()
 

--- a/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
@@ -8,9 +8,11 @@ import gui.mainFrame
 from service.settings import NetworkSettings
 from service.network import Network
 
+_t = wx.GetTranslation
+
 
 class PFNetworkPref(PreferenceView):
-    title = "Network"
+    title = _t("Network")
 
     def populatePanel(self, panel):
 
@@ -29,23 +31,23 @@ class PFNetworkPref(PreferenceView):
         self.m_staticline1 = wx.StaticLine(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
         mainSizer.Add(self.m_staticline1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        self.cbEnableNetwork = wx.CheckBox(panel, wx.ID_ANY, "Enable Network", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbEnableNetwork = wx.CheckBox(panel, wx.ID_ANY, _t("Enable Network"), wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbEnableNetwork, 0, wx.ALL | wx.EXPAND, 5)
 
         subSizer = wx.BoxSizer(wx.VERTICAL)
-        self.cbEve = wx.CheckBox(panel, wx.ID_ANY, "EVE Servers (API && CREST import)", wx.DefaultPosition,
+        self.cbEve = wx.CheckBox(panel, wx.ID_ANY, _t("EVE Servers (API && CREST import)"), wx.DefaultPosition,
                                  wx.DefaultSize, 0)
         subSizer.Add(self.cbEve, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbPricing = wx.CheckBox(panel, wx.ID_ANY, "Pricing updates", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbPricing = wx.CheckBox(panel, wx.ID_ANY, _t("Pricing updates"), wx.DefaultPosition, wx.DefaultSize, 0)
         subSizer.Add(self.cbPricing, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.cbPyfaUpdate = wx.CheckBox(panel, wx.ID_ANY, "Pyfa Update checks", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.cbPyfaUpdate = wx.CheckBox(panel, wx.ID_ANY, _t("Pyfa Update checks"), wx.DefaultPosition, wx.DefaultSize, 0)
         subSizer.Add(self.cbPyfaUpdate, 0, wx.ALL | wx.EXPAND, 5)
 
         mainSizer.Add(subSizer, 0, wx.LEFT | wx.EXPAND, 30)
 
-        proxyTitle = wx.StaticText(panel, wx.ID_ANY, "Proxy settings", wx.DefaultPosition, wx.DefaultSize, 0)
+        proxyTitle = wx.StaticText(panel, wx.ID_ANY, _t("Proxy settings"), wx.DefaultPosition, wx.DefaultSize, 0)
         proxyTitle.Wrap(-1)
         proxyTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
 
@@ -79,11 +81,11 @@ class PFNetworkPref(PreferenceView):
 
         ptypeSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.stPType = wx.StaticText(panel, wx.ID_ANY, "Mode:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPType = wx.StaticText(panel, wx.ID_ANY, _t("Mode:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPType.Wrap(-1)
         ptypeSizer.Add(self.stPType, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
-        self.chProxyTypeChoices = ["No proxy", "Auto-detected proxy settings", "Manual proxy settings"]
+        self.chProxyTypeChoices = [_t("No proxy"), _t("Auto-detected proxy settings"), _t("Manual proxy settings")]
         self.chProxyType = wx.Choice(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, self.chProxyTypeChoices, 0)
 
         self.chProxyType.SetSelection(self.nMode)
@@ -97,7 +99,7 @@ class PFNetworkPref(PreferenceView):
         fgAddrSizer.SetFlexibleDirection(wx.BOTH)
         fgAddrSizer.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
 
-        self.stPSetAddr = wx.StaticText(panel, wx.ID_ANY, "Addr:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetAddr = wx.StaticText(panel, wx.ID_ANY, _t("Addr:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetAddr.Wrap(-1)
         fgAddrSizer.Add(self.stPSetAddr, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
@@ -105,7 +107,7 @@ class PFNetworkPref(PreferenceView):
 
         fgAddrSizer.Add(self.editProxySettingsAddr, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
 
-        self.stPSetPort = wx.StaticText(panel, wx.ID_ANY, "Port:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetPort = wx.StaticText(panel, wx.ID_ANY, _t("Port:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetPort.Wrap(-1)
 
         fgAddrSizer.Add(self.stPSetPort, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
@@ -117,14 +119,14 @@ class PFNetworkPref(PreferenceView):
         mainSizer.Add(fgAddrSizer, 0, wx.EXPAND, 5)
 
         # proxy auth information: login and pass
-        self.stPSetLogin = wx.StaticText(panel, wx.ID_ANY, "Username:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stPSetLogin = wx.StaticText(panel, wx.ID_ANY, _t("Username:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetLogin.Wrap(-1)
         self.editProxySettingsLogin = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[0], wx.DefaultPosition, wx.DefaultSize,
-                                                   0)
-        self.stPSetPassword = wx.StaticText(panel, wx.ID_ANY, "Password:", wx.DefaultPosition, wx.DefaultSize, 0)
+                                                  0)
+        self.stPSetPassword = wx.StaticText(panel, wx.ID_ANY, _t("Password:"), wx.DefaultPosition, wx.DefaultSize, 0)
         self.stPSetPassword.Wrap(-1)
         self.editProxySettingsPassword = wx.TextCtrl(panel, wx.ID_ANY, self.nAuth[1], wx.DefaultPosition,
-                                                      wx.DefaultSize, wx.TE_PASSWORD)
+                                                     wx.DefaultSize, wx.TE_PASSWORD)
         pAuthSizer = wx.BoxSizer(wx.HORIZONTAL)
         pAuthSizer.Add(self.stPSetLogin, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         pAuthSizer.Add(self.editProxySettingsLogin, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
@@ -132,15 +134,15 @@ class PFNetworkPref(PreferenceView):
         pAuthSizer.Add(self.editProxySettingsPassword, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         mainSizer.Add(pAuthSizer, 0, wx.EXPAND, 5)
 
-        self.stPSAutoDetected = wx.StaticText(panel, wx.ID_ANY, "Auto-detected: ", wx.DefaultPosition, wx.DefaultSize,
-                                               0)
+        self.stPSAutoDetected = wx.StaticText(panel, wx.ID_ANY, _t("Auto-detected: "), wx.DefaultPosition, wx.DefaultSize,
+                                              0)
         self.stPSAutoDetected.Wrap(-1)
         mainSizer.Add(self.stPSAutoDetected, 0, wx.ALL, 5)
 
         btnSizer = wx.BoxSizer(wx.HORIZONTAL)
         btnSizer.AddStretchSpacer()
 
-        self.btnApply = wx.Button(panel, wx.ID_ANY, "Apply Proxy Settings", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.btnApply = wx.Button(panel, wx.ID_ANY, _t("Apply Proxy Settings"), wx.DefaultPosition, wx.DefaultSize, 0)
 
         btnSizer.Add(self.btnApply, 0, wx.ALL, 5)
 
@@ -154,7 +156,7 @@ class PFNetworkPref(PreferenceView):
         else:
             txt = "None"
 
-        self.stPSAutoDetected.SetLabel("Auto-detected: " + txt)
+        self.stPSAutoDetected.SetLabel(_t("Auto-detected: ") + txt)
         self.stPSAutoDetected.Disable()
 
         self.chProxyType.Bind(wx.EVT_CHOICE, self.OnCHProxyTypeSelect)

--- a/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaNetworkPreferences.py
@@ -12,10 +12,9 @@ _t = wx.GetTranslation
 
 
 class PFNetworkPref(PreferenceView):
-    title = _t("Network")
 
     def populatePanel(self, panel):
-
+        self.title = _t("Network")
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.settings = NetworkSettings.getInstance()
         self.network = Network.getInstance()

--- a/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
@@ -5,9 +5,11 @@ from gui.preferenceView import PreferenceView
 from gui.bitmap_loader import BitmapLoader
 from service.settings import StatViewSettings
 
+_t = wx.GetTranslation
+
 
 class PFStatViewPref(PreferenceView):
-    title = "Statistics Panel"
+    title = _t("Statistics Panel")
 
     def __init__(self):
         self.dirtySettings = False
@@ -26,7 +28,7 @@ class PFStatViewPref(PreferenceView):
         mainSizer.Add(self.stTitle, 0, wx.EXPAND | wx.ALL, 5)
 
         self.stSubTitle = wx.StaticText(panel, wx.ID_ANY,
-                                        "Changes require restart of pyfa to take effect.",
+                                        _t("Changes require restart of pyfa to take effect."),
                                         wx.DefaultPosition, wx.DefaultSize, 0)
         self.stSubTitle.Wrap(-1)
         mainSizer.Add(self.stSubTitle, 0, wx.ALL, 3)
@@ -37,21 +39,24 @@ class PFStatViewPref(PreferenceView):
 
         rbSizerRow1 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbResources = wx.RadioBox(panel, -1, "Resources", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbResources = wx.RadioBox(panel, -1, _t("Resources"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1,
+                                       wx.RA_SPECIFY_COLS)
         # Disable minimal as we don't have a view for this yet
         self.rbResources.EnableItem(1, False)
         self.rbResources.SetSelection(self.settings.get('resources'))
         rbSizerRow1.Add(self.rbResources, 1, wx.TOP | wx.RIGHT, 5)
         self.rbResources.Bind(wx.EVT_RADIOBOX, self.OnResourcesChange)
 
-        self.rbResistances = wx.RadioBox(panel, -1, "Resistances", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbResistances = wx.RadioBox(panel, -1, _t("Resistances"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1,
+                                         wx.RA_SPECIFY_COLS)
         # Disable minimal as we don't have a view for this yet
         self.rbResistances.EnableItem(1, False)
         self.rbResistances.SetSelection(self.settings.get('resistances'))
         rbSizerRow1.Add(self.rbResistances, 1, wx.ALL, 5)
         self.rbResistances.Bind(wx.EVT_RADIOBOX, self.OnResistancesChange)
 
-        self.rbRecharge = wx.RadioBox(panel, -1, "Shield/Armor Tank", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbRecharge = wx.RadioBox(panel, -1, _t("Shield/Armor Tank"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1,
+                                      wx.RA_SPECIFY_COLS)
         # Disable minimal as we don't have a view for this yet
         self.rbRecharge.EnableItem(1, False)
         self.rbRecharge.SetSelection(self.settings.get('recharge'))
@@ -63,21 +68,23 @@ class PFStatViewPref(PreferenceView):
         # Row 2
         rbSizerRow2 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbFirepower = wx.RadioBox(panel, -1, "Firepower", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbFirepower = wx.RadioBox(panel, -1, _t("Firepower"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1,
+                                       wx.RA_SPECIFY_COLS)
         # Disable minimal as we don't have a view for this yet
         self.rbFirepower.EnableItem(1, False)
         self.rbFirepower.SetSelection(self.settings.get('firepower'))
         rbSizerRow2.Add(self.rbFirepower, 1, wx.TOP | wx.RIGHT, 5)
         self.rbFirepower.Bind(wx.EVT_RADIOBOX, self.OnFirepowerChange)
 
-        self.rbCapacitor = wx.RadioBox(panel, -1, "Capacitor", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbCapacitor = wx.RadioBox(panel, -1, _t("Capacitor"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1,
+                                       wx.RA_SPECIFY_COLS)
         # Disable minimal as we don't have a view for this yet
         self.rbCapacitor.EnableItem(1, False)
         self.rbCapacitor.SetSelection(self.settings.get('capacitor'))
         rbSizerRow2.Add(self.rbCapacitor, 1, wx.ALL, 5)
         self.rbCapacitor.Bind(wx.EVT_RADIOBOX, self.OnCapacitorChange)
 
-        self.rbMisc = wx.RadioBox(panel, -1, "Misc", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbMisc = wx.RadioBox(panel, -1, _t("Misc"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1, wx.RA_SPECIFY_COLS)
         # Disable full as we don't have a view for this yet
         self.rbMisc.EnableItem(2, False)
         self.rbMisc.SetSelection(self.settings.get('targetingMisc'))
@@ -89,12 +96,12 @@ class PFStatViewPref(PreferenceView):
         # Row 3
         rbSizerRow3 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbPrice = wx.RadioBox(panel, -1, "Price", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbPrice = wx.RadioBox(panel, -1, _t("Price"), wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
         self.rbPrice.SetSelection(self.settings.get('price'))
         rbSizerRow3.Add(self.rbPrice, 1, wx.TOP | wx.RIGHT, 5)
         self.rbPrice.Bind(wx.EVT_RADIOBOX, self.OnPriceChange)
 
-        self.rbOutgoing = wx.RadioBox(panel, -1, "Remote Reps", wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbOutgoing = wx.RadioBox(panel, -1, _t("Remote Reps"), wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
         self.rbOutgoing.SetSelection(self.settings.get('outgoing'))
         rbSizerRow3.Add(self.rbOutgoing, 1, wx.TOP | wx.RIGHT, 5)
         self.rbOutgoing.Bind(wx.EVT_RADIOBOX, self.OnOutgoingChange)

--- a/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaStatViewPreferences.py
@@ -9,7 +9,6 @@ _t = wx.GetTranslation
 
 
 class PFStatViewPref(PreferenceView):
-    title = _t("Statistics Panel")
 
     def __init__(self):
         self.dirtySettings = False
@@ -20,6 +19,7 @@ class PFStatViewPref(PreferenceView):
 
     # noinspection PyAttributeOutsideInit
     def populatePanel(self, panel):
+        self.title = _t("Statistics Panel")
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
         self.stTitle = wx.StaticText(panel, wx.ID_ANY, self.title, wx.DefaultPosition, wx.DefaultSize, 0)
@@ -96,12 +96,12 @@ class PFStatViewPref(PreferenceView):
         # Row 3
         rbSizerRow3 = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.rbPrice = wx.RadioBox(panel, -1, _t("Price"), wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbPrice = wx.RadioBox(panel, -1, _t("Price"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1, wx.RA_SPECIFY_COLS)
         self.rbPrice.SetSelection(self.settings.get('price'))
         rbSizerRow3.Add(self.rbPrice, 1, wx.TOP | wx.RIGHT, 5)
         self.rbPrice.Bind(wx.EVT_RADIOBOX, self.OnPriceChange)
 
-        self.rbOutgoing = wx.RadioBox(panel, -1, _t("Remote Reps"), wx.DefaultPosition, wx.DefaultSize, ['None', 'Minimal', 'Full'], 1, wx.RA_SPECIFY_COLS)
+        self.rbOutgoing = wx.RadioBox(panel, -1, _t("Remote Reps"), wx.DefaultPosition, wx.DefaultSize, [_t('None'), _t('Minimal'), _t('Full')], 1, wx.RA_SPECIFY_COLS)
         self.rbOutgoing.SetSelection(self.settings.get('outgoing'))
         rbSizerRow3.Add(self.rbOutgoing, 1, wx.TOP | wx.RIGHT, 5)
         self.rbOutgoing.Bind(wx.EVT_RADIOBOX, self.OnOutgoingChange)

--- a/gui/builtinPreferenceViews/pyfaUpdatePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaUpdatePreferences.py
@@ -9,13 +9,13 @@ _t = wx.GetTranslation
 
 
 class PFUpdatePref(PreferenceView):
-    title = _t("Updates")
-    desc = _t("Pyfa can automatically check and notify you of new releases. "
-              "This feature is toggled in the Network settings. "
-              "Here, you may allow pre-release notifications and view "
-              "suppressed release notifications, if any.")
 
     def populatePanel(self, panel):
+        self.title = _t("Updates")
+        self.desc = _t("Pyfa can automatically check and notify you of new releases. "
+                       "This feature is toggled in the Network settings. "
+                       "Here, you may allow pre-release notifications and view "
+                       "suppressed release notifications, if any.")
         self.UpdateSettings = UpdateSettings.getInstance()
         self.dirtySettings = False
 

--- a/gui/builtinPreferenceViews/pyfaUpdatePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaUpdatePreferences.py
@@ -5,13 +5,15 @@ from gui.preferenceView import PreferenceView
 from gui.bitmap_loader import BitmapLoader
 from service.settings import UpdateSettings
 
+_t = wx.GetTranslation
+
 
 class PFUpdatePref(PreferenceView):
-    title = "Updates"
-    desc = ("Pyfa can automatically check and notify you of new releases. "
-            "This feature is toggled in the Network settings. "
-            "Here, you may allow pre-release notifications and view "
-            "suppressed release notifications, if any.")
+    title = _t("Updates")
+    desc = _t("Pyfa can automatically check and notify you of new releases. "
+              "This feature is toggled in the Network settings. "
+              "Here, you may allow pre-release notifications and view "
+              "suppressed release notifications, if any.")
 
     def populatePanel(self, panel):
         self.UpdateSettings = UpdateSettings.getInstance()
@@ -33,7 +35,7 @@ class PFUpdatePref(PreferenceView):
         self.stDesc.Wrap(dlgWidth - 50)
         mainSizer.Add(self.stDesc, 0, wx.ALL, 5)
 
-        self.suppressPrerelease = wx.CheckBox(panel, wx.ID_ANY, "Allow pre-release notifications", wx.DefaultPosition,
+        self.suppressPrerelease = wx.CheckBox(panel, wx.ID_ANY, _t("Allow pre-release notifications"), wx.DefaultPosition,
                                               wx.DefaultSize, 0)
         self.suppressPrerelease.Bind(wx.EVT_CHECKBOX, self.OnPrereleaseStateChange)
         self.suppressPrerelease.SetValue(not self.UpdateSettings.get('prerelease'))
@@ -43,14 +45,14 @@ class PFUpdatePref(PreferenceView):
         if self.UpdateSettings.get('version'):
             self.versionSizer = wx.BoxSizer(wx.VERTICAL)
 
-            self.versionTitle = wx.StaticText(panel, wx.ID_ANY, "Suppressing {0} Notifications".format(
+            self.versionTitle = wx.StaticText(panel, wx.ID_ANY, _t("Suppressing {0} Notifications").format(
                     self.UpdateSettings.get('version')), wx.DefaultPosition, wx.DefaultSize, 0)
             self.versionTitle.Wrap(-1)
             self.versionTitle.SetFont(wx.Font(12, 70, 90, 90, False, wx.EmptyString))
 
-            self.versionInfo = ("There is a release available which you have chosen to suppress. "
-                                "You can choose to reset notification suppression for this release, "
-                                "or download the new release from GitHub.")
+            self.versionInfo = _t("There is a release available which you have chosen to suppress. "
+                                  "You can choose to reset notification suppression for this release, "
+                                  "or download the new release from GitHub.")
 
             self.versionSizer.AddStretchSpacer()
 
@@ -66,12 +68,12 @@ class PFUpdatePref(PreferenceView):
             actionSizer = wx.BoxSizer(wx.HORIZONTAL)
             resetSizer = wx.BoxSizer(wx.VERTICAL)
 
-            self.downloadButton = wx.Button(panel, wx.ID_ANY, "Download", wx.DefaultPosition, wx.DefaultSize, 0)
+            self.downloadButton = wx.Button(panel, wx.ID_ANY, _t("Download"), wx.DefaultPosition, wx.DefaultSize, 0)
             self.downloadButton.Bind(wx.EVT_BUTTON, self.OnDownload)
             resetSizer.Add(self.downloadButton, 0, wx.ALL, 5)
             actionSizer.Add(resetSizer, 1, wx.EXPAND, 5)
 
-            self.resetButton = wx.Button(panel, wx.ID_ANY, "Reset Suppression", wx.DefaultPosition, wx.DefaultSize, 0)
+            self.resetButton = wx.Button(panel, wx.ID_ANY, _t("Reset Suppression"), wx.DefaultPosition, wx.DefaultSize, 0)
             self.resetButton.Bind(wx.EVT_BUTTON, self.ResetSuppression)
             actionSizer.Add(self.resetButton, 0, wx.ALL, 5)
             self.versionSizer.Add(actionSizer, 0, wx.EXPAND, 5)

--- a/gui/builtinShipBrowser/navigationPanel.py
+++ b/gui/builtinShipBrowser/navigationPanel.py
@@ -126,14 +126,14 @@ class NavigationPanel(SFItem.SFBrowserItem):
 
         if not toggle:
             self.shipBrowser.recentFits = False
-            self.btnRecent.label = "Recent Fits"
+            self.btnRecent.label = _t("Recent Fits")
             self.btnRecent.normalBmp = self.recentBmpD
 
             if emitEvent:
                 wx.PostEvent(self.shipBrowser, Stage1Selected())
         else:
             self.shipBrowser.recentFits = True
-            self.btnRecent.label = "Hide Recent Fits"
+            self.btnRecent.label = _t("Hide Recent Fits")
             self.btnRecent.normalBmp = self.recentBmp
 
             if emitEvent:

--- a/gui/builtinShipBrowser/shipItem.py
+++ b/gui/builtinShipBrowser/shipItem.py
@@ -15,7 +15,7 @@ from service.market import Market
 from .events import FitSelected, Stage3Selected
 
 pyfalog = Logger(__name__)
-
+_t = wx.GetTranslation
 
 class ShipItem(SFItem.SFBrowserItem):
 
@@ -108,7 +108,7 @@ class ShipItem(SFItem.SFBrowserItem):
     def OnShowPopup(self, event):
         pos = event.GetPosition()
         pos = self.ScreenToClient(pos)
-        contexts = [("baseShip", "Ship Basic")]
+        contexts = [("baseShip", _t("Ship Basic"))]
         menu = ContextMenu.getMenu(self, self.baseItem, (self.baseItem,), *contexts)
         self.PopupMenu(menu, pos)
 

--- a/gui/builtinStatsViews/firepowerViewFull.py
+++ b/gui/builtinStatsViews/firepowerViewFull.py
@@ -64,7 +64,7 @@ class FirepowerViewFull(StatsView):
 
         counter = 0
 
-        for damageType, image in (("weapon", "turret"), ("drone", "droneDPS")):
+        for label, image, attr in ((_t("Weapon"), "turret", "Weapon"), (_t("Drone"), "droneDPS", "Drone")):
             baseBox = wx.BoxSizer(wx.HORIZONTAL)
             sizerFirepower.Add(baseBox, 1, wx.ALIGN_LEFT if counter == 0 else wx.ALIGN_CENTER_HORIZONTAL)
 
@@ -73,13 +73,13 @@ class FirepowerViewFull(StatsView):
             box = wx.BoxSizer(wx.VERTICAL)
             baseBox.Add(box, 0, wx.ALIGN_CENTER)
 
-            box.Add(wx.StaticText(parent, wx.ID_ANY, _t(damageType).capitalize()), 0, wx.ALIGN_LEFT)
+            box.Add(wx.StaticText(parent, wx.ID_ANY, label), 0, wx.ALIGN_LEFT)
 
             hbox = wx.BoxSizer(wx.HORIZONTAL)
             box.Add(hbox, 1, wx.ALIGN_CENTER)
 
             lbl = wx.StaticText(parent, wx.ID_ANY, "0.0 DPS")
-            setattr(self, "label%sDps%s" % (panel.capitalize(), damageType.capitalize()), lbl)
+            setattr(self, "label%sDps%s" % (panel.capitalize(), attr), lbl)
 
             hbox.Add(lbl, 0, wx.ALIGN_CENTER)
             self._cachedValues.append(0)
@@ -112,7 +112,7 @@ class FirepowerViewFull(StatsView):
 
         image = BitmapLoader.getBitmap("mining_small", "gui")
         self.miningyield = wx.BitmapButton(contentPanel, -1, image)
-        self.miningyield.SetToolTip(wx.ToolTip(_t("Click to toggle to Mining Yield ")))
+        self.miningyield.SetToolTip(wx.ToolTip(_t("Click to toggle to Mining Yield")))
         self.miningyield.Bind(wx.EVT_BUTTON, self.switchToMiningYieldView)
         sizerFirepower.Add(self.miningyield, 0, wx.ALIGN_LEFT)
 

--- a/gui/builtinStatsViews/priceViewFull.py
+++ b/gui/builtinStatsViews/priceViewFull.py
@@ -53,7 +53,10 @@ class PriceViewFull(StatsView):
 
         gridPrice = wx.GridSizer(2, 3, 0, 0)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for _type in ("ship", "fittings", "character", "drones", "cargoBay", "total"):
+        for _type, label in (
+                ("ship", _t("Ship")), ("fittings", _t("Fittings")), ("character", _t("Character")),
+                ("drones", _t("Drones")), ("cargoBay", _t("Cargo bay")), ("total", _t("Total"))
+        ):
             if _type in "ship":
                 image = "ship_big"
             elif _type in ("fittings", "total"):
@@ -69,7 +72,7 @@ class PriceViewFull(StatsView):
             vbox = wx.BoxSizer(wx.VERTICAL)
             box.Add(vbox, 1, wx.EXPAND)
 
-            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, _t(_type).capitalize()), 0, wx.ALIGN_LEFT)
+            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, label.capitalize()), 0, wx.ALIGN_LEFT)
 
             hbox = wx.BoxSizer(wx.HORIZONTAL)
             vbox.Add(hbox)

--- a/gui/builtinStatsViews/priceViewMinimal.py
+++ b/gui/builtinStatsViews/priceViewMinimal.py
@@ -53,7 +53,9 @@ class PriceViewMinimal(StatsView):
 
         gridPrice = wx.GridSizer(1, 3, 0, 0)
         contentSizer.Add(gridPrice, 0, wx.EXPAND | wx.ALL, 0)
-        for _type in ("ship", "fittings", "total"):
+        for _type, label in (
+                ("ship", _t("Ship")), ("fittings", _t("Fittings")), ("total", _t("Total"))
+        ):
             image = "%sPrice_big" % _type if _type != "ship" else "ship_big"
             box = wx.BoxSizer(wx.HORIZONTAL)
             gridPrice.Add(box, 0, wx.ALIGN_TOP)
@@ -63,7 +65,7 @@ class PriceViewMinimal(StatsView):
             vbox = wx.BoxSizer(wx.VERTICAL)
             box.Add(vbox, 1, wx.EXPAND)
 
-            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, _t(_type).capitalize()), 0, wx.ALIGN_LEFT)
+            vbox.Add(wx.StaticText(contentPanel, wx.ID_ANY, label), 0, wx.ALIGN_LEFT)
 
             hbox = wx.BoxSizer(wx.HORIZONTAL)
             vbox.Add(hbox)

--- a/gui/builtinStatsViews/resistancesViewFull.py
+++ b/gui/builtinStatsViews/resistancesViewFull.py
@@ -169,7 +169,7 @@ class ResistancesViewFull(StatsView):
         self.stEHPs.SetToolTip(wx.ToolTip(_t("Click to toggle between effective HP and raw HP")))
 
     def toggleEHP(self, event):
-        wx.PostEvent(self.mainFrame, GE.EffectiveHpToggled(effective=self.stEHPs.GetLabel() == "HP"))
+        wx.PostEvent(self.mainFrame, GE.EffectiveHpToggled(effective=self.stEHPs.GetLabel() == _t("HP")))
 
     def ehpSwitch(self, event):
         event.Skip()

--- a/gui/builtinStatsViews/resistancesViewFull.py
+++ b/gui/builtinStatsViews/resistancesViewFull.py
@@ -58,7 +58,7 @@ class ResistancesViewFull(StatsView):
         # Custom header  EHP
         headerContentSizer = self.headerPanel.Parent.GetHeaderContentSizer()
 
-        self.stEff = wx.StaticText(headerPanel, wx.ID_ANY, "(" + _t("Effective HP") + ": ")
+        self.stEff = wx.StaticText(headerPanel, wx.ID_ANY, "(" + _t("Effective HP: "))
         headerContentSizer.Add(self.stEff)
         headerPanel.GetParent().AddToggleItem(self.stEff)
 
@@ -93,7 +93,7 @@ class ResistancesViewFull(StatsView):
             bitmap.SetToolTip(tooltip)
             sizerResistances.Add(bitmap, wx.GBPosition(row, col), wx.GBSpan(1, 1), wx.ALIGN_CENTER)
             col += 1
-        self.stEHPs = wx.Button(contentPanel, style=wx.BU_EXACTFIT, label="EHP")
+        self.stEHPs = wx.Button(contentPanel, style=wx.BU_EXACTFIT, label=_t("EHP"))
         self.stEHPs.SetToolTip(wx.ToolTip(_t("Click to toggle between effective HP and raw HP")))
 
         self.stEHPs.Bind(wx.EVT_BUTTON, self.toggleEHP)
@@ -184,7 +184,7 @@ class ResistancesViewFull(StatsView):
             wx.PostEvent(self.mainFrame, GE.EffectiveHpToggled(effective=True))
             return
 
-        self.stEHPs.SetLabel("EHP" if self.showEffective else "HP")
+        self.stEHPs.SetLabel(_t("EHP") if self.showEffective else _t("HP"))
         self.activeFit = fit.ID if fit is not None else None
 
         for tankType in ("shield", "armor", "hull"):
@@ -203,24 +203,24 @@ class ResistancesViewFull(StatsView):
 
         ehp = (fit.ehp if self.showEffective else fit.hp) if fit is not None else None
         total = 0
-        for tankType in ("shield", "armor", "hull"):
+        for tankType, tooltip in (("shield", _t("Shield: ")), ("armor", _t("Armor: ")), ("hull", _t("Hull: "))):
             lbl = getattr(self, "labelResistance%sEhp" % tankType.capitalize())
             if ehp is not None:
                 total += ehp[tankType]
                 rrFactor = fit.ehp[tankType] / fit.hp[tankType]
                 lbl.SetLabel(formatAmount(ehp[tankType], 3, 0, 9))
                 lbl.SetToolTip(
-                        wx.ToolTip("%s: %d\nResist Multiplier: x%.2f" % (tankType.capitalize(), ehp[tankType], rrFactor)))
+                        wx.ToolTip(tooltip + "%d\n" % ehp[tankType] + _t("Resist Multiplier: ") + "%.2fx" % rrFactor))
             else:
                 lbl.SetLabel("0")
 
         self.labelEhp.SetLabel("%s" % formatAmount(total, 3, 0, 9))
         if self.showEffective:
-            self.stEff.SetLabel("( Effective HP: ")
-            self.labelEhp.SetToolTip(wx.ToolTip("Effective: %d HP" % total))
+            self.stEff.SetLabel("(" + _t("Effective HP: "))
+            self.labelEhp.SetToolTip(wx.ToolTip(_t("Effective: %d HP") % total))
         else:
-            self.stEff.SetLabel("( Raw HP: ")
-            self.labelEhp.SetToolTip(wx.ToolTip("Raw: %d HP" % total))
+            self.stEff.SetLabel("(" + _t("Raw HP: "))
+            self.labelEhp.SetToolTip(wx.ToolTip(_t("Raw: %d HP") % total))
 
         damagePattern = fit.damagePattern if fit is not None and self.showEffective else None
         total = sum((damagePattern.emAmount, damagePattern.thermalAmount,

--- a/gui/builtinStatsViews/targetingMiscViewMinimal.py
+++ b/gui/builtinStatsViews/targetingMiscViewMinimal.py
@@ -17,11 +17,13 @@
 # along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
+from collections import OrderedDict
+
 # noinspection PyPackageRequirements
 import wx
+
 from gui.statsView import StatsView
 from gui.utils.numberFormatter import formatAmount
-from collections import OrderedDict
 
 _t = wx.GetTranslation
 
@@ -104,7 +106,8 @@ class TargetingMiscViewMinimal(StatsView):
 
         sensorValues = {
             "main": lambda: fit.scanStrength,
-            "jamChance": lambda: fit.jamChance}
+            "jamChance": lambda: fit.jamChance
+        }
 
         cargoNamesOrder = OrderedDict((
             ("fleetHangarCapacity", _t("Fleet hangar")),
@@ -143,7 +146,8 @@ class TargetingMiscViewMinimal(StatsView):
             "specialSalvageHoldCapacity": lambda: fit.ship.getModifiedItemAttr("specialSalvageHoldCapacity"),
             "specialCommandCenterHoldCapacity": lambda: fit.ship.getModifiedItemAttr("specialCommandCenterHoldCapacity"),
             "specialPlanetaryCommoditiesHoldCapacity": lambda: fit.ship.getModifiedItemAttr("specialPlanetaryCommoditiesHoldCapacity"),
-            "specialQuafeHoldCapacity": lambda: fit.ship.getModifiedItemAttr("specialQuafeHoldCapacity")}
+            "specialQuafeHoldCapacity": lambda: fit.ship.getModifiedItemAttr("specialQuafeHoldCapacity")
+        }
 
         stats = (("labelTargets", {"main": lambda: fit.maxTargets}, 3, 0, 0, ""),
                  ("labelRange", {"main": lambda: fit.maxTargetRange / 1000}, 3, 0, 0, "km"),
@@ -157,10 +161,10 @@ class TargetingMiscViewMinimal(StatsView):
                  ("labelFullCargo", cargoValues, 4, 0, 9, "m\u00B3"))
 
         counter = 0
-        RADII = [("Pod", 25), ("Interceptor", 33), ("Frigate", 38),
-                 ("Destroyer", 83), ("Cruiser", 130),
-                 ("Battlecruiser", 265), ("Battleship", 420),
-                 ("Carrier", 3000)]
+        RADII = [(_t("Pod"), 25), (_t("Interceptor"), 33), (_t("Frigate"), 38),
+                 (_t("Destroyer"), 83), (_t("Cruiser"), 130),
+                 (_t("Battlecruiser"), 265), (_t("Battleship"), 420),
+                 (_t("Carrier"), 3000)]
         for labelName, valueDict, prec, lowest, highest, unit in stats:
             label = getattr(self, labelName)
             newValues = {}
@@ -185,8 +189,8 @@ class TargetingMiscViewMinimal(StatsView):
                     ecmChance = round(ecmChance, 1)
                     if ecmChance:
                         label.SetLabel("{} ({}%)".format(
-                            formatAmount(mainValue, prec, lowest, highest),
-                            formatAmount(ecmChance, 3, 0, 0)))
+                                formatAmount(mainValue, prec, lowest, highest),
+                                formatAmount(ecmChance, 3, 0, 0)))
                     else:
                         label.SetLabel("{}".format(formatAmount(mainValue, prec, lowest, highest)))
                 else:
@@ -194,35 +198,35 @@ class TargetingMiscViewMinimal(StatsView):
                 # Tooltip stuff
                 if fit:
                     if labelName == "labelScanRes":
-                        lockTime = "%s\n" % "Lock Times".center(30)
+                        lockTime = "%s\n" % _t("Lock Times").center(30)
                         for size, radius in RADII:
                             left = "%.1fs" % fit.calculateLockTime(radius)
                             right = "%s [%d]" % (size, radius)
                             lockTime += "%5s\t%s\n" % (left, right)
                         label.SetToolTip(wx.ToolTip(lockTime))
                     elif labelName == "labelFullWarpSpeed":
-                        maxWarpDistance = "Max Warp Distance: %.1f AU" % fit.maxWarpDistance
+                        maxWarpDistance = _t("Max Warp Distance: %.1f AU") % fit.maxWarpDistance
                         if fit.ship.getModifiedItemAttr("warpScrambleStatus"):
-                            warpScrambleStatus = "Warp Core Strength: %.1f" % (fit.ship.getModifiedItemAttr("warpScrambleStatus") * -1)
+                            warpScrambleStatus = _t("Warp Core Strength: %.1f") % (fit.ship.getModifiedItemAttr("warpScrambleStatus") * -1)
                         else:
-                            warpScrambleStatus = "Warp Core Strength: %.1f" % 0
+                            warpScrambleStatus = _t("Warp Core Strength: %.1f") % 0
                         label.SetToolTip(wx.ToolTip("%s\n%s" % (maxWarpDistance, warpScrambleStatus)))
                     elif labelName == "labelSensorStr":
                         ecmChance = otherValues["jamChance"]
                         ecmChance = round(ecmChance, 1)
                         if ecmChance > 0:
-                            label.SetToolTip(wx.ToolTip("Type: {}\n{}% chance to be jammed".format(
-                                fit.scanType,
-                                formatAmount(ecmChance, 3, 0, 0))))
+                            label.SetToolTip(wx.ToolTip(
+                                _t("Type: {0}\n").foramt(fit.scanType) + "{}%".format(formatAmount(ecmChance, 3, 0, 0)) + _t(" chance to be jammed").format(
+                                    formatAmount(ecmChance, 3, 0, 0))))
                         else:
-                            label.SetToolTip(wx.ToolTip("Type: {}".format(fit.scanType)))
+                            label.SetToolTip(wx.ToolTip(_t("Type: {}").format(fit.scanType)))
                     elif labelName == "labelFullAlignTime":
-                        alignTime = "Align:\t%.3fs" % mainValue
-                        mass = 'Mass:\t{:,.0f}kg'.format(fit.ship.getModifiedItemAttr("mass"))
-                        agility = "Agility:\t%.3fx" % (fit.ship.getModifiedItemAttr("agility") or 0)
+                        alignTime = _t("Align:\t%.3fs") % mainValue
+                        mass = _t('Mass:\t{:,.0f}kg').format(fit.ship.getModifiedItemAttr("mass"))
+                        agility = _t("Agility:\t%.3fx") % (fit.ship.getModifiedItemAttr("agility") or 0)
                         label.SetToolTip(wx.ToolTip("%s\n%s\n%s" % (alignTime, mass, agility)))
                     elif labelName == "labelFullCargo":
-                        tipLines = ["Cargohold: {:,.2f}m\u00B3 / {:,.2f}m\u00B3".format(fit.cargoBayUsed, newValues["main"])]
+                        tipLines = [_t("Cargohold: ")+"{:,.2f}m\u00B3 / {:,.2f}m\u00B3".format(fit.cargoBayUsed, newValues["main"])]
                         for attrName, tipAlias in list(cargoNamesOrder.items()):
                             if newValues[attrName] > 0:
                                 tipLines.append("{}: {:,.2f}m\u00B3".format(tipAlias, newValues[attrName]))
@@ -234,11 +238,11 @@ class TargetingMiscViewMinimal(StatsView):
                 self._cachedValues[counter] = newValues
             elif labelName == "labelFullWarpSpeed":
                 if fit:
-                    maxWarpDistance = "Max Warp Distance: %.1f AU" % fit.maxWarpDistance
+                    maxWarpDistance = _t("Max Warp Distance: %.1f AU") % fit.maxWarpDistance
                     if fit.ship.getModifiedItemAttr("warpScrambleStatus"):
-                        warpScrambleStatus = "Warp Core Strength: %.1f" % (fit.ship.getModifiedItemAttr("warpScrambleStatus") * -1)
+                        warpScrambleStatus = _t("Warp Core Strength: %.1f") % (fit.ship.getModifiedItemAttr("warpScrambleStatus") * -1)
                     else:
-                        warpScrambleStatus = "Warp Core Strength: %.1f" % 0
+                        warpScrambleStatus = _t("Warp Core Strength: %.1f") % 0
                     label.SetToolTip(wx.ToolTip("%s\n%s" % (maxWarpDistance, warpScrambleStatus)))
                 else:
                     label.SetToolTip(wx.ToolTip(""))
@@ -247,7 +251,7 @@ class TargetingMiscViewMinimal(StatsView):
                     cachedCargo = self._cachedValues[counter]
                     # if you add stuff to cargo, the capacity doesn't change and thus it is still cached
                     # This assures us that we force refresh of cargo tooltip
-                    tipLines = ["Cargohold: {:,.2f}m\u00B3 / {:,.2f}m\u00B3".format(fit.cargoBayUsed, cachedCargo["main"])]
+                    tipLines = [_t("Cargohold: ")+"{:,.2f}m\u00B3 / {:,.2f}m\u00B3".format(fit.cargoBayUsed, cachedCargo["main"])]
                     for attrName, tipAlias in list(cargoNamesOrder.items()):
                         if cachedCargo[attrName] > 0:
                             tipLines.append("{}: {:,.2f}m\u00B3".format(tipAlias, cachedCargo[attrName]))
@@ -258,7 +262,7 @@ class TargetingMiscViewMinimal(StatsView):
             # forces update of probe size, since this stat is used by both sig radius and sensor str
             if labelName == "labelFullSigRadius":
                 if fit:
-                    label.SetToolTip(wx.ToolTip("Probe Size: %.3f" % (fit.probeSize or 0)))
+                    label.SetToolTip(wx.ToolTip(_t("Probe Size: %.3f") % (fit.probeSize or 0)))
                 else:
                     label.SetToolTip(wx.ToolTip(""))
 

--- a/gui/builtinViewColumns/abilities.py
+++ b/gui/builtinViewColumns/abilities.py
@@ -24,6 +24,8 @@ from eos.saveddata.fighter import Fighter
 from gui.viewColumn import ViewColumn
 import gui.mainFrame
 
+_t = wx.GetTranslation
+
 
 class Abilities(ViewColumn):
     name = "Fighter Abilities"
@@ -32,7 +34,7 @@ class Abilities(ViewColumn):
         ViewColumn.__init__(self, fittingView)
 
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
-        self.columnText = "Active Abilities"
+        self.columnText = _t("Active Abilities")
         self.mask = wx.LIST_MASK_TEXT
 
     def getText(self, stuff):

--- a/gui/builtinViewColumns/baseName.py
+++ b/gui/builtinViewColumns/baseName.py
@@ -40,6 +40,7 @@ from service.market import Market
 
 
 pyfalog = Logger(__name__)
+_t = wx.GetTranslation
 
 
 class BaseName(ViewColumn):
@@ -51,7 +52,7 @@ class BaseName(ViewColumn):
         ViewColumn.__init__(self, fittingView)
 
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
-        self.columnText = "Name"
+        self.columnText = _t("Name")
         self.mask = wx.LIST_MASK_TEXT
         self.projectedView = isinstance(fittingView, gui.builtinAdditionPanes.projectedView.ProjectedView)
 

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -47,7 +47,7 @@ class Miscellanea(ViewColumn):
             self.imageId = -1
 
         if params["displayName"] or self.imageId == -1:
-            self.columnText = "Misc data"
+            self.columnText = _("Misc data")
             self.mask |= wx.LIST_MASK_TEXT
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
         self.fittingView = fittingView

--- a/gui/builtinViewColumns/sideEffects.py
+++ b/gui/builtinViewColumns/sideEffects.py
@@ -24,6 +24,8 @@ from eos.saveddata.booster import Booster
 from gui.viewColumn import ViewColumn
 import gui.mainFrame
 
+_t = wx.GetTranslation
+
 
 class SideEffects(ViewColumn):
     name = "Side Effects"
@@ -32,7 +34,7 @@ class SideEffects(ViewColumn):
         ViewColumn.__init__(self, fittingView)
 
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
-        self.columnText = "Active Side Effects"
+        self.columnText = _t("Active Side Effects")
         self.mask = wx.LIST_MASK_TEXT
 
     def getText(self, stuff):

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -45,6 +45,7 @@ from config import slotColourMap
 from gui.fitCommands.helpers import getSimilarModPositions
 
 pyfalog = Logger(__name__)
+_t = wx.GetTranslation
 
 
 # Tab spawning handler
@@ -653,11 +654,11 @@ class FittingView(d.Display):
                     contexts.append(fullContext)
         elif isinstance(mainMod, Mode):
             srcContext = "fittingMode"
-            itemContext = "Tactical Mode"
+            itemContext = _t("Tactical Mode")
             fullContext = (srcContext, itemContext)
             if srcContext not in tuple(fCtx[0] for fCtx in contexts):
                 contexts.append(fullContext)
-        contexts.append(("fittingShip", "Ship" if not fit.isStructure else "Citadel"))
+        contexts.append(("fittingShip", _t("Ship") if not fit.isStructure else _t("Citadel")))
 
         menu = ContextMenu.getMenu(self, mainMod, selection, *contexts)
         self.PopupMenu(menu)

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -605,7 +605,7 @@ class SkillTreeView(wx.Panel):
         eveItem = Market.getInstance().getItem(id)
 
         srcContext = "skillItem"
-        itemContext = "Skill"
+        itemContext = _t("Skill")
         context = (srcContext, itemContext)
         menu = ContextMenu.getMenu(self, eveItem, [eveItem], context)
         char = self.charEditor.entityEditor.getActiveEntity()

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -646,7 +646,7 @@ class SkillTreeView(wx.Panel):
             lvl, dirty = sChar.getSkillLevel(char.ID, skillID)
             self.skillTreeListCtrl.SetItemText(treeItem,
                                                1,
-                                               _("Level {}").format(int(lvl)) if not isinstance(lvl, str) else lvl)
+                                               _t("Level {}").format(int(lvl)) if not isinstance(lvl, str) else lvl)
 
             if not dirty:
                 self.skillTreeListCtrl.SetItemImage(treeItem, self.skillBookImageId)

--- a/gui/characterEditor.py
+++ b/gui/characterEditor.py
@@ -369,10 +369,10 @@ class SkillTreeView(wx.Panel):
 
         bSizerButtons.AddStretchSpacer()
 
-        importExport = ((_t("Import"), wx.ART_FILE_OPEN, _t("from")),
-                        (_t("Export"), wx.ART_FILE_SAVE_AS, _t("to")))
+        importExport = ((_t("Import skills from clipboard"), wx.ART_FILE_OPEN, "import"),
+                        (_t("Export skills from clipboard"), wx.ART_FILE_SAVE_AS, "export"))
 
-        for name, art, direction in importExport:
+        for tooltip, art, attr in importExport:
             bitmap = wx.ArtProvider.GetBitmap(art, wx.ART_BUTTON)
             btn = wx.BitmapButton(self, wx.ID_ANY, bitmap)
 
@@ -380,11 +380,11 @@ class SkillTreeView(wx.Panel):
             btn.SetMaxSize(btn.GetSize())
 
             btn.Layout()
-            setattr(self, "{}Btn".format(name.lower()), btn)
+            setattr(self, "{}Btn".format(attr), btn)
             btn.Enable(True)
-            btn.SetToolTip(_t("%s skills %s clipboard") % (name, direction))
+            btn.SetToolTip(tooltip)
             bSizerButtons.Add(btn, 0, wx.ALL, 5)
-            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Skills".format(name.lower())))
+            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Skills".format(attr)))
 
         pmainSizer.Add(bSizerButtons, 0, wx.EXPAND, 5)
 

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -197,7 +197,7 @@ class ItemStatsContainer(wx.Panel):
 
         if config.debug:
             self.properties = ItemProperties(self.nbContainer, stuff, item, context)
-            self.nbContainer.AddPage(self.properties, "Properties")
+            self.nbContainer.AddPage(self.properties, _t("Properties"))
 
         self.nbContainer.Bind(wx.EVT_LEFT_DOWN, self.mouseHit)
         self.SetSizer(mainSizer)

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -283,9 +283,10 @@ class MainFrame(wx.Frame):
     def LoadMainFrameAttribs(self):
         mainFrameDefaultAttribs = {
             "wnd_display": 0, "wnd_x": 0, "wnd_y": 0, "wnd_width": 1000, "wnd_height": 700, "wnd_maximized": False,
-            "browser_width": 300, "market_height": 0, "fitting_height": -200}
+            "browser_width": 300, "market_height": 0, "fitting_height": -200
+        }
         self.mainFrameAttribs = SettingsProvider.getInstance().getSettings(
-            "pyfaMainWindowAttribs", mainFrameDefaultAttribs)
+                "pyfaMainWindowAttribs", mainFrameDefaultAttribs)
 
         wndDisplay = self.mainFrameAttribs["wnd_display"]
         displayData = self._getDisplayData()
@@ -463,10 +464,10 @@ class MainFrame(wx.Frame):
         defaultFile = "%s - %s.xml" % (fit.ship.item.name, fit.name) if fit else None
 
         with wx.FileDialog(
-            self, _t("Save Fitting As..."),
-            wildcard=_t("EVE XML fitting files (*.xml)|*.xml"),
-            style=wx.FD_SAVE,
-            defaultFile=defaultFile
+                self, _t("Save Fitting As..."),
+                wildcard=_t("EVE XML fitting files") + " (*.xml)|*.xml",
+                style=wx.FD_SAVE,
+                defaultFile=defaultFile
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 self.supress_left_up = True
@@ -643,15 +644,15 @@ class MainFrame(wx.Frame):
 
         if not fit.ignoreRestrictions:
             with wx.MessageDialog(
-                self, _t("Are you sure you wish to ignore fitting restrictions for the "
-                "current fit? This could lead to wildly inaccurate results and possible errors."),
-                _t("Confirm"), wx.YES_NO | wx.ICON_QUESTION
+                    self, _t("Are you sure you wish to ignore fitting restrictions for the "
+                             "current fit? This could lead to wildly inaccurate results and possible errors."),
+                    _t("Confirm"), wx.YES_NO | wx.ICON_QUESTION
             ) as dlg:
                 result = dlg.ShowModal() == wx.ID_YES
         else:
             with wx.MessageDialog(
-                self, _t("Re-enabling fitting restrictions for this fit will also remove any illegal items "
-                "from the fit. Do you want to continue?"), _t("Confirm"), wx.YES_NO | wx.ICON_QUESTION
+                    self, _t("Re-enabling fitting restrictions for this fit will also remove any illegal items "
+                             "from the fit. Do you want to continue?"), _t("Confirm"), wx.YES_NO | wx.ICON_QUESTION
             ) as dlg:
                 result = dlg.ShowModal() == wx.ID_YES
         if result:
@@ -802,14 +803,14 @@ class MainFrame(wx.Frame):
         """ Exports skills needed for active fit and active character """
         sCharacter = Character.getInstance()
         with wx.FileDialog(
-            self,
-            _t("Export Skills Needed As..."),
-            wildcard=("|".join([
-                _t("EVEMon skills training file") + " (*.emp)|*.emp",
-                _t("EVEMon skills training XML file") + " (*.xml)|*.xml",
-                _t("Text skills training file") + " (*.txt)|*.txt"
-            ])),
-            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                self,
+                _t("Export Skills Needed As..."),
+                wildcard=("|".join([
+                    _t("EVEMon skills training file") + " (*.emp)|*.emp",
+                    _t("EVEMon skills training XML file") + " (*.xml)|*.xml",
+                    _t("Text skills training file") + " (*.txt)|*.txt"
+                ])),
+                style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 saveFmtInt = dlg.GetFilterIndex()
@@ -831,21 +832,21 @@ class MainFrame(wx.Frame):
     def fileImportDialog(self, event):
         """Handles importing single/multiple EVE XML / EFT cfg fit files"""
         with wx.FileDialog(
-            self,
-            _t("Open One Or More Fitting Files"),
-            wildcard=("|".join([
-                _t("EVE XML fitting files") + " (*.xml)|*.xml",
-                _t("EFT text fitting files") + " (*.cfg)|*.cfg",
-                _t("All Files") + "|*"
-            ])),
-            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE
+                self,
+                _t("Open One Or More Fitting Files"),
+                wildcard=("|".join([
+                    _t("EVE XML fitting files") + " (*.xml)|*.xml",
+                    _t("EFT text fitting files") + " (*.cfg)|*.cfg",
+                    _t("All Files") + "|*"
+                ])),
+                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 self.progressDialog = wx.ProgressDialog(
-                    _t("Importing fits"),
-                    " " * 100,  # set some arbitrary spacing to create width in window
-                    parent=self,
-                    style=wx.PD_CAN_ABORT | wx.PD_SMOOTH | wx.PD_ELAPSED_TIME | wx.PD_APP_MODAL
+                        _t("Importing fits"),
+                        " " * 100,  # set some arbitrary spacing to create width in window
+                        parent=self,
+                        style=wx.PD_CAN_ABORT | wx.PD_SMOOTH | wx.PD_ELAPSED_TIME | wx.PD_APP_MODAL
                 )
                 Port.importFitsThreaded(dlg.GetPaths(), self)
                 self.progressDialog.ShowModal()
@@ -855,11 +856,11 @@ class MainFrame(wx.Frame):
         defaultFile = "pyfa-fits-%s.xml" % strftime("%Y%m%d_%H%M%S", gmtime())
 
         with wx.FileDialog(
-            self,
-            _t("Save Backup As..."),
-            wildcard=_t("EVE XML fitting file") + " (*.xml)|*.xml",
-            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-            defaultFile=defaultFile,
+                self,
+                _t("Save Backup As..."),
+                wildcard=_t("EVE XML fitting file") + " (*.xml)|*.xml",
+                style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                defaultFile=defaultFile,
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 filePath = dlg.GetPath()
@@ -870,11 +871,11 @@ class MainFrame(wx.Frame):
                 max_ = sFit.countAllFits()
 
                 self.progressDialog = wx.ProgressDialog(
-                    _t("Backup fits"),
-                    _t("Backing up {} fits to: {}").format(max_, filePath),
-                    maximum=max_,
-                    parent=self,
-                    style=wx.PD_CAN_ABORT | wx.PD_SMOOTH | wx.PD_ELAPSED_TIME | wx.PD_APP_MODAL
+                        _t("Backup fits"),
+                        _t("Backing up {} fits to: {}").format(max_, filePath),
+                        maximum=max_,
+                        parent=self,
+                        style=wx.PD_CAN_ABORT | wx.PD_SMOOTH | wx.PD_ELAPSED_TIME | wx.PD_APP_MODAL
                 )
                 Port.backupFits(filePath, self)
                 self.progressDialog.ShowModal()
@@ -889,22 +890,22 @@ class MainFrame(wx.Frame):
 
         if not os.path.isdir(os.path.dirname(path)):
             with wx.MessageDialog(
-                self,
+                    self,
                     _t("Invalid Path") + "\n\n" +
                     _t("The following path is invalid or does not exist:") +
                     f"\n{path}\n\n" +
                     _t("Please verify path location pyfa's preferences."),
-                _t("Error"),
-                wx.OK | wx.ICON_ERROR
+                    _t("Error"),
+                    wx.OK | wx.ICON_ERROR
             ) as dlg:
                 if dlg.ShowModal() == wx.ID_OK:
                     return
 
         self.progressDialog = wx.ProgressDialog(
-            _t("Backup fits"),
-            _t("Generating HTML file at: {}").format(path),
-            maximum=max_, parent=self,
-            style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
+                _t("Backup fits"),
+                _t("Generating HTML file at: {}").format(path),
+                maximum=max_, parent=self,
+                style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
 
         exportHtml.getInstance().refreshFittingHtml(True, self.backupCallback)
         self.progressDialog.ShowModal()
@@ -922,7 +923,7 @@ class MainFrame(wx.Frame):
     def on_port_processing(self, action, data=None):
         # 2017/03/29 NOTE: implementation like interface
         wx.CallAfter(
-            self._on_port_processing, action, data
+                self._on_port_processing, action, data
         )
 
         return self.__progress_flag
@@ -946,11 +947,11 @@ class MainFrame(wx.Frame):
             self.closeProgressDialog()
             _message = _t("Import Error") if action & IPortUser.PROCESS_IMPORT else _t("Export Error")
             with wx.MessageDialog(
-                self,
+                    self,
                     _t("The following error was generated") +
-                f"\n\n{data}\n\n" +
+                    f"\n\n{data}\n\n" +
                     _t("Be aware that already processed fits were not saved"),
-                _message, wx.OK | wx.ICON_ERROR
+                    _message, wx.OK | wx.ICON_ERROR
             ) as dlg:
                 dlg.ShowModal()
             return
@@ -1007,13 +1008,13 @@ class MainFrame(wx.Frame):
     def importCharacter(self, event):
         """ Imports character XML file from EVE API """
         with wx.FileDialog(
-            self,
-            _t("Open One Or More Character Files"),
-            wildcard="|".join([
-                _t("EVE API XML character files") + " (*.xml)|*.xml",
-                _t("All Files") + "|*"
-            ]),
-            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE
+                self,
+                _t("Open One Or More Character Files"),
+                wildcard="|".join([
+                    _t("EVE API XML character files") + " (*.xml)|*.xml",
+                    _t("All Files") + "|*"
+                ]),
+                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 self.supress_left_up = True

--- a/gui/patternEditor.py
+++ b/gui/patternEditor.py
@@ -168,10 +168,10 @@ class DmgPatternEditor(AuxiliaryFrame):
 
         self.SetSizer(mainSizer)
 
-        importExport = (("Import", wx.ART_FILE_OPEN, _t("from")),
-                        ("Export", wx.ART_FILE_SAVE_AS, _t("to")))
+        importExport = ((_t("Import patterns from clipboard"), wx.ART_FILE_OPEN, "import"),
+                        (_t("Export patterns to clipboard"), wx.ART_FILE_SAVE_AS, "export"))
 
-        for name, art, direction in importExport:
+        for tooltip, art, attr in importExport:
             bitmap = wx.ArtProvider.GetBitmap(art, wx.ART_BUTTON)
             btn = wx.BitmapButton(self, wx.ID_ANY, bitmap)
 
@@ -179,11 +179,11 @@ class DmgPatternEditor(AuxiliaryFrame):
             btn.SetMaxSize(btn.GetSize())
 
             btn.Layout()
-            setattr(self, name, btn)
+            setattr(self, "{}Btn".format(attr), btn)
             btn.Enable(True)
-            btn.SetToolTip(_t("%s patterns %s clipboard") % (name, direction))
+            btn.SetToolTip(tooltip)
             footerSizer.Add(btn, 0)
-            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Patterns".format(name.lower())))
+            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Patterns".format(attr)))
 
         if not self.entityEditor.checkEntitiesExist():
             self.Close()

--- a/gui/propertyEditor.py
+++ b/gui/propertyEditor.py
@@ -26,7 +26,7 @@ class AttributeEditor(AuxiliaryFrame):
 
     def __init__(self, parent):
         super().__init__(
-            parent, wx.ID_ANY, title=_("Attribute Editor"), pos=wx.DefaultPosition,
+            parent, wx.ID_ANY, title=_t("Attribute Editor"), pos=wx.DefaultPosition,
             size=wx.Size(650, 600), resizeable=True)
 
         i = wx.Icon(BitmapLoader.getBitmap("fit_rename_small", "gui"))
@@ -36,11 +36,11 @@ class AttributeEditor(AuxiliaryFrame):
 
         menubar = wx.MenuBar()
         fileMenu = wx.Menu()
-        fileImport = fileMenu.Append(wx.ID_ANY, _('Import'), _('Import overrides'))
-        fileExport = fileMenu.Append(wx.ID_ANY, _('Export'), _('Import overrides'))
-        fileClear = fileMenu.Append(wx.ID_ANY, _('Clear All'), _('Clear all overrides'))
+        fileImport = fileMenu.Append(wx.ID_ANY, _t('Import'), _t('Import overrides'))
+        fileExport = fileMenu.Append(wx.ID_ANY, _t('Export'), _t('Import overrides'))
+        fileClear = fileMenu.Append(wx.ID_ANY, _t('Clear All'), _t('Clear all overrides'))
 
-        menubar.Append(fileMenu, '&File')
+        menubar.Append(fileMenu, _t('&File'))
         self.SetMenuBar(menubar)
 
         self.Bind(wx.EVT_MENU, self.OnImport, fileImport)
@@ -69,7 +69,7 @@ class AttributeEditor(AuxiliaryFrame):
         mainSizer.Add(leftPanel, 1, wx.ALL | wx.EXPAND, 5)
 
         rightSizer = wx.BoxSizer(wx.VERTICAL)
-        self.btnRemoveOverrides = wx.Button(panel, wx.ID_ANY, _("Remove Overides for Item"), wx.DefaultPosition,
+        self.btnRemoveOverrides = wx.Button(panel, wx.ID_ANY, _t("Remove Overides for Item"), wx.DefaultPosition,
                                             wx.DefaultSize, 0)
         self.pg = AttributeGrid(panel)
         rightSizer.Add(self.pg, 1, wx.ALL | wx.EXPAND, 5)
@@ -105,8 +105,8 @@ class AttributeEditor(AuxiliaryFrame):
 
     def OnImport(self, event):
         with wx.FileDialog(
-            self, _("Import pyfa override file"),
-            wildcard="pyfa override file (*.csv)|*.csv",
+            self, _t("Import pyfa override file"),
+            wildcard=_t("pyfa override file (*.csv)|*.csv"),
             style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
@@ -128,8 +128,8 @@ class AttributeEditor(AuxiliaryFrame):
         defaultFile = "pyfa_overrides.csv"
 
         with wx.FileDialog(
-            self, _("Save Overrides As..."),
-            wildcard="pyfa overrides (*.csv)|*.csv",
+            self, _t("Save Overrides As..."),
+            wildcard=_t("pyfa overrides (*.csv)|*.csv"),
             style=wx.FD_SAVE,
             defaultFile=defaultFile
         ) as dlg:
@@ -269,7 +269,7 @@ class AttributeGrid(wxpg.PropertyGrid):
                 prop = wxpg.FloatProperty(key, value=default)
 
             prop.SetClientData(item.attributes[key])  # set this so that we may access it later
-            prop.SetHelpString("%s\n%s" % (item.attributes[key].displayName or key, _("Default Value: %0.3f") % default))
+            prop.SetHelpString("%s\n%s" % (item.attributes[key].displayName or key, _t("Default Value: %0.3f") % default))
             self.Append(prop)
 
     def removeOverrides(self, event):

--- a/gui/propertyEditor.py
+++ b/gui/propertyEditor.py
@@ -16,7 +16,6 @@ from gui.marketBrowser import SearchBox
 from service.fit import Fit
 from service.market import Market
 
-
 pyfalog = Logger(__name__)
 
 _t = wx.GetTranslation
@@ -26,8 +25,8 @@ class AttributeEditor(AuxiliaryFrame):
 
     def __init__(self, parent):
         super().__init__(
-            parent, wx.ID_ANY, title=_t("Attribute Editor"), pos=wx.DefaultPosition,
-            size=wx.Size(650, 600), resizeable=True)
+                parent, wx.ID_ANY, title=_t("Attribute Editor"), pos=wx.DefaultPosition,
+                size=wx.Size(650, 600), resizeable=True)
 
         i = wx.Icon(BitmapLoader.getBitmap("fit_rename_small", "gui"))
         self.SetIcon(i)
@@ -105,9 +104,9 @@ class AttributeEditor(AuxiliaryFrame):
 
     def OnImport(self, event):
         with wx.FileDialog(
-            self, _t("Import pyfa override file"),
-            wildcard=_t("pyfa override file (*.csv)|*.csv"),
-            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
+                self, _t("Import pyfa override file"),
+                wildcard=_t("pyfa override file") + " (*.csv)|*.csv",
+                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 path = dlg.GetPath()
@@ -128,10 +127,10 @@ class AttributeEditor(AuxiliaryFrame):
         defaultFile = "pyfa_overrides.csv"
 
         with wx.FileDialog(
-            self, _t("Save Overrides As..."),
-            wildcard=_t("pyfa overrides (*.csv)|*.csv"),
-            style=wx.FD_SAVE,
-            defaultFile=defaultFile
+                self, _t("Save Overrides As..."),
+                wildcard=_t("pyfa overrides") + " (*.csv)|*.csv",
+                style=wx.FD_SAVE,
+                defaultFile=defaultFile
         ) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
                 path = dlg.GetPath()
@@ -143,10 +142,10 @@ class AttributeEditor(AuxiliaryFrame):
 
     def OnClear(self, event):
         with wx.MessageDialog(
-            self,
-            _t("Are you sure you want to delete all overrides?"),
-            _t("Confirm Delete"),
-            wx.YES | wx.NO | wx.ICON_EXCLAMATION
+                self,
+                _t("Are you sure you want to delete all overrides?"),
+                _t("Confirm Delete"),
+                wx.YES | wx.NO | wx.ICON_EXCLAMATION
         ) as dlg:
             if dlg.ShowModal() == wx.ID_YES:
                 sMkt = Market.getInstance()

--- a/gui/setEditor.py
+++ b/gui/setEditor.py
@@ -145,10 +145,10 @@ class ImplantSetEditor(AuxiliaryFrame):
         self.stNotice.Wrap(-1)
         footerSizer.Add(self.stNotice, 1, wx.BOTTOM | wx.TOP | wx.LEFT, 5)
 
-        importExport = (("Import", wx.ART_FILE_OPEN, _t("from")),
-                        ("Export", wx.ART_FILE_SAVE_AS, _t("to")))
+        importExport = ((_t("Import implant sets from clipboard"), wx.ART_FILE_OPEN, "Import"),
+                        (_t("Export implant sets to clipboard"), wx.ART_FILE_SAVE_AS, "Export"))
 
-        for name, art, direction in importExport:
+        for tooltip, art, attr in importExport:
             bitmap = wx.ArtProvider.GetBitmap(art, wx.ART_BUTTON)
             btn = wx.BitmapButton(self, wx.ID_ANY, bitmap)
 
@@ -156,9 +156,9 @@ class ImplantSetEditor(AuxiliaryFrame):
             btn.SetMaxSize(btn.GetSize())
 
             btn.Layout()
-            setattr(self, name, btn)
+            setattr(self, attr, btn)
             btn.Enable(True)
-            btn.SetToolTip(_t("{} implant sets {} clipboard").format(name, direction))
+            btn.SetToolTip(tooltip)
             footerSizer.Add(btn, 0)
 
         mainSizer.Add(footerSizer, 0, wx.ALL | wx.EXPAND, 5)

--- a/gui/targetProfileEditor.py
+++ b/gui/targetProfileEditor.py
@@ -218,10 +218,10 @@ class TargetProfileEditor(AuxiliaryFrame):
 
         self.SetSizer(mainSizer)
 
-        importExport = (("Import", wx.ART_FILE_OPEN, _t("from")),
-                        ("Export", wx.ART_FILE_SAVE_AS, _t("to")))
+        importExport = ((_t("Import profiles from clipboard"), wx.ART_FILE_OPEN, "import"),
+                        (_t("Export profiles to clipboard"), wx.ART_FILE_SAVE_AS, "export"))
 
-        for name, art, direction in importExport:
+        for tooltip, art, attr in importExport:
             bitmap = wx.ArtProvider.GetBitmap(art, wx.ART_BUTTON)
             btn = wx.BitmapButton(self, wx.ID_ANY, bitmap)
 
@@ -229,11 +229,11 @@ class TargetProfileEditor(AuxiliaryFrame):
             btn.SetMaxSize(btn.GetSize())
 
             btn.Layout()
-            setattr(self, name, btn)
+            setattr(self, attr, btn)
             btn.Enable(True)
-            btn.SetToolTip(_t("{} profiles {} clipboard").format(name, direction))
+            btn.SetToolTip(tooltip)
             footerSizer.Add(btn, 0)
-            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Patterns".format(name.lower())))
+            btn.Bind(wx.EVT_BUTTON, getattr(self, "{}Patterns".format(attr)))
 
         if not self.entityEditor.checkEntitiesExist():
             self.Close()

--- a/locale/README.md
+++ b/locale/README.md
@@ -7,7 +7,7 @@ Below is a summary of [GNU gettext](https://www.gnu.org/software/gettext/) manua
 ## i18n with command line
 
 Windows users can get these tools via Git for windows, Msys2 or Cygwin; or just use WSL / WSL2.
-For Linux and macOS users these tools might be avaliable out-of-box.
+For Linux and macOS users these tools might be available out-of-box.
 
 ### To generate new template for translation:
 
@@ -15,9 +15,9 @@ For Linux and macOS users these tools might be avaliable out-of-box.
 $ find */ *.py -name "*.py" | xgettext -o locale/lang.pot -d lang -k_t -f -
 ```
 
-explaination:
+explanation:
 
-* `find */ *.py -name "*.py"`: collect all `.py` file path in root dir and all sub-folder, write it to stdout
+* `find */ *.py -name "*.py"`: collect all `.py` file path in root folder and all sub-folder, write it to stdout
 * `xgettext`: a utility looking for keyword and put string literals in a specific format for human translation
     * `-o locale/lang.pot`: let `xgettext` write to `locale/lang.pot`
     * `-d lang`: default language domain is `lang`
@@ -26,13 +26,13 @@ explaination:
 
 this `locale/lang.pot` is called PO template, which is throwed away once actual `ll_CC/LC_MESSAGES/lang.po` is ready for use.
 
-### To initalize PO file for new language
+### To initialize PO file for new language
 
 ```console
 $ msginit -i locale/lang.pot -l ll_CC -o locale/ll_CC/LC_MESSAGES/lang.po
 ```
 
-explaination:
+explanation:
 
 * `-i locale/lang.pot`: input file location
 * `-l ll_CC`: target locale. `ll` should be a language code, and `CC` should be a country code
@@ -53,7 +53,7 @@ $ msgmerge locale/ll_CC/LC_MESSAGES/lang.po locale/lang.pot
 
 just edit the `lang.po` file :)
 
-### To generate mechine readable MO file
+### To generate machine readable MO file
 
 For a single locale:
 
@@ -61,7 +61,7 @@ For a single locale:
 $ msgfmt locale/ll_CC/LC_MESSAGES/lang.po -o locale/ll_CC/LC_MESSAGES/lang.mo
 ```
 
-For all avaliable locale:
+For all available locale:
 ```bash
 for f in locale/*/; do 
     msgfmt $f/LC_MESSAGES/lang.po -o $f/LC_MESSAGES/lang.mo

--- a/locale/README.md
+++ b/locale/README.md
@@ -12,7 +12,7 @@ For Linux and macOS users these tools might be avaliable out-of-box.
 ### To generate new template for translation:
 
 ```console
-$ find */ *.py -name "*.py" | xgettext -o locale/lang.pot -d lang -k_t -k_r -
+$ find */ *.py -name "*.py" | xgettext -o locale/lang.pot -d lang -k_t -f -
 ```
 
 explaination:
@@ -21,8 +21,8 @@ explaination:
 * `xgettext`: a utility looking for keyword and put string literals in a specific format for human translation
     * `-o locale/lang.pot`: let `xgettext` write to `locale/lang.pot`
     * `-d lang`: default language domain is `lang`
-    * `-k_t -k_r`: besides default keyword (including `_`, see `info xgettext` for detail), also look for `_t` and `_r`
-    * `-`: let `xgettext` to read from stdin, which is connected to `find` stdout
+    * `-k_t`: besides default keyword (including `_`, see `info xgettext` for detail), also look for `_t`
+    * `-f -`: let `xgettext` to read from stdin, which is connected to `find` stdout
 
 this `locale/lang.pot` is called PO template, which is throwed away once actual `ll_CC/LC_MESSAGES/lang.po` is ready for use.
 
@@ -63,7 +63,7 @@ $ msgfmt locale/ll_CC/LC_MESSAGES/lang.po -o locale/ll_CC/LC_MESSAGES/lang.mo
 
 For all avaliable locale:
 ```bash
-for $f in locale/*/; do 
+for f in locale/*/; do 
     msgfmt $f/LC_MESSAGES/lang.po -o $f/LC_MESSAGES/lang.mo
 done
 ```

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyfa 2.22.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-21 16:22+0800\n"
-"PO-Revision-Date: 2020-06-21 17:22+0800\n"
+"POT-Creation-Date: 2020-06-22 17:50+0800\n"
+"PO-Revision-Date: 2020-06-22 17:51+0800\n"
 "Last-Translator: zhaoweny <zhaoweny@users.noreply.github.com>\n"
 "Language-Team: Chinese (simplified)\n"
 "Language: zh_CN\n"
@@ -18,275 +18,137 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gui/propertyEditor.py:29
-msgid "Attribute Editor"
-msgstr "属性编辑器"
+#: gui/aboutData.py:31
+msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
+msgstr ""
+"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/propertyEditor.py:39
-msgid "Import"
-msgstr "导入"
+#: gui/aboutData.py:32
+msgid "All EVE-Online related materials are property of CCP hf."
+msgstr "所有 EvE Online 相关材料版权归CCP所有。"
 
-#: gui/propertyEditor.py:39 gui/propertyEditor.py:40
-msgid "Import overrides"
-msgstr "导入自定义属性"
+#: gui/aboutData.py:33
+msgid ""
+"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
+msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
 
-#: gui/propertyEditor.py:40
-msgid "Export"
-msgstr "导出"
+#: gui/aboutData.py:34
+msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
+msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
 
-#: gui/propertyEditor.py:41
-msgid "Clear All"
-msgstr "清除所有"
+#: gui/aboutData.py:49
+msgid ""
+"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
+"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
+"high degree of accuracy. Pyfa can run on all platforms where Python and "
+"wxWidgets are supported."
+msgstr ""
+"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
+"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
+"wxWidgets支持的所有平台运行。"
 
-#: gui/propertyEditor.py:41
-msgid "Clear all overrides"
-msgstr "清除所有自定义属性"
+#: gui/additionsPane.py:45
+msgid "Additions"
+msgstr "附加装备"
 
-#: gui/propertyEditor.py:72
-msgid "Remove Overides for Item"
-msgstr "删除物品的自定义属性"
+#: gui/additionsPane.py:66
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
+#: gui/builtinStatsViews/priceViewFull.py:58
+msgid "Drones"
+msgstr "无人机"
 
-#: gui/propertyEditor.py:108
-msgid "Import pyfa override file"
-msgstr "导入Pyfa自定义配置文件"
+#: gui/additionsPane.py:69
+msgid "Fighters"
+msgstr "铁骑舰载机"
 
-#: gui/propertyEditor.py:131
-msgid "Save Overrides As..."
-msgstr "保存自定义属性为..."
+#: gui/additionsPane.py:72
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:88
+msgid "Cargo"
+msgstr "货舱"
 
-#: gui/propertyEditor.py:147
-msgid "Are you sure you want to delete all overrides?"
-msgstr "您确定要删除所有自定义属性吗？"
-
-#: gui/propertyEditor.py:148 gui/esiFittings.py:157
-msgid "Confirm Delete"
-msgstr "删除确认"
-
-#: gui/propertyEditor.py:272
-#, python-format
-msgid "Default Value: %0.3f"
-msgstr "默认值：%0.3f"
-
-#: gui/characterEditor.py:76
-msgid "You must supply a name for the Character!"
-msgstr "您必须填写一个角色名！"
-
-#: gui/characterEditor.py:78
-msgid "Character name already in use, please choose another."
-msgstr "角色名已占用，请使用其他名称。"
-
-#: gui/characterEditor.py:83 gui/characterEditor.py:463
-#: gui/characterEditor.py:898 gui/characterSelection.py:174
-#: gui/patternEditor.py:58 gui/setEditor.py:55 gui/targetProfileEditor.py:78
-#: gui/mainFrame.py:897
-msgid "Error"
-msgstr "错误"
-
-#: gui/characterEditor.py:90 gui/esiFittings.py:341
-msgid "Character"
-msgstr "角色"
-
-#: gui/characterEditor.py:137
-msgid "Character Editor"
-msgstr "角色编辑器"
-
-#: gui/characterEditor.py:160
-msgid "Skills"
-msgstr "技能列表"
-
-#: gui/characterEditor.py:161 gui/additionsPane.py:75
+#: gui/additionsPane.py:75 gui/characterEditor.py:161
 msgid "Implants"
 msgstr "植入体"
 
-#: gui/characterEditor.py:162
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:14
-msgid "EVE SSO"
-msgstr "连接到EvE"
+#: gui/additionsPane.py:78
+msgid "Boosters"
+msgstr "增效剂"
 
-#: gui/characterEditor.py:281
-msgid "Enter a name for your new Character:"
-msgstr "请为新角色输入一个名称："
+#: gui/additionsPane.py:81
+msgid "Projected"
+msgstr "环境效果"
 
-#: gui/characterEditor.py:282
-msgid "Save Character As..."
-msgstr "保存角色为..."
+#: gui/additionsPane.py:84
+msgid "Command"
+msgstr "指令"
 
-#: gui/characterEditor.py:284
-msgid "{} Copy"
-msgstr "复制{}"
+#: gui/additionsPane.py:87
+msgid "Notes"
+msgstr "备注"
 
-#: gui/characterEditor.py:326
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
+msgid "Context Menus"
+msgstr "右键菜单"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
 msgid ""
-"Setting an Alpha clone does not replace the character's skills, but rather "
-"caps them to Alpha levels."
+"Disabling context menus can improve responsiveness.\n"
+"You can hold {} key + right-click to show all menu items regardless of these "
+"settings."
 msgstr ""
-"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
+"关闭右键菜单可提升响应速度。\n"
+"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
 
-#: gui/characterEditor.py:342
-msgid "Skill"
-msgstr "技能"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+msgid "Set as Damage Pattern"
+msgstr "设置为伤害模型"
 
-#: gui/characterEditor.py:343
-msgid "Level"
-msgstr "技能等级"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Disabled"
+msgstr "关闭"
 
-#: gui/characterEditor.py:356
-#, python-brace-format
-msgid "Sec Status: {0:.2f}"
-msgstr "安全等级: {0:.2f}"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Enabled"
+msgstr "打开"
 
-#: gui/characterEditor.py:372
-msgid "Import skills from clipboard"
-msgstr "从剪贴板导入技能列表"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+msgid "Change Skills"
+msgstr "修改技能等级"
 
-#: gui/characterEditor.py:373
-msgid "Export skills from clipboard"
-msgstr "从剪贴板导出技能列表"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+msgid "Variations"
+msgstr "变种"
 
-#: gui/characterEditor.py:440
-msgid ""
-"Importing skills into this character will set the skill levels as pending. "
-"To save the skills permanently, please click the Save button at the bottom "
-"of the window after importing"
-msgstr ""
-"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
-"窗口底部的保存按钮"
-
-#: gui/characterEditor.py:442
-msgid "Import Skills"
-msgstr "导入技能"
-
-#: gui/characterEditor.py:463
-msgid "There was an error importing skills, please see log file"
-msgstr "导入技能列表出错，详见日志文件"
-
-#: gui/characterEditor.py:532
-msgid "Level {}d"
-msgstr "等级"
-
-#: gui/characterEditor.py:591 gui/characterEditor.py:616
-#: gui/characterEditor.py:649
-msgid "Level {}"
-msgstr "等级"
-
-#: gui/characterEditor.py:614
-msgid "Unlearn"
-msgstr "忘掉"
-
-#: gui/characterEditor.py:757
-msgid "You cannot link All 0 or All 5 characters to an EVE character."
-msgstr "你不能关联全0级或全5级到一个EvE角色。"
-
-#: gui/characterEditor.py:758
-msgid "Please select another character or make a new one."
-msgstr "请选择另一角色或创建新角色。"
-
-#: gui/characterEditor.py:771
-msgid "Character:"
-msgstr "角色："
-
-#: gui/characterEditor.py:778
-msgid "Get Skills"
-msgstr "获取技能列表"
-
-#: gui/characterEditor.py:789
-msgid "Don't see your EVE character in the list?"
-msgstr "列表中没有你的EvE角色？"
-
-#: gui/characterEditor.py:794
-msgid "Log In with EVE SSO"
-msgstr "通过EVE登录"
-
-#: gui/characterEditor.py:855
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "None"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+msgid "Project onto Fit"
 msgstr ""
 
-#: gui/characterEditor.py:897 gui/characterSelection.py:173
-msgid "Error fetching skill information"
-msgstr "无法获取技能信息"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+msgid "Fill with module"
+msgstr "用该模块填满空白槽位"
 
-#: gui/characterEditor.py:901
-msgid "Successfully fetched skills"
-msgstr "成功获取到技能列表"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+msgid "Spoolup"
+msgstr "预热"
 
-#: gui/characterEditor.py:901
-msgid "Success"
-msgstr "成功"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Additions Panel Copy/Paste"
+msgstr "附加装备栏复制/粘贴"
 
-#: gui/characterEditor.py:907
-msgid "Set Security Status"
-msgstr "设置安全等级"
-
-#: gui/characterEditor.py:914
-msgid "Security Status is used in some CONCORD hull calculations"
-msgstr "安全等级会用于计算CONCORD警察船体属性"
-
-#: gui/itemStats.py:58
-msgid "Item stats"
-msgstr "物品属性"
-
-#: gui/itemStats.py:87
-#, python-brace-format
-msgid "{context}Stats: {name}{debug_info}"
-msgstr ""
-
-#: gui/itemStats.py:166
-msgid "Traits"
-msgstr "特征"
-
-#: gui/itemStats.py:170
-msgid "Mutations"
-msgstr "变质"
-
-#: gui/itemStats.py:174
-msgid "Description"
-msgstr "简介"
-
-#: gui/itemStats.py:177
-msgid "Attributes"
-msgstr "属性"
-
-#: gui/itemStats.py:182
-msgid "Compare"
-msgstr "对比"
-
-#: gui/itemStats.py:185
-msgid "Requirements"
-msgstr "技能需求"
-
-#: gui/itemStats.py:189
-msgid "Dependents"
-msgstr ""
-
-#: gui/itemStats.py:192
-msgid "Effects"
-msgstr "效果"
-
-#: gui/itemStats.py:196
-msgid "Affected by"
-msgstr "影响因素"
-
-#: gui/updateDialog.py:54
-msgid "Update Available"
-msgstr "有更新可用"
-
-#: gui/updateDialog.py:102
-msgid "Don't remind me again for this release"
-msgstr "不再提示此更新"
-
-#: gui/updateDialog.py:113
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
-msgid "Download"
-msgstr "下载"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:13
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
 msgid "Database"
 msgstr "数据库"
 
@@ -302,7 +164,7 @@ msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
 
 #: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
 msgid "pyfa User Path:"
-msgstr "Pyfa自定义路径："
+msgstr "pyfa用户数据路径："
 
 #: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
 msgid "Fitting Database:"
@@ -356,137 +218,221 @@ msgstr ""
 "本操作将永久删除所有价格缓存数据。\n"
 "您确定要继续吗？"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:12
-msgid "Statistics Panel"
-msgstr "属性面板"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
+msgid "Fitting Engine"
+msgstr "装配引擎"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
-msgid "Changes require restart of pyfa to take effect."
-msgstr "变更将在重启Pyfa之后生效。"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinStatsViews/resourcesViewFull.py:84
-msgid "Resources"
-msgstr "装配资源"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Minimal"
-msgstr "简洁"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Full"
-msgstr "完整"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinStatsViews/resistancesViewFull.py:47
-msgid "Resistances"
-msgstr "抗性"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-msgid "Shield/Armor Tank"
-msgstr "回充速度"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinStatsViews/firepowerViewFull.py:43
-msgid "Firepower"
-msgstr "火力"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinStatsViews/capacitorViewFull.py:37
-msgid "Capacitor"
-msgstr "电容"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Misc"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinStatsViews/priceViewFull.py:40
-msgid "Price"
-msgstr "价格"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/builtinStatsViews/outgoingViewMinimal.py:65
-#: gui/builtinStatsViews/outgoingViewFull.py:66
-msgid "Remote Reps"
-msgstr "遥修"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:12
-msgid "Context Menus"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
 msgid ""
-"Disabling context menus can improve responsiveness.\n"
-"You can hold {} key + right-click to show all menu items regardless of these "
-"settings."
+"Factor in reload time when calculating capacitor usage, damage, and tank."
+msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
+msgid "Enforce strict skill level requirements"
+msgstr "使用严格的技能等级检查"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
+msgid ""
+"When enabled, skills will check their dependencies' requirements when their "
+"levels change and reset skills that no longer meet the requirement.\n"
+"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
+"skill, as that requires Drones V"
 msgstr ""
-"关闭右键菜单可提升响应速度。\n"
-"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
+"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
+"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-msgid "Set as Damage Pattern"
-msgstr "设置为伤害模型"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
+msgid ""
+"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
+"behavior)."
+msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Disabled"
-msgstr "关闭"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
+msgid "Global Default Spoolup Percentage:"
+msgstr "全局默认预热百分比"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Enabled"
-msgstr "打开"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
+msgid ""
+"The amount of spoolup to use by default on module which support it. Can be "
+"changed on a per-module basis"
+msgstr "默认模块预热量。可以分模块单独设置。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-msgid "Change Skills"
-msgstr "修改技能等级"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
+#: gui/characterEditor.py:162
+msgid "EVE SSO"
+msgstr "EvE单点登录(SSO)"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-msgid "Variations"
-msgstr "变种"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:32
+msgid ""
+"Please see the pyfa wiki on GitHub for information regarding these options."
+msgstr "关于下列选项，详情请参考GitHub上的百科。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-msgid "Project onto Fit"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:38
+msgid "Login Authentication Method"
+msgstr "登录鉴权模式"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Local Server"
+msgstr "本地服务器"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Manual"
+msgstr "手动"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
+msgid ""
+"This options starts a local webserver that the web application will call "
+"back to with information about the character login."
+msgstr "本选项将启动一个本地服务器以接收登录页返回的角色信息。"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:42
+msgid ""
+"This option prompts users to copy and paste information from the web "
+"application to allow for character login. Use this if having issues with the "
+"local server."
 msgstr ""
+"本选项将在角色登录时提示您复制和粘贴登录页相关信息。如果本地服务器出现问题，"
+"可使用该选项。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-msgid "Fill with module"
-msgstr "用该模块填满空白槽位"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:45
+msgid "SSO Mode"
+msgstr "单点登录(SSO)模式"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-msgid "Spoolup"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "pyfa.io"
+msgstr "pyfa.io"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "Custom application"
+msgstr "自定义应用"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
+msgid ""
+"This options routes SSO Logins through pyfa.io, allowing you to easily login "
+"without any configuration. When in doubt, use this option."
 msgstr ""
+"本选项将通过pyfa.io处理单点登录(SSO)请求，使你无需配置即可登录到EVE。不清除时"
+"可以使用该选项。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Additions Panel Copy/Paste"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:49
+msgid ""
+"This option goes through EVE SSO directly, but requires more configuration. "
+"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
+"route data throguh pyfa.io."
 msgstr ""
+"本选项将直接发送EvE单点登录请求，但这需要更多配置。如果pyfa.io无法访问，或你"
+"不想让pyfa.io处理登录请求，请使用该选项。"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:17
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:63
+msgid "Custom Application"
+msgstr "自定义应用"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:76
+msgid "Client ID:"
+msgstr "客户ID(Client ID)："
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:85
+msgid "Client Secret:"
+msgstr "客户密钥(Client Secret)："
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
+msgid "General"
+msgstr "通用"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
+msgid "Use global character"
+msgstr "使用全局角色"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
+msgid "Use character implants by default for new fits"
+msgstr "新装配默认使用角色植入体组"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
+msgid "Use global damage pattern"
+msgstr "使用全局伤害分布配置"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
+msgid "Compact skills needed tooltip"
+msgstr "简洁技能需求提示"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
+msgid "Color fitting view by slot"
+msgstr "用背景色区分槽位"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
+msgid "Reopen previous fits on startup"
+msgstr "重新启动时打开之前的装配"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
+msgid "Separate Racks"
+msgstr "分隔不同槽位类型"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
+msgid "Show Rack Labels"
+msgstr "显示槽位类型标签"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
+msgid "Show fitting tab tooltips"
+msgstr "装配标签页显示预览"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
+msgid "Animate gauges"
+msgstr "启用属性进度条动画"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
+msgid "Open fittings in a new page by default"
+msgstr "默认在新标签页打开装配"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
+msgid "Show ship browser tooltip"
+msgstr "船体列表显示预览"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
+msgid "Change charge in all modules of the same type"
+msgstr "同时更换所有同类型模块的弹药"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
+msgid ""
+"When disabled, reloads charges just in selected modules. Action can be "
+"reversed by holding Ctrl or Alt key while changing charge."
+msgstr ""
+"关闭该选项时，更换弹药仅更换选中的模块。按住Ctrl或Alt以更换所有同类型武器弹"
+"药。"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
+msgid "Extra info in Additions panel tab names"
+msgstr "附加装备标签名显示额外信息"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/characterEditor.py:855
+msgid "None"
+msgstr "无"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of active items"
+msgstr "激活的物品数量"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of all items"
+msgstr "所有物品数量"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
+msgid "Language (restart required):"
+msgstr "语言（重启后生效）："
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:19
 msgid "HTML Export"
 msgstr "HTML导出"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:18
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:20
 msgid ""
 "HTML Export (File > Export HTML) allows you to export your entire fitting "
 "database into an HTML file at the specified location. This file can be used "
@@ -496,7 +442,7 @@ msgstr ""
 "路径下。This file can be used to easily open your fits in a web-based "
 "fitting program"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:21
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
 msgid ""
 "Export Fittings in a minimal HTML Version, just containing the fittings "
 "links without any visual styling"
@@ -517,13 +463,265 @@ msgstr "设置导出路径"
 
 #: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
 msgid "Enable minimal format"
-msgstr "使用极简版风格"
+msgstr "使用极简风格"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:12
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
+msgid "Logging"
+msgstr "日志"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
+msgid "Log file location:"
+msgstr "日志文件路径："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
+msgid "Cert Path:"
+msgstr "证书路径："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
+msgid "Debug Logging Enabled"
+msgstr "调试日子已开启"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
+msgid ""
+"Pressing this button will cause all logs in memory to write to the log file:"
+msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
+msgid "Dump All Logs"
+msgstr "将所有日志写入文件"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:23
+msgid "Market & Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:30
+msgid "Market && Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
+msgid "Market Search Delay (ms):"
+msgstr "市场搜索延迟（毫秒）："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
+msgid ""
+"The delay between a keystroke and the market search. Can help reduce lag "
+"when typing fast in the market search box."
+msgstr ""
+"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
+msgid "Show market shortcuts"
+msgstr "显示市场快捷方式"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
+msgid "Default Market Prices:"
+msgstr "默认价格源："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
+msgid ""
+"The source you choose will be tried first, but subsequent sources will be "
+"used if the preferred source fails. The system you choose will also be tried "
+"first, and if no data is available, global price will be used."
+msgstr ""
+"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
+"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
+msgid "Total Price Includes"
+msgstr "价格总计包括"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
+msgid "Implants && Boosters"
+msgstr "植入体和增效剂"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
+msgid "Market Search && Recent Items"
+msgstr "搜索和显示最近使用列表时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "No changes to meta buttons"
+msgstr "不改变衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+msgid "Enable all meta buttons for a duration of search / recents"
+msgstr "一段时间内启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
+msgid "Enable all meta buttons"
+msgstr "启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
+msgid "Market Group Selection"
+msgstr "选择物品类别时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
+msgid "Empty Market View"
+msgstr "空白搜索结果时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable leftmost available meta button"
+msgstr "启用最左侧可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable all available meta buttons"
+msgstr "启用所有可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
+msgid "Item Market Group Jump"
+msgstr "切换物品分类时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button"
+msgstr "启用该物品所在衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button, disable others"
+msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
+msgid "Network"
+msgstr "网络"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:33
+msgid "Enable Network"
+msgstr "启用网络功能"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:37
+msgid "EVE Servers (API && CREST import)"
+msgstr "连接到EvE服务器（API 和 CREST 导入）"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:41
+msgid "Pricing updates"
+msgstr "价格更新"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:44
+msgid "Pyfa Update checks"
+msgstr "Pyfa更新检查"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:49
+msgid "Proxy settings"
+msgstr "代理设置"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:83
+msgid "Mode:"
+msgstr "模式"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "No proxy"
+msgstr "无代理"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Auto-detected proxy settings"
+msgstr "自动检测代理设置"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Manual proxy settings"
+msgstr "手动配置代理"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:101
+msgid "Addr:"
+msgstr "地址："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:109
+msgid "Port:"
+msgstr "端口："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:121
+msgid "Username:"
+msgstr "用户名："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:125
+msgid "Password:"
+msgstr "密码："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:136
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:158
+msgid "Auto-detected: "
+msgstr "自动检测结果："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:144
+msgid "Apply Proxy Settings"
+msgstr "应用代理配置"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
+msgid "Statistics Panel"
+msgstr "属性面板"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
+msgid "Changes require restart of pyfa to take effect."
+msgstr "变更将在重启Pyfa之后生效。"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinStatsViews/resourcesViewFull.py:84
+msgid "Resources"
+msgstr "装配资源"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+msgid "Minimal"
+msgstr "简洁"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+msgid "Full"
+msgstr "完整"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinStatsViews/resistancesViewFull.py:47
+msgid "Resistances"
+msgstr "抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+msgid "Shield/Armor Tank"
+msgstr "恢复"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinStatsViews/firepowerViewFull.py:43
+msgid "Firepower"
+msgstr "火力"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinStatsViews/capacitorViewFull.py:37
+msgid "Capacitor"
+msgstr "电容"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Misc"
+msgstr "其他"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinStatsViews/priceViewFull.py:40
+msgid "Price"
+msgstr "价格"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinStatsViews/outgoingViewFull.py:66
+#: gui/builtinStatsViews/outgoingViewMinimal.py:65
+msgid "Remote Reps"
+msgstr "遥修"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
 msgid "Updates"
 msgstr "更新"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:13
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
 msgid ""
 "Pyfa can automatically check and notify you of new releases. This feature is "
 "toggled in the Network settings. Here, you may allow pre-release "
@@ -549,396 +747,575 @@ msgid ""
 msgstr ""
 "当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
 
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
+#: gui/updateDialog.py:113
+msgid "Download"
+msgstr "下载"
+
 #: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
 msgid "Reset Suppression"
 msgstr "重置版本更新提示"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:17
-msgid "Logging"
-msgstr "日志"
+#: gui/builtinShipBrowser/navigationPanel.py:48
+msgid "Ship groups"
+msgstr "舰船类型"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
-msgid "Log file location:"
-msgstr "日志文件路径："
+#: gui/builtinShipBrowser/navigationPanel.py:50
+msgid "Back"
+msgstr "返回"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
-msgid "Cert Path:"
-msgstr "证书路径"
+#: gui/builtinShipBrowser/navigationPanel.py:51
+msgid "New fitting"
+msgstr "新装配"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
-msgid "Debug Logging Enabled"
-msgstr "调试日子已开启"
+#: gui/builtinShipBrowser/navigationPanel.py:53
+#: gui/builtinShipBrowser/navigationPanel.py:147
+msgid "Hide empty ship groups"
+msgstr "隐藏空的舰船类型"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
-msgid ""
-"Pressing this button will cause all logs in memory to write to the log file:"
-msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+#: gui/builtinShipBrowser/navigationPanel.py:56
+#: gui/builtinShipBrowser/navigationPanel.py:129
+msgid "Recent Fits"
+msgstr "最近使用的装配"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
-msgid "Dump All Logs"
-msgstr "将所有日志写入文件"
+#: gui/builtinShipBrowser/navigationPanel.py:61
+msgid "Search fittings"
+msgstr "搜索装配"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:18
-msgid "Market & Prices"
-msgstr "市场和价格"
+#: gui/builtinShipBrowser/navigationPanel.py:136
+msgid "Hide Recent Fits"
+msgstr "隐藏最近使用的装配"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:30
-msgid "Market && Prices"
-msgstr "市场和价格"
+#: gui/builtinShipBrowser/navigationPanel.py:151
+msgid "Show empty ship groups"
+msgstr "显示空的舰船类型"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
-msgid "Market Search Delay (ms):"
-msgstr "市场搜索延迟（毫秒）："
+#: gui/builtinStatsViews/capacitorViewFull.py:57
+msgid "Capacitor stability"
+msgstr "电容稳定性"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
-msgid ""
-"The delay between a keystroke and the market search. Can help reduce lag "
-"when typing fast in the market search box."
-msgstr ""
-"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
+#: gui/builtinStatsViews/capacitorViewFull.py:67
+msgid "Total: "
+msgstr "总计："
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
-msgid "Show market shortcuts"
-msgstr ""
+#: gui/builtinStatsViews/capacitorViewFull.py:77
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Lasts "
+msgstr "可维持"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
-msgid "Default Market Prices:"
-msgstr "默认价格源："
+#: gui/builtinStatsViews/capacitorViewFull.py:81
+msgid "0s"
+msgstr "0秒"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
-msgid ""
-"The source you choose will be tried first, but subsequent sources will be "
-"used if the preferred source fails. The system you choose will also be tried "
-"first, and if no data is available, global price will be used."
-msgstr ""
-"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
-"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
+#: gui/builtinStatsViews/capacitorViewFull.py:90
+msgid "Extra stats"
+msgstr "额外状态"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
-msgid "Total Price Includes"
-msgstr "价格总计包括"
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Stable: "
+msgstr "稳定："
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
-#: gui/additionsPane.py:66
-msgid "Drones"
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Weapon"
+msgstr "武器"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Drone"
 msgstr "无人机"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
-#: gui/additionsPane.py:72 gui/builtinStatsViews/targetingMiscViewMinimal.py:88
-msgid "Cargo"
+#: gui/builtinStatsViews/firepowerViewFull.py:100
+msgid " Volley: "
+msgstr "齐射"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:107
+msgid " DPS: "
+msgstr " DPS: "
+
+#: gui/builtinStatsViews/firepowerViewFull.py:115
+msgid "Click to toggle to Mining Yield"
+msgstr "点击切换到矿物产出视图"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:39
+msgid "Mining Yield"
+msgstr "矿物产出"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:89
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+msgid "Total"
+msgstr "总计"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:102
+msgid "Click to toggle to Firepower View"
+msgstr "点击切换到火力视图"
+
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+msgid "Ship"
+msgstr "船体"
+
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57 gui/mainFrame.py:186
+msgid "Fittings"
+msgstr "装配"
+
+#: gui/builtinStatsViews/priceViewFull.py:57 gui/characterEditor.py:90
+#: gui/esiFittings.py:341
+msgid "Character"
+msgstr "角色"
+
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/resourcesViewFull.py:158
+msgid "Cargo bay"
 msgstr "货舱"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
-msgid "Implants && Boosters"
-msgstr "植入体和增效剂"
+#: gui/builtinStatsViews/rechargeViewFull.py:43
+msgid "Recharge rates"
+msgstr "回充速度"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
-msgid "Market Search && Recent Items"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:75
+msgid "Passive shield recharge"
+msgstr "被动回充"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "No changes to meta buttons"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:76
+msgid "Active shield boost"
+msgstr "主动维修"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-msgid "Enable all meta buttons for a duration of search / recents"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:77
+msgid "Armor repair amount"
+msgstr "装甲修量"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
-msgid "Enable all meta buttons"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:78
+msgid "Hull repair amount"
+msgstr "结构修量"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
-msgid "Market Group Selection"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:86
+msgid "Reinforced"
+msgstr "加强回充"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
-msgid "Empty Market View"
-msgstr ""
+#: gui/builtinStatsViews/rechargeViewFull.py:87
+msgid "Sustained"
+msgstr "持续回充"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable leftmost available meta button"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:61
+#: gui/builtinStatsViews/resistancesViewFull.py:219
+msgid "Effective HP: "
+msgstr "有效HP："
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable all available meta buttons"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:85
+msgid "Electromagnetic resistance"
+msgstr "电磁抗性"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
-msgid "Item Market Group Jump"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:86
+#: gui/targetProfileEditor.py:120
+msgid "Thermal resistance"
+msgstr "热能抗性"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:87
+#: gui/targetProfileEditor.py:121
+msgid "Kinetic resistance"
+msgstr "动能抗性"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button, disable others"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:88
+#: gui/targetProfileEditor.py:122
+msgid "Explosive resistance"
+msgstr "爆炸抗性"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:33
-msgid ""
-"Please see the pyfa wiki on GitHub for information regarding these options."
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:96
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "EHP"
+msgstr "有效HP"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
-msgid "Login Authentication Method"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:97
+#: gui/builtinStatsViews/resistancesViewFull.py:169
+msgid "Click to toggle between effective HP and raw HP"
+msgstr "点击切换有效HP和原始HP"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
-msgid "Local Server"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:112
+msgid "Shield resistance"
+msgstr "护盾抗性"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
-msgid "Manual"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:113
+msgid "Armor resistance"
+msgstr "装甲抗性"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:41
-msgid ""
-"This options starts a local webserver that the web application will call "
-"back to with information about the character login."
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:114
+msgid "Hull resistance"
+msgstr "结构抗性"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:43
-msgid ""
-"This option prompts users to copy and paste information from the web "
-"application to allow for character login. Use this if having issues with the "
-"local server."
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
-msgid "SSO Mode"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
-msgid "pyfa.io"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
-#, fuzzy
-#| msgid "Calibration"
-msgid "Custom application"
-msgstr "校准"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:48
-msgid ""
-"This options routes SSO Logins through pyfa.io, allowing you to easily login "
-"without any configuration. When in doubt, use this option."
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:50
-msgid ""
-"This option goes through EVE SSO directly, but requires more configuration. "
-"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
-"route data throguh pyfa.io."
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:64
-msgid "Custom Application"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:77
-msgid "Client ID:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:86
-msgid "Client Secret:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:19
-#, fuzzy
-#| msgid "Fittings"
-msgid "Fitting Engine"
-msgstr "装配列表"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:45
-msgid ""
-"Factor in reload time when calculating capacitor usage, damage, and tank."
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:51
-msgid "Enforce strict skill level requirements"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:55
-msgid ""
-"When enabled, skills will check their dependencies' requirements when their "
-"levels change and reset skills that no longer meet the requirement.\n"
-"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
-"skill, as that requires Drones V"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:62
-msgid ""
-"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
-"behavior)."
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:69
-msgid "Global Default Spoolup Percentage:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:73
-msgid ""
-"The amount of spoolup to use by default on module which support it. Can be "
-"changed on a per-module basis"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:15
-msgid "General"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
-#, fuzzy
-#| msgid "Remove Character"
-msgid "Use global character"
-msgstr "删除角色"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
-msgid "Use character implants by default for new fits"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
-#, fuzzy
-#| msgid "Incoming damage pattern"
-msgid "Use global damage pattern"
+#: gui/builtinStatsViews/resistancesViewFull.py:115
+msgid "Incoming damage pattern"
 msgstr "伤害分布"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
-#, fuzzy
-#| msgid "Export skills needed for this fitting"
-msgid "Compact skills needed tooltip"
-msgstr "导出使用本装配所需技能"
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "HP"
+msgstr "原始HP"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
-msgid "Color fitting view by slot"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Shield: "
+msgstr "护盾："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
-msgid "Reopen previous fits on startup"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Armor: "
+msgstr "装甲："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
-msgid "Separate Racks"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Hull: "
+msgstr "结构："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
-msgid "Show Rack Labels"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:213
+msgid "Resist Multiplier: "
+msgstr "抗性倍率："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
-msgid "Show fitting tab tooltips"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:220
+#, python-format
+msgid "Effective: %d HP"
+msgstr "有效：%dHP"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
-msgid "Animate gauges"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:222
+msgid "Raw HP: "
+msgstr "原始HP："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
-msgid "Open fittings in a new page by default"
-msgstr ""
+#: gui/builtinStatsViews/resistancesViewFull.py:223
+#, python-format
+msgid "Raw: %d HP"
+msgstr "原始：%dHP"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
-msgid "Show ship browser tooltip"
-msgstr ""
+#: gui/builtinStatsViews/resourcesViewFull.py:111
+msgid "Turret hardpoints"
+msgstr "炮台"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
-msgid "Change charge in all modules of the same type"
-msgstr ""
+#: gui/builtinStatsViews/resourcesViewFull.py:112
+msgid "Launcher hardpoints"
+msgstr "发射器"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
+#: gui/builtinStatsViews/resourcesViewFull.py:113
+msgid "Drones active"
+msgstr "激活的无人机"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:114
+msgid "Fighter squadrons active"
+msgstr "激活的铁骑舰载机中队"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:115
+msgid "Calibration"
+msgstr "校准"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:153
+msgid "CPU"
+msgstr "CPU"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:154
+msgid "PowerGrid"
+msgstr "PG"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:155
+msgid "Drone bay"
+msgstr "无人机仓库"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:156
+msgid "Fighter bay"
+msgstr "铁骑舰载机仓库"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:157
+msgid "Drone bandwidth"
+msgstr "无人机带宽"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:38
+msgid "Targeting && Misc"
+msgstr "目标和其他"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:60
+msgid "Targets"
+msgstr "最大锁定数"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:61
+msgid "Range"
+msgstr "锁定范围"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
+msgid "Scan res."
+msgstr "扫描精度"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
+msgid "Sensor str."
+msgstr "传感器强度"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
+msgid "Drone range"
+msgstr "无人机半径"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:84
+msgid "Speed"
+msgstr "亚光速航速"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:85
+msgid "Align time"
+msgstr "起跳时间"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
+msgid "Signature"
+msgstr "信号半径"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
+msgid "Warp Speed"
+msgstr "曲速航速"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:110
+msgid "Fleet hangar"
+msgstr "舰队机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:111
+msgid "Maintenance bay"
+msgstr "维护舱"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:112
+msgid "Ammo hold"
+msgstr "弹药仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
+msgid "Fuel bay"
+msgstr "燃料仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
+msgid "Ship hold"
+msgstr "舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
+msgid "Small ship hold"
+msgstr "小型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
+msgid "Medium ship hold"
+msgstr "中型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
+msgid "Large ship hold"
+msgstr "大型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
+msgid "Industrial ship hold"
+msgstr "工业舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
+msgid "Ore hold"
+msgstr "矿石仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
+msgid "Mineral hold"
+msgstr "矿物仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
+msgid "Material bay"
+msgstr "物料仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
+msgid "Gas hold"
+msgstr "气体矿物仓库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
+msgid "Salvage hold"
+msgstr "打捞件仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
+msgid "Command center hold"
+msgstr "指挥中心仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
+msgid "Planetary goods hold"
+msgstr "星系物质仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
+msgid "Quafe hold"
+msgstr "酷菲(Quafe)仓"
+
+#: gui/characterEditor.py:76
+msgid "You must supply a name for the Character!"
+msgstr "您必须填写一个角色名！"
+
+#: gui/characterEditor.py:78
+msgid "Character name already in use, please choose another."
+msgstr "角色名已占用，请使用其他名称。"
+
+#: gui/characterEditor.py:83 gui/characterEditor.py:463
+#: gui/characterEditor.py:898 gui/characterSelection.py:174
+#: gui/mainFrame.py:897 gui/patternEditor.py:58 gui/setEditor.py:55
+#: gui/targetProfileEditor.py:78
+msgid "Error"
+msgstr "错误"
+
+#: gui/characterEditor.py:137
+msgid "Character Editor"
+msgstr "角色编辑器"
+
+#: gui/characterEditor.py:160
+msgid "Skills"
+msgstr "技能列表"
+
+#: gui/characterEditor.py:281
+msgid "Enter a name for your new Character:"
+msgstr "请为新角色输入一个名称："
+
+#: gui/characterEditor.py:282
+msgid "Save Character As..."
+msgstr "保存角色为..."
+
+#: gui/characterEditor.py:284
+msgid "{} Copy"
+msgstr "复制{}"
+
+#: gui/characterEditor.py:326
 msgid ""
-"When disabled, reloads charges just in selected modules. Action can be "
-"reversed by holding Ctrl or Alt key while changing charge."
+"Setting an Alpha clone does not replace the character's skills, but rather "
+"caps them to Alpha levels."
 msgstr ""
+"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
-msgid "Extra info in Additions panel tab names"
+#: gui/characterEditor.py:342
+msgid "Skill"
+msgstr "技能"
+
+#: gui/characterEditor.py:343
+msgid "Level"
+msgstr "技能等级"
+
+#: gui/characterEditor.py:356
+#, python-brace-format
+msgid "Sec Status: {0:.2f}"
+msgstr "安全等级: {0:.2f}"
+
+#: gui/characterEditor.py:372
+msgid "Import skills from clipboard"
+msgstr "从剪贴板导入技能列表"
+
+#: gui/characterEditor.py:373
+msgid "Export skills from clipboard"
+msgstr "导出技能列表到剪贴板"
+
+#: gui/characterEditor.py:440
+msgid ""
+"Importing skills into this character will set the skill levels as pending. "
+"To save the skills permanently, please click the Save button at the bottom "
+"of the window after importing"
 msgstr ""
+"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
+"窗口底部的保存按钮"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of active items"
+#: gui/characterEditor.py:442
+msgid "Import Skills"
+msgstr "导入技能"
+
+#: gui/characterEditor.py:463
+msgid "There was an error importing skills, please see log file"
+msgstr "导入技能列表出错，详见日志文件"
+
+#: gui/characterEditor.py:532
+msgid "Level {}d"
+msgstr "等级{}d"
+
+#: gui/characterEditor.py:591 gui/characterEditor.py:616
+#: gui/characterEditor.py:649
+msgid "Level {}"
+msgstr "等级{}"
+
+#: gui/characterEditor.py:614
+msgid "Unlearn"
+msgstr "未学习"
+
+#: gui/characterEditor.py:757
+msgid "You cannot link All 0 or All 5 characters to an EVE character."
+msgstr "你不能关联全0级或全5级到一个EvE角色。"
+
+#: gui/characterEditor.py:758
+msgid "Please select another character or make a new one."
+msgstr "请选择另一角色或创建新角色。"
+
+#: gui/characterEditor.py:771
+msgid "Character:"
+msgstr "角色："
+
+#: gui/characterEditor.py:778
+msgid "Get Skills"
+msgstr "获取技能列表"
+
+#: gui/characterEditor.py:789
+msgid "Don't see your EVE character in the list?"
+msgstr "列表中没有你的EvE角色？"
+
+#: gui/characterEditor.py:794
+msgid "Log In with EVE SSO"
+msgstr "通过EVE登录"
+
+#: gui/characterEditor.py:897 gui/characterSelection.py:173
+msgid "Error fetching skill information"
+msgstr "无法获取技能信息"
+
+#: gui/characterEditor.py:901
+msgid "Successfully fetched skills"
+msgstr "成功获取到技能列表"
+
+#: gui/characterEditor.py:901
+msgid "Success"
+msgstr "成功"
+
+#: gui/characterEditor.py:907
+msgid "Set Security Status"
+msgstr "设置安全等级"
+
+#: gui/characterEditor.py:914
+msgid "Security Status is used in some CONCORD hull calculations"
+msgstr "安全等级会用于计算CONCORD警察船体属性"
+
+#: gui/characterSelection.py:47
+msgid "Character: "
+msgstr "角色："
+
+#: gui/characterSelection.py:68
+msgid "Refresh Skills"
+msgstr "刷新技能"
+
+#: gui/characterSelection.py:102
+msgid "Grant Missing Skills"
+msgstr "习得所需技能"
+
+#: gui/characterSelection.py:105
+msgid "Copy Missing Skills"
+msgstr "复制所需技能"
+
+#: gui/characterSelection.py:150
+msgid "Open Character Editor"
+msgstr "打开角色编辑器"
+
+#: gui/characterSelection.py:230
+msgid "No active fit"
+msgstr "没有选中的装配"
+
+#: gui/characterSelection.py:238
+msgid "All skill prerequisites have been met"
+msgstr "已达到所有技能要求"
+
+#: gui/characterSelection.py:242
+msgid "Skills required:"
+msgstr "所需技能："
+
+#: gui/errorDialog.py:68
+msgid "Error!"
+msgstr "错误！"
+
+#: gui/errorDialog.py:69
+msgid "pyfa error"
+msgstr "Pyfa错误"
+
+#: gui/errorDialog.py:76
+msgid ""
+"pyfa has experienced an unexpected issue. Below is a message that contains "
+"crucial \n"
+"information about how this was triggered. Please contact the developers with "
+"the \n"
+"information provided through the EVE Online forums or file a GitHub issue."
 msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of all items"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
-msgid "Language (restart required): "
-msgstr "语言（重启后生效）："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:15
-msgid "Network"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:34
-msgid "Enable Network"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:38
-msgid "EVE Servers (API && CREST import)"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:42
-msgid "Pricing updates"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:45
-msgid "Pyfa Update checks"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:50
-#, fuzzy
-#| msgid "Browse EVE Fittings"
-msgid "Proxy settings"
-msgstr "浏览游戏内装配"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:84
-msgid "Mode:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
-msgid "No proxy"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
-msgid "Auto-detected proxy settings"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
-msgid "Manual proxy settings"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:102
-msgid "Addr:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:110
-msgid "Port:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:122
-msgid "Username:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:126
-msgid "Password:"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:137
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:159
-msgid "Auto-detected: "
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:145
-msgid "Apply Proxy Settings"
-msgstr ""
+"Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
+"请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
 
 #: gui/esiFittings.py:32
 msgid "Browse EVE Fittings"
@@ -971,6 +1348,10 @@ msgstr "连接错误，请检查您的网络连接"
 #: gui/esiFittings.py:156
 msgid "Do you really want to delete {} ({}) from EVE?"
 msgstr "真的要从游戏内删除 {} ({})吗？"
+
+#: gui/esiFittings.py:157 gui/propertyEditor.py:148
+msgid "Confirm Delete"
+msgstr "删除确认"
 
 #: gui/esiFittings.py:179
 msgid ""
@@ -1040,413 +1421,200 @@ msgstr "添加角色"
 msgid "Remove Character"
 msgstr "删除角色"
 
-#: gui/aboutData.py:31
-msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
-msgstr ""
-"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
-
-#: gui/aboutData.py:32
-msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有"
-
-#: gui/aboutData.py:33
-msgid ""
-"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
-msgstr ""
-
-#: gui/aboutData.py:34
-msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
-msgstr ""
-
-#: gui/aboutData.py:49
-msgid ""
-"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
-"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
-"high degree of accuracy. Pyfa can run on all platforms where Python and "
-"wxWidgets are supported."
-msgstr ""
-"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
-"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
-"wxWidgets支持的所有平台运行。"
-
-#: gui/characterSelection.py:47
-msgid "Character: "
-msgstr "角色："
-
-#: gui/characterSelection.py:68
-msgid "Refresh Skills"
-msgstr "刷新技能"
-
-#: gui/characterSelection.py:102
-msgid "Grant Missing Skills"
-msgstr ""
-
-#: gui/characterSelection.py:105
-msgid "Copy Missing Skills"
-msgstr "复制所需技能"
-
-#: gui/characterSelection.py:150
-msgid "Open Character Editor"
-msgstr "打开角色编辑器"
-
-#: gui/characterSelection.py:230
-msgid "No active fit"
-msgstr "没有选中的装配"
-
-#: gui/characterSelection.py:238
-msgid "All skill prerequisites have been met"
-msgstr "已达到所有技能要求"
-
-#: gui/characterSelection.py:242
-msgid "Skills required:"
-msgstr "所需技能："
-
-#: gui/patternEditor.py:51
-msgid "You must supply a name for your Damage Profile!"
-msgstr "您必须填写一个伤害模型名！"
-
-#: gui/patternEditor.py:53
-msgid "Damage Profile name already in use, please choose another."
-msgstr "伤害模型名已占用，请使用其他名称。"
-
-#: gui/patternEditor.py:65
-msgid "Damage Profile"
-msgstr "伤害模型"
-
-#: gui/patternEditor.py:99
-msgid "Damage Pattern Editor"
-msgstr "伤害模型编辑器"
-
-#: gui/patternEditor.py:171
-#, fuzzy
-#| msgid "Import a fit from the clipboard"
-msgid "Import patterns from clipboard"
-msgstr "从剪贴板导入装配"
-
-#: gui/patternEditor.py:172
-#, fuzzy
-#| msgid "Export a fit to the clipboard"
-msgid "Export patterns to clipboard"
-msgstr "导出装配到剪贴板"
-
-#: gui/patternEditor.py:276 gui/setEditor.py:210
-msgid "Patterns successfully imported from clipboard"
-msgstr "从剪贴板导入伤害模型成功"
-
-#: gui/patternEditor.py:283 gui/setEditor.py:218
-msgid "Could not import from clipboard: unknown errors"
-msgstr "无法从剪贴板导入：未知错误"
-
-#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
-msgid "Could not import from clipboard"
-msgstr "无法从剪贴板导入"
-
-#: gui/patternEditor.py:295
-msgid "Patterns exported to clipboard"
-msgstr "伤害模型已导出到剪贴板"
-
-#: gui/additionsPane.py:45
-msgid "Additions"
-msgstr "附加装备"
-
-#: gui/additionsPane.py:69
-msgid "Fighters"
-msgstr "铁骑舰载机"
-
-#: gui/additionsPane.py:78
-msgid "Boosters"
-msgstr "增效剂"
-
-#: gui/additionsPane.py:81
-msgid "Projected"
-msgstr "环境效果"
-
-#: gui/additionsPane.py:84
-msgid "Command"
-msgstr "指令"
-
-#: gui/additionsPane.py:87
-msgid "Notes"
-msgstr "备注"
-
 #: gui/fitBrowserLite.py:17
 msgid "Add Fits"
 msgstr "添加装配"
 
-#: gui/builtinStatsViews/rechargeViewFull.py:43
-msgid "Recharge rates"
-msgstr "回充速度"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:75
-msgid "Passive shield recharge"
-msgstr "被动回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:76
-msgid "Active shield boost"
-msgstr "主动维修"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:77
-msgid "Armor repair amount"
-msgstr "装甲修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:78
-msgid "Hull repair amount"
-msgstr "结构修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:86
-msgid "Reinforced"
-msgstr "加强回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:87
-msgid "Sustained"
-msgstr "持续回充"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:57
-msgid "Capacitor stability"
-msgstr "电容稳定性"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:67
-msgid "Total: "
-msgstr "总容量："
-
-#: gui/builtinStatsViews/capacitorViewFull.py:77
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Lasts "
-msgstr "可维持"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:81
-msgid "0s"
-msgstr "0秒"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:90
-msgid "Extra stats"
-msgstr "额外状态"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Stable: "
-msgstr "稳定："
-
-#: gui/builtinStatsViews/firepowerViewFull.py:100
-msgid " Volley: "
-msgstr "齐射"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:107
-msgid " DPS: "
-msgstr " DPS: "
-
-#: gui/builtinStatsViews/firepowerViewFull.py:115
-msgid "Click to toggle to Mining Yield "
-msgstr "点击切换到矿物产出视图"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:111
-msgid "Turret hardpoints"
-msgstr "炮台"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:112
-msgid "Launcher hardpoints"
-msgstr "发射器"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:113
-msgid "Drones active"
-msgstr "激活的无人机"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:114
-msgid "Fighter squadrons active"
-msgstr "激活的铁骑舰载机中队"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:115
-msgid "Calibration"
-msgstr "校准"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:153
-msgid "CPU"
-msgstr "CPU"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:154
-msgid "PowerGrid"
-msgstr "PG"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:155
-msgid "Drone bay"
-msgstr "无人机仓库"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:156
-msgid "Fighter bay"
-msgstr "铁骑舰载机仓库"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:157
-msgid "Drone bandwidth"
-msgstr "无人机带宽"
+#: gui/itemStats.py:58
+msgid "Item stats"
+msgstr "物品属性"
+
+#: gui/itemStats.py:87
+#, python-brace-format
+msgid "{context}Stats: {name}{debug_info}"
+msgstr "{context}属性：{name}{debug_info}"
+
+#: gui/itemStats.py:166
+msgid "Traits"
+msgstr "特征"
+
+#: gui/itemStats.py:170
+msgid "Mutations"
+msgstr "变质"
+
+#: gui/itemStats.py:174
+msgid "Description"
+msgstr "简介"
+
+#: gui/itemStats.py:177
+msgid "Attributes"
+msgstr "属性"
+
+#: gui/itemStats.py:182
+msgid "Compare"
+msgstr "对比"
+
+#: gui/itemStats.py:185
+msgid "Requirements"
+msgstr "技能需求"
+
+#: gui/itemStats.py:189
+msgid "Dependents"
+msgstr "依赖"
+
+#: gui/itemStats.py:192
+msgid "Effects"
+msgstr "效果"
+
+#: gui/itemStats.py:196
+msgid "Affected by"
+msgstr "影响因素"
+
+#: gui/itemStats.py:200
+msgid "Properties"
+msgstr "属性"
+
+#: gui/mainFrame.py:182
+msgid "Market"
+msgstr "市场"
+
+#: gui/mainFrame.py:273
+msgid "Loading previous fits..."
+msgstr "正在打开之前的装配..."
+
+#: gui/mainFrame.py:467
+msgid "EVE XML fitting files (*.xml)|*.xml"
+msgstr "EvE装配XML文件 (*.xml)|*.xml"
+
+#: gui/mainFrame.py:646
+msgid ""
+"Are you sure you wish to ignore fitting restrictions for the current fit? "
+"This could lead to wildly inaccurate results and possible errors."
+msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
+
+#: gui/mainFrame.py:653
+msgid ""
+"Re-enabling fitting restrictions for this fit will also remove any illegal "
+"items from the fit. Do you want to continue?"
+msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
+
+#: gui/mainFrame.py:672
+msgid "Manage Characters"
+msgstr "管理角色"
+
+#: gui/mainFrame.py:689
+msgid "&Turn Overrides Off"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainFrame.py:689 gui/mainMenuBar.py:131
+msgid "&Turn Overrides On"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainFrame.py:722
+msgid "Please Wait..."
+msgstr "请稍候..."
+
+#: gui/mainFrame.py:806
+msgid "Export Skills Needed As..."
+msgstr "导出所需技能列表到..."
+
+#: gui/mainFrame.py:808
+msgid "EVEMon skills training file"
+msgstr "EvEMon技能训练文件"
+
+#: gui/mainFrame.py:809
+msgid "EVEMon skills training XML file"
+msgstr "EvEMon技能训练XML文件"
+
+#: gui/mainFrame.py:810
+msgid "Text skills training file"
+msgstr "技能列表文本文件"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:158
-msgid "Cargo bay"
-msgstr "货舱"
+#: gui/mainFrame.py:828
+msgid "Exporting skills needed..."
+msgstr "正在导出所需技能..."
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:38
-msgid "Targeting && Misc"
-msgstr "目标锁定和其他"
+#: gui/mainFrame.py:835
+msgid "Open One Or More Fitting Files"
+msgstr "打开多个装配文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:60
-msgid "Targets"
-msgstr "最大锁定数"
+#: gui/mainFrame.py:837
+msgid "EVE XML fitting files"
+msgstr "EvE装配XML文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:61
-msgid "Range"
-msgstr "锁定范围"
+#: gui/mainFrame.py:838
+msgid "EFT text fitting files"
+msgstr "EFT装配文本文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
-msgid "Scan res."
-msgstr "扫描精度"
+#: gui/mainFrame.py:839 gui/mainFrame.py:1014
+msgid "All Files"
+msgstr "所有文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
-msgid "Sensor str."
-msgstr "传感器强度"
+#: gui/mainFrame.py:845
+msgid "Importing fits"
+msgstr "正在导入装配"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
-msgid "Drone range"
-msgstr "无人机半径"
+#: gui/mainFrame.py:859
+msgid "Save Backup As..."
+msgstr "保存备份为..."
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:84
-msgid "Speed"
-msgstr "亚光速航速"
+#: gui/mainFrame.py:860
+msgid "EVE XML fitting file"
+msgstr "EvE装配XML文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:85
-msgid "Align time"
-msgstr "起跳时间"
+#: gui/mainFrame.py:873 gui/mainFrame.py:904
+msgid "Backup fits"
+msgstr "备份装配"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
-msgid "Signature"
-msgstr "信号半径"
+#: gui/mainFrame.py:874
+msgid "Backing up {} fits to: {}"
+msgstr "正在备份{}个装配到：{}"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
-msgid "Warp Speed"
-msgstr "曲速航速"
+#: gui/mainFrame.py:893
+msgid "Invalid Path"
+msgstr "无效路径"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:110
-msgid "Fleet hangar"
-msgstr "舰队机库"
+#: gui/mainFrame.py:894
+msgid "The following path is invalid or does not exist:"
+msgstr "下述路径无效或不存在："
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:111
-msgid "Maintenance bay"
-msgstr "维护机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:112
-msgid "Ammo hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
-msgid "Fuel bay"
-msgstr "燃料机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
-msgid "Ship hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
-msgid "Small ship hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
-msgid "Medium ship hold"
-msgstr "中型舰船机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
-msgid "Large ship hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
-msgid "Industrial ship hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
-msgid "Ore hold"
-msgstr "矿石机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
-msgid "Mineral hold"
-msgstr "矿物机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
-msgid "Material bay"
-msgstr "矿物机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
-msgid "Gas hold"
-msgstr "气态矿物仓库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
-msgid "Salvage hold"
-msgstr "打捞件机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
-msgid "Command center hold"
-msgstr ""
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
-msgid "Planetary goods hold"
-msgstr "星系开发机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
-msgid "Quafe hold"
-msgstr ""
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:39
-msgid "Mining Yield"
-msgstr "矿物产出"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:89
-msgid "Total"
-msgstr "总容量"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:102
-msgid "Click to toggle to Firepower View"
-msgstr "点击切换到火力视图"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:61
-msgid "Effective HP"
-msgstr "有效HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:85
-msgid "Electromagnetic resistance"
-msgstr "电磁抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:86
-#: gui/targetProfileEditor.py:120
-msgid "Thermal resistance"
-msgstr "热能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:87
-#: gui/targetProfileEditor.py:121
-msgid "Kinetic resistance"
-msgstr "动能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:88
-#: gui/targetProfileEditor.py:122
-msgid "Explosive resistance"
-msgstr "爆炸抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:97
-#: gui/builtinStatsViews/resistancesViewFull.py:169
-msgid "Click to toggle between effective HP and raw HP"
-msgstr "点击切换有效HP和原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:112
-msgid "Shield resistance"
-msgstr "护盾抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:113
-msgid "Armor resistance"
-msgstr "装甲抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:114
-msgid "Hull resistance"
-msgstr "结构抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:115
-msgid "Incoming damage pattern"
-msgstr "伤害分布"
-
-#: gui/mainMenuBar.py:66
+#: gui/mainFrame.py:896
+msgid "Please verify path location pyfa's preferences."
+msgstr "请确认Pyfa偏好保存位置。"
+
+#: gui/mainFrame.py:905
+msgid "Generating HTML file at: {}"
+msgstr "正在生成网页到：{}"
+
+#: gui/mainFrame.py:947
+msgid "Import Error"
+msgstr "导入错误"
+
+#: gui/mainFrame.py:947
+msgid "Export Error"
+msgstr "导出错误"
+
+#: gui/mainFrame.py:950
+msgid "The following error was generated"
+msgstr "Pyfa 遇到以下错误"
+
+#: gui/mainFrame.py:952
+msgid "Be aware that already processed fits were not saved"
+msgstr "请注意已处理的装配未作保存"
+
+#: gui/mainFrame.py:1011
+msgid "Open One Or More Character Files"
+msgstr "打开多个角色文件"
+
+#: gui/mainFrame.py:1013
+msgid "EVE API XML character files"
+msgstr "EvE API XML角色文件"
+
+#: gui/mainFrame.py:1020
+msgid "Importing Character..."
+msgstr "正在导入角色..."
+
+#: gui/mainMenuBar.py:66 gui/propertyEditor.py:43
 msgid "&File"
 msgstr "文件(&F)"
 
@@ -1590,10 +1758,6 @@ msgstr "管理游戏内角色(&M)"
 msgid "Attribute &Overrides"
 msgstr "自定义属性(&O)"
 
-#: gui/mainMenuBar.py:131 gui/mainFrame.py:689
-msgid "&Turn Overrides On"
-msgstr "启用自定义属性(&T)"
-
 #: gui/mainMenuBar.py:135
 msgid "&Global"
 msgstr "全局设置(&G)"
@@ -1662,41 +1826,106 @@ msgstr "开发者工具"
 msgid "Enable Fitting Re&strictions"
 msgstr "开启装配限制(&S)"
 
-#: gui/builtinShipBrowser/navigationPanel.py:48
-msgid "Ship groups"
-msgstr "舰船类型"
+#: gui/multiSwitch.py:41
+msgid "Empty Tab"
+msgstr "空白标签页"
 
-#: gui/builtinShipBrowser/navigationPanel.py:50
-msgid "Back"
-msgstr "返回"
+#: gui/patternEditor.py:51
+msgid "You must supply a name for your Damage Profile!"
+msgstr "您必须填写一个伤害模型名！"
 
-#: gui/builtinShipBrowser/navigationPanel.py:51
-msgid "New fitting"
-msgstr "新装配"
+#: gui/patternEditor.py:53
+msgid "Damage Profile name already in use, please choose another."
+msgstr "伤害模型名已占用，请使用其他名称。"
 
-#: gui/builtinShipBrowser/navigationPanel.py:53
-#: gui/builtinShipBrowser/navigationPanel.py:147
-msgid "Hide empty ship groups"
-msgstr "隐藏空的舰船类型"
+#: gui/patternEditor.py:65
+msgid "Damage Profile"
+msgstr "伤害模型"
 
-#: gui/builtinShipBrowser/navigationPanel.py:56
-#: gui/builtinShipBrowser/navigationPanel.py:129
-msgid "Recent Fits"
-msgstr "最近使用的装配"
+#: gui/patternEditor.py:99
+msgid "Damage Pattern Editor"
+msgstr "伤害模型编辑器"
 
-#: gui/builtinShipBrowser/navigationPanel.py:61
-msgid "Search fittings"
-msgstr "搜索装配"
+#: gui/patternEditor.py:171
+msgid "Import patterns from clipboard"
+msgstr "从剪贴板导入伤害模型"
 
-#: gui/builtinShipBrowser/navigationPanel.py:136
-#, fuzzy
-#| msgid "Recent Fits"
-msgid "Hide Recent Fits"
-msgstr "最近使用的装配"
+#: gui/patternEditor.py:172
+msgid "Export patterns to clipboard"
+msgstr "导出伤害模型到剪贴板"
 
-#: gui/builtinShipBrowser/navigationPanel.py:151
-msgid "Show empty ship groups"
-msgstr "显示空的舰船类型"
+#: gui/patternEditor.py:276 gui/setEditor.py:210
+msgid "Patterns successfully imported from clipboard"
+msgstr "从剪贴板导入伤害模型成功"
+
+#: gui/patternEditor.py:283 gui/setEditor.py:218
+msgid "Could not import from clipboard: unknown errors"
+msgstr "无法从剪贴板导入：未知错误"
+
+#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
+msgid "Could not import from clipboard"
+msgstr "无法从剪贴板导入"
+
+#: gui/patternEditor.py:295
+msgid "Patterns exported to clipboard"
+msgstr "伤害模型已导出到剪贴板"
+
+#: gui/preferenceDialog.py:31
+msgid "Preferences"
+msgstr "偏好设置"
+
+#: gui/propertyEditor.py:29
+msgid "Attribute Editor"
+msgstr "属性编辑器"
+
+#: gui/propertyEditor.py:39
+msgid "Import"
+msgstr "导入"
+
+#: gui/propertyEditor.py:39 gui/propertyEditor.py:40
+msgid "Import overrides"
+msgstr "导入自定义属性"
+
+#: gui/propertyEditor.py:40
+msgid "Export"
+msgstr "导出"
+
+#: gui/propertyEditor.py:41
+msgid "Clear All"
+msgstr "清除所有"
+
+#: gui/propertyEditor.py:41
+msgid "Clear all overrides"
+msgstr "清除所有自定义属性"
+
+#: gui/propertyEditor.py:72
+msgid "Remove Overides for Item"
+msgstr "删除物品的自定义属性"
+
+#: gui/propertyEditor.py:108
+msgid "Import pyfa override file"
+msgstr "导入Pyfa属性自定义文件"
+
+#: gui/propertyEditor.py:109
+msgid "pyfa override file (*.csv)|*.csv"
+msgstr "Pyfa属性自定义文件(*.csv)|*.csv"
+
+#: gui/propertyEditor.py:131
+msgid "Save Overrides As..."
+msgstr "保存自定义属性为..."
+
+#: gui/propertyEditor.py:132
+msgid "pyfa overrides (*.csv)|*.csv"
+msgstr "Pyfa属性自定义文件(*.csv)|*.csv"
+
+#: gui/propertyEditor.py:147
+msgid "Are you sure you want to delete all overrides?"
+msgstr "您确定要删除所有自定义属性吗？"
+
+#: gui/propertyEditor.py:272
+#, python-format
+msgid "Default Value: %0.3f"
+msgstr "默认值：%0.3f"
 
 #: gui/setEditor.py:48
 msgid "You must supply a name for the Implant Set!"
@@ -1714,21 +1943,29 @@ msgstr "植入体配置"
 msgid "Implant Set Editor"
 msgstr "植入体配置编辑器"
 
-#: gui/setEditor.py:148 gui/targetProfileEditor.py:221
-msgid "from"
-msgstr ""
+#: gui/setEditor.py:148
+msgid "Import implant sets from clipboard"
+msgstr "从剪贴板导入植入体配置"
 
-#: gui/setEditor.py:149 gui/targetProfileEditor.py:222
-msgid "to"
-msgstr ""
-
-#: gui/setEditor.py:161
-msgid "{} implant sets {} clipboard"
-msgstr "{}植入体配置{}剪贴板"
+#: gui/setEditor.py:149
+msgid "Export implant sets to clipboard"
+msgstr "导出植入体配置到剪贴板"
 
 #: gui/setEditor.py:229
 msgid "Sets exported to clipboard"
 msgstr "植入体配置已导出到剪贴板"
+
+#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
+msgid "SSO Login"
+msgstr "通过EVE登录"
+
+#: gui/ssoLogin.py:20
+msgid "Copy and paste the block of text provided by pyfa.io"
+msgstr "请复制和粘贴pyfa.io提供的字符串"
+
+#: gui/ssoLogin.py:62
+msgid "Waiting for character login through EVE Single Sign-On."
+msgstr "正在等待角色通过EvE登录。"
 
 #: gui/targetProfileEditor.py:50
 msgid "Incorrect formatting (decimals only)"
@@ -1774,9 +2011,13 @@ msgstr "信号半径"
 msgid "Target Profile Editor"
 msgstr "目标属性编辑器"
 
-#: gui/targetProfileEditor.py:234
-msgid "{} profiles {} clipboard"
-msgstr "{}目标属性{}剪贴板"
+#: gui/targetProfileEditor.py:221
+msgid "Import profiles from clipboard"
+msgstr "从剪贴板导入目标属性"
+
+#: gui/targetProfileEditor.py:222
+msgid "Export profiles to clipboard"
+msgstr "导出目标属性到剪贴板"
 
 #: gui/targetProfileEditor.py:352
 msgid "Profiles successfully imported from clipboard"
@@ -1790,193 +2031,43 @@ msgstr "无法从剪贴板导入："
 msgid "Profiles exported to clipboard"
 msgstr "目标属性已导出到剪贴板"
 
-#: gui/multiSwitch.py:41
-msgid "Empty Tab"
-msgstr "空白标签页"
+#: gui/updateDialog.py:54
+msgid "Update Available"
+msgstr "有更新可用"
 
-#: gui/preferenceDialog.py:31
-msgid "Preferences"
-msgstr "偏好设置"
+#: gui/updateDialog.py:102
+msgid "Don't remind me again for this release"
+msgstr "不再提示此更新"
 
-#: gui/errorDialog.py:68
-msgid "Error!"
-msgstr "错误！"
+#~ msgid "Cargo Bay"
+#~ msgstr "货舱"
 
-#: gui/errorDialog.py:69
-msgid "pyfa error"
-msgstr "Pyfa错误"
+#~ msgid "ship"
+#~ msgstr "船体"
 
-#: gui/errorDialog.py:76
-msgid ""
-"pyfa has experienced an unexpected issue. Below is a message that contains "
-"crucial \n"
-"information about how this was triggered. Please contact the developers with "
-"the \n"
-"information provided through the EVE Online forums or file a GitHub issue."
-msgstr ""
-"Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
-"请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
+#~ msgid "fittings"
+#~ msgstr "装配"
 
-#: gui/mainFrame.py:182
-msgid "Market"
-msgstr "市场"
+#~ msgid "character"
+#~ msgstr "角色"
 
-#: gui/mainFrame.py:186
-msgid "Fittings"
-msgstr "装配列表"
-
-#: gui/mainFrame.py:273
-msgid "Loading previous fits..."
-msgstr "正在打开之前的装配..."
-
-#: gui/mainFrame.py:467
-msgid "EVE XML fitting files (*.xml)|*.xml"
-msgstr "EvE装配XML文件 (*.xml)|*.xml"
-
-#: gui/mainFrame.py:646
-msgid ""
-"Are you sure you wish to ignore fitting restrictions for the current fit? "
-"This could lead to wildly inaccurate results and possible errors."
-msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
-
-#: gui/mainFrame.py:653
-msgid ""
-"Re-enabling fitting restrictions for this fit will also remove any illegal "
-"items from the fit. Do you want to continue?"
-msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
-
-#: gui/mainFrame.py:672
-msgid "Manage Characters"
-msgstr "管理角色"
-
-#: gui/mainFrame.py:689
-msgid "&Turn Overrides Off"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:722
-msgid "Please Wait..."
-msgstr "请稍候..."
-
-#: gui/mainFrame.py:806
-msgid "Export Skills Needed As..."
-msgstr "导出所需技能列表到..."
-
-#: gui/mainFrame.py:808
-msgid "EVEMon skills training file"
-msgstr "EvEMon技能训练文件"
-
-#: gui/mainFrame.py:809
-msgid "EVEMon skills training XML file"
-msgstr "EvEMon技能训练XML文件"
-
-#: gui/mainFrame.py:810
-msgid "Text skills training file"
-msgstr "技能列表文本文件"
-
-#: gui/mainFrame.py:828
-msgid "Exporting skills needed..."
-msgstr "正在导出所需技能..."
-
-#: gui/mainFrame.py:835
-msgid "Open One Or More Fitting Files"
-msgstr "打开多个装配文件"
-
-#: gui/mainFrame.py:837
-msgid "EVE XML fitting files"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:838
-msgid "EFT text fitting files"
-msgstr "EFT装配文本文件"
-
-#: gui/mainFrame.py:839 gui/mainFrame.py:1014
-msgid "All Files"
-msgstr "所有文件"
-
-#: gui/mainFrame.py:845
-msgid "Importing fits"
-msgstr "正在导入装配"
-
-#: gui/mainFrame.py:859
-msgid "Save Backup As..."
-msgstr "保存备份为..."
-
-#: gui/mainFrame.py:860
-msgid "EVE XML fitting file"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:873 gui/mainFrame.py:904
-msgid "Backup fits"
-msgstr "备份装配"
-
-#: gui/mainFrame.py:874
-msgid "Backing up {} fits to: {}"
-msgstr ""
-
-#: gui/mainFrame.py:893
-msgid "Invalid Path"
-msgstr "无效路径"
-
-#: gui/mainFrame.py:894
-msgid "The following path is invalid or does not exist:"
-msgstr "下述路径无效或不存在："
-
-#: gui/mainFrame.py:896
-msgid "Please verify path location pyfa's preferences."
-msgstr "请确认Pyfa偏好保存位置。"
-
-#: gui/mainFrame.py:905
-msgid "Generating HTML file at: {}"
-msgstr ""
-
-#: gui/mainFrame.py:947
-msgid "Import Error"
-msgstr "导入错误"
-
-#: gui/mainFrame.py:947
-msgid "Export Error"
-msgstr "导出错误"
-
-#: gui/mainFrame.py:950
-msgid "The following error was generated"
-msgstr "Pyfa 遇到以下错误"
-
-#: gui/mainFrame.py:952
-msgid "Be aware that already processed fits were not saved"
-msgstr "请注意已处理的装配未作保存"
-
-#: gui/mainFrame.py:1011
-msgid "Open One Or More Character Files"
-msgstr "打开多个角色文件"
-
-#: gui/mainFrame.py:1013
-msgid "EVE API XML character files"
-msgstr ""
-
-#: gui/mainFrame.py:1020
-msgid "Importing Character..."
-msgstr "正在导入角色..."
-
-#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
-msgid "SSO Login"
-msgstr "通过EVE登录"
-
-#: gui/ssoLogin.py:20
-msgid "Copy and paste the block of text provided by pyfa.io"
-msgstr "请复制和粘贴pyfa.io提供的字符串"
-
-#: gui/ssoLogin.py:62
-msgid "Waiting for character login through EVE Single Sign-On."
-msgstr "正在等待角色通过EvE登录。"
-
-#~ msgid "drone"
+#~ msgid "drones"
 #~ msgstr "无人机"
+
+#~ msgid "cargoBay"
+#~ msgstr "货舱"
+
+#~ msgid "total"
+#~ msgstr "总计"
+
+#~ msgid "{} implant sets {} clipboard"
+#~ msgstr "{}植入体配置{}剪贴板"
+
+#~ msgid "{} profiles {} clipboard"
+#~ msgstr "{}目标属性{}剪贴板"
 
 #~ msgid "miner"
 #~ msgstr "采矿器"
 
 #~ msgid "turret"
 #~ msgstr "炮台"
-
-#~ msgid "weapon"
-#~ msgstr "武器"

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyfa 2.22.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-20 17:09+0800\n"
-"PO-Revision-Date: 2020-06-20 17:40+0800\n"
+"POT-Creation-Date: 2020-06-21 16:22+0800\n"
+"PO-Revision-Date: 2020-06-21 17:22+0800\n"
 "Last-Translator: zhaoweny <zhaoweny@users.noreply.github.com>\n"
 "Language-Team: Chinese (simplified)\n"
 "Language: zh_CN\n"
@@ -18,281 +18,69 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gui/builtinStatsViews/firepowerViewFull.py:107
-msgid " DPS: "
-msgstr " DPS: "
-
-#: gui/builtinStatsViews/firepowerViewFull.py:100
-msgid " Volley: "
-msgstr "齐射"
-
-#: gui/patternEditor.py:184
-#, python-format
-msgid "%s patterns %s clipboard"
-msgstr ""
-
-#: gui/characterEditor.py:385
-#, python-format
-msgid "%s skills %s clipboard"
-msgstr ""
-
-#: gui/mainMenuBar.py:73
-msgid "&Backup All Fittings"
-msgstr "备份所有装配(&B)"
-
-#: gui/mainMenuBar.py:104
-msgid "&Browse ESI Fittings"
-msgstr "浏览游戏内装配(&B)"
-
-#: gui/mainMenuBar.py:111
-msgid "&Character"
-msgstr "角色(&C)"
-
-#: gui/mainMenuBar.py:144
-msgid "&Character Editor"
-msgstr "角色编辑器(&C)"
-
-#: gui/mainMenuBar.py:70
-msgid "&Close All Tabs"
-msgstr "关闭所有标签页(&C)"
-
-#: gui/mainMenuBar.py:69
-msgid "&Close Tab"
-msgstr "关闭标签页(&C)"
-
-#: gui/mainMenuBar.py:150
-msgid "&Damage Pattern Editor"
-msgstr "伤害模型编辑器(&D)"
-
-#: gui/mainMenuBar.py:143
-msgid "&Editors"
-msgstr "编辑器(&E)"
-
-#: gui/mainMenuBar.py:92
-msgid "&Export Fitting"
-msgstr "导出装配(&E)"
-
-#: gui/mainMenuBar.py:119
-msgid "&Export Skills Needed"
-msgstr "导出所需技能列表(&E)"
-
-#: gui/mainMenuBar.py:66
-msgid "&File"
-msgstr "文件(&F)"
-
-#: gui/mainMenuBar.py:161
-msgid "&Forums"
-msgstr "论坛(&F)"
-
-#: gui/mainMenuBar.py:88
-msgid "&From Clipboard"
-msgstr "从剪贴板导入(&F)"
-
-#: gui/mainMenuBar.py:135
-msgid "&Global"
-msgstr "全局设置(&G)"
-
-#: gui/mainMenuBar.py:96
-msgid "&Graphs"
-msgstr "图表(&G)"
-
-#: gui/mainMenuBar.py:159
-msgid "&Help"
-msgstr "帮助(&H)"
-
-#: gui/mainMenuBar.py:147
-msgid "&Implant Set Editor"
-msgstr "植入体配置编辑器(&I)"
-
-#: gui/mainMenuBar.py:118
-msgid "&Import Character File"
-msgstr "导入角色文件(&I)"
-
-#: gui/mainMenuBar.py:91
-msgid "&Import Fittings"
-msgstr "导入装配(&I)"
-
-#: gui/mainMenuBar.py:122
-msgid "&Manage ESI Characters"
-msgstr "管理游戏内角色(&M)"
-
-#: gui/mainMenuBar.py:68
-msgid "&New Tab"
-msgstr "新标签页(&N)"
-
-#: gui/mainMenuBar.py:95
-msgid "&Optimize Fit Price"
-msgstr "优化装配价格(&O)"
-
-#: gui/mainMenuBar.py:137
-msgid "&Preferences"
-msgstr "偏好设置(&P)"
-
-#: gui/mainMenuBar.py:84
-msgid "&Redo"
-msgstr "恢复(&R)"
-
-#: gui/mainMenuBar.py:115
-msgid "&Revert Character"
-msgstr "还原角色(&R)"
-
-#: gui/mainMenuBar.py:113
-msgid "&Save Character"
-msgstr "保存角色(&S)"
-
-#: gui/mainMenuBar.py:153
-msgid "&Target Profile Editor"
-msgstr "目标属性编辑器(&T)"
-
-#: gui/mainMenuBar.py:87
-msgid "&To Clipboard"
-msgstr "导出到剪贴板(&T)"
-
-#: gui/mainFrame.py:689
-msgid "&Turn Overrides Off"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:689 gui/mainMenuBar.py:131
-msgid "&Turn Overrides On"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainMenuBar.py:83
-msgid "&Undo"
-msgstr "撤销(&R)"
-
-#: gui/mainMenuBar.py:160
-msgid "&Wiki"
-msgstr "百科(&W)"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:81
-msgid "0s"
-msgstr "0秒"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:76
-msgid "Active shield boost"
-msgstr "主动维修"
-
-#: gui/esiFittings.py:350
-msgid "Add Character"
-msgstr "添加角色"
-
-#: gui/esiFittings.py:183
-msgid "Add Character Error"
-msgstr "添加角色错误"
-
-#: gui/fitBrowserLite.py:17
-msgid "Add Fits"
-msgstr "添加装配"
-
-#: gui/additionsPane.py:45
-msgid "Additions"
-msgstr "附加装备"
-
-#: gui/itemStats.py:196
-msgid "Affected by"
-msgstr "影响因素"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:85
-msgid "Align time"
-msgstr "起跳时间"
-
-#: gui/aboutData.py:32
-msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有"
-
-#: gui/mainFrame.py:839 gui/mainFrame.py:1014
-msgid "All Files"
-msgstr "所有文件"
-
-#: gui/characterSelection.py:238
-msgid "All skill prerequisites have been met"
-msgstr "已达到所有技能要求"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:112
-msgid "Ammo hold"
-msgstr ""
-
-#: gui/propertyEditor.py:145
-msgid "Are you sure you want to delete all overrides?"
-msgstr "您确定要删除所有自定义属性吗？"
-
-#: gui/mainFrame.py:646
-msgid ""
-"Are you sure you wish to ignore fitting restrictions for the current fit? "
-"This could lead to wildly inaccurate results and possible errors."
-msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:77
-msgid "Armor repair amount"
-msgstr "装甲修量"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:113
-msgid "Armor resistance"
-msgstr "装甲抗性"
-
-#: gui/mainMenuBar.py:128
-msgid "Attribute &Overrides"
-msgstr "自定义属性(&O)"
-
-#: gui/propertyEditor.py:27
+#: gui/propertyEditor.py:29
 msgid "Attribute Editor"
 msgstr "属性编辑器"
 
-#: gui/itemStats.py:177
-msgid "Attributes"
-msgstr "属性"
+#: gui/propertyEditor.py:39
+msgid "Import"
+msgstr "导入"
 
-#: gui/builtinShipBrowser/navigationPanel.py:50
-msgid "Back"
-msgstr "返回"
+#: gui/propertyEditor.py:39 gui/propertyEditor.py:40
+msgid "Import overrides"
+msgstr "导入自定义属性"
 
-#: gui/mainFrame.py:874
-msgid "Backing up {} fits to: {}"
-msgstr ""
+#: gui/propertyEditor.py:40
+msgid "Export"
+msgstr "导出"
 
-#: gui/mainMenuBar.py:73
-msgid "Backup all fittings to a XML file"
-msgstr "备份所有装配到XML文件"
+#: gui/propertyEditor.py:41
+msgid "Clear All"
+msgstr "清除所有"
 
-#: gui/mainFrame.py:873 gui/mainFrame.py:904
-msgid "Backup fits"
-msgstr "备份装配"
+#: gui/propertyEditor.py:41
+msgid "Clear all overrides"
+msgstr "清除所有自定义属性"
 
-#: gui/mainFrame.py:952
-msgid "Be aware that already processed fits were not saved"
-msgstr "请注意已处理的装配未作保存"
+#: gui/propertyEditor.py:72
+msgid "Remove Overides for Item"
+msgstr "删除物品的自定义属性"
 
-#: gui/additionsPane.py:78
-msgid "Boosters"
-msgstr "增效剂"
+#: gui/propertyEditor.py:108
+msgid "Import pyfa override file"
+msgstr "导入Pyfa自定义配置文件"
 
-#: gui/esiFittings.py:32
-msgid "Browse EVE Fittings"
-msgstr "浏览游戏内装配"
+#: gui/propertyEditor.py:131
+msgid "Save Overrides As..."
+msgstr "保存自定义属性为..."
 
-#: gui/builtinStatsViews/resourcesViewFull.py:153
-msgid "CPU"
-msgstr "CPU"
+#: gui/propertyEditor.py:147
+msgid "Are you sure you want to delete all overrides?"
+msgstr "您确定要删除所有自定义属性吗？"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:115
-msgid "Calibration"
-msgstr "校准"
+#: gui/propertyEditor.py:148 gui/esiFittings.py:157
+msgid "Confirm Delete"
+msgstr "删除确认"
 
-#: gui/builtinStatsViews/capacitorViewFull.py:37
-msgid "Capacitor"
-msgstr "电容"
+#: gui/propertyEditor.py:272
+#, python-format
+msgid "Default Value: %0.3f"
+msgstr "默认值：%0.3f"
 
-#: gui/builtinStatsViews/capacitorViewFull.py:57
-msgid "Capacitor stability"
-msgstr "电容稳定性"
+#: gui/characterEditor.py:76
+msgid "You must supply a name for the Character!"
+msgstr "您必须填写一个角色名！"
 
-#: gui/additionsPane.py:72 gui/builtinStatsViews/targetingMiscViewMinimal.py:88
-msgid "Cargo"
-msgstr "货舱"
+#: gui/characterEditor.py:78
+msgid "Character name already in use, please choose another."
+msgstr "角色名已占用，请使用其他名称。"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:158
-msgid "Cargo bay"
-msgstr "货舱"
+#: gui/characterEditor.py:83 gui/characterEditor.py:463
+#: gui/characterEditor.py:898 gui/characterSelection.py:174
+#: gui/patternEditor.py:58 gui/setEditor.py:55 gui/targetProfileEditor.py:78
+#: gui/mainFrame.py:897
+msgid "Error"
+msgstr "错误"
 
 #: gui/characterEditor.py:90 gui/esiFittings.py:341
 msgid "Character"
@@ -302,440 +90,58 @@ msgstr "角色"
 msgid "Character Editor"
 msgstr "角色编辑器"
 
-#: gui/esiFittings.py:342
-msgid "Character ID"
-msgstr "角色ID"
+#: gui/characterEditor.py:160
+msgid "Skills"
+msgstr "技能列表"
 
-#: gui/characterEditor.py:78
-msgid "Character name already in use, please choose another."
-msgstr "角色名已占用，请使用其他名称。"
-
-#: gui/characterEditor.py:771
-msgid "Character:"
-msgstr "角色："
-
-#: gui/characterSelection.py:47
-msgid "Character: "
-msgstr "角色："
-
-#: gui/propertyEditor.py:39
-msgid "Clear All"
-msgstr "清除所有"
-
-#: gui/propertyEditor.py:39
-msgid "Clear all overrides"
-msgstr "清除所有自定义属性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:97
-#: gui/builtinStatsViews/resistancesViewFull.py:169
-msgid "Click to toggle between effective HP and raw HP"
-msgstr "点击切换有效HP和原始HP"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:102
-msgid "Click to toggle to Firepower View"
-msgstr "点击切换到火力视图"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:115
-msgid "Click to toggle to Mining Yield "
-msgstr "点击切换到矿物产出视图"
-
-#: gui/additionsPane.py:84
-msgid "Command"
-msgstr "指令"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
-msgid "Command center hold"
-msgstr ""
-
-#: gui/itemStats.py:182
-msgid "Compare"
-msgstr "对比"
-
-#: gui/mainFrame.py:648 gui/mainFrame.py:654
-msgid "Confirm"
-msgstr "确认"
-
-#: gui/esiFittings.py:157 gui/propertyEditor.py:146
-msgid "Confirm Delete"
-msgstr "删除确认"
-
-#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
-msgid "Connection error, please check your internet connection"
-msgstr "连接错误，请检查您的网络连接"
-
-#: gui/characterSelection.py:105
-msgid "Copy Missing Skills"
-msgstr "复制所需技能"
-
-#: gui/ssoLogin.py:18
-msgid "Copy and paste the block of text provided by pyfa.io"
-msgstr "请复制和粘贴pyfa.io提供的字符串"
-
-#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
-msgid "Could not import from clipboard"
-msgstr "无法从剪贴板导入"
-
-#: gui/targetProfileEditor.py:359
-msgid "Could not import from clipboard:"
-msgstr "无法从剪贴板导入："
-
-#: gui/patternEditor.py:283 gui/setEditor.py:218
-msgid "Could not import from clipboard: unknown errors"
-msgstr "无法从剪贴板导入：未知错误"
-
-#: gui/patternEditor.py:99
-msgid "Damage Pattern Editor"
-msgstr "伤害模型编辑器"
-
-#: gui/patternEditor.py:65
-msgid "Damage Profile"
-msgstr "伤害模型"
-
-#: gui/patternEditor.py:53
-msgid "Damage Profile name already in use, please choose another."
-msgstr "伤害模型名已占用，请使用其他名称。"
-
-#: gui/propertyEditor.py:270
-#, python-format
-msgid "Default Value: %0.3f"
-msgstr "默认值：%0.3f"
-
-#: gui/esiFittings.py:65
-msgid "Delete from EVE"
-msgstr "删除游戏内装配"
-
-#: gui/itemStats.py:189
-msgid "Dependents"
-msgstr ""
-
-#: gui/itemStats.py:174
-msgid "Description"
-msgstr "简介"
-
-#: gui/mainMenuBar.py:167
-msgid "Dev Tools"
-msgstr "开发者工具"
-
-#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
-msgid "Disable Fitting Re&strictions"
-msgstr "关闭装配资源限制(&S)"
-
-#: gui/esiFittings.py:156
-msgid "Do you really want to delete {} ({}) from EVE?"
-msgstr "真的要从游戏内删除 {} ({})吗？"
-
-#: gui/updateDialog.py:102
-msgid "Don't remind me again for this release"
-msgstr "不再提示此更新"
-
-#: gui/characterEditor.py:789
-msgid "Don't see your EVE character in the list?"
-msgstr "列表中没有你的EvE角色？"
-
-#: gui/updateDialog.py:113
-msgid "Download"
-msgstr "下载"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:157
-msgid "Drone bandwidth"
-msgstr "无人机带宽"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:155
-msgid "Drone bay"
-msgstr "无人机仓库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
-msgid "Drone range"
-msgstr "无人机半径"
-
-#: gui/additionsPane.py:66
-msgid "Drones"
-msgstr "无人机"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:113
-msgid "Drones active"
-msgstr "激活的无人机"
-
-#: gui/mainMenuBar.py:105
-msgid "E&xport to ESI"
-msgstr "导出到游戏(&X)"
-
-#: gui/mainFrame.py:838
-msgid "EFT text fitting files"
-msgstr "EFT装配文本文件"
-
-#: gui/targetProfileEditor.py:119
-msgid "EM resistance"
-msgstr "电磁抗性"
-
-#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
-msgid "ERROR"
-msgstr "错误"
-
-#: gui/mainFrame.py:1013
-msgid "EVE API XML character files"
-msgstr ""
+#: gui/characterEditor.py:161 gui/additionsPane.py:75
+msgid "Implants"
+msgstr "植入体"
 
 #: gui/characterEditor.py:162
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:14
 msgid "EVE SSO"
 msgstr "连接到EvE"
-
-#: gui/mainFrame.py:860
-msgid "EVE XML fitting file"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:837
-msgid "EVE XML fitting files"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:467
-msgid "EVE XML fitting files (*.xml)|*.xml"
-msgstr "EvE装配XML文件 (*.xml)|*.xml"
-
-#: gui/mainFrame.py:809
-msgid "EVEMon skills training XML file"
-msgstr "EvEMon技能训练XML文件"
-
-#: gui/mainFrame.py:808
-msgid "EVEMon skills training file"
-msgstr "EvEMon技能训练文件"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:61
-msgid "Effective HP"
-msgstr "有效HP"
-
-#: gui/itemStats.py:192
-msgid "Effects"
-msgstr "效果"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:85
-msgid "Electromagnetic resistance"
-msgstr "电磁抗性"
-
-#: gui/multiSwitch.py:40
-msgid "Empty Tab"
-msgstr "空白标签页"
-
-#: gui/mainMenuBar.py:200
-msgid "Enable Fitting Re&strictions"
-msgstr "开启装配限制(&S)"
 
 #: gui/characterEditor.py:281
 msgid "Enter a name for your new Character:"
 msgstr "请为新角色输入一个名称："
 
-#: gui/characterEditor.py:83 gui/characterEditor.py:463
-#: gui/characterEditor.py:898 gui/characterSelection.py:174
-#: gui/mainFrame.py:897 gui/patternEditor.py:58 gui/setEditor.py:55
-#: gui/targetProfileEditor.py:78
-msgid "Error"
-msgstr "错误"
+#: gui/characterEditor.py:282
+msgid "Save Character As..."
+msgstr "保存角色为..."
 
-#: gui/characterEditor.py:897 gui/characterSelection.py:173
-msgid "Error fetching skill information"
-msgstr "无法获取技能信息"
+#: gui/characterEditor.py:284
+msgid "{} Copy"
+msgstr "复制{}"
 
-#: gui/errorDialog.py:68
-msgid "Error!"
-msgstr "错误！"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:88
-#: gui/targetProfileEditor.py:122
-msgid "Explosive resistance"
-msgstr "爆炸抗性"
-
-#: gui/characterEditor.py:373 gui/propertyEditor.py:38
-msgid "Export"
+#: gui/characterEditor.py:326
+msgid ""
+"Setting an Alpha clone does not replace the character's skills, but rather "
+"caps them to Alpha levels."
 msgstr ""
+"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
 
-#: gui/mainMenuBar.py:74
-msgid "Export All Fittings to &HTML"
-msgstr "导出所有装配到网页"
+#: gui/characterEditor.py:342
+msgid "Skill"
+msgstr "技能"
 
-#: gui/mainFrame.py:947
-msgid "Export Error"
-msgstr "导出错误"
+#: gui/characterEditor.py:343
+msgid "Level"
+msgstr "技能等级"
 
-#: gui/esiFittings.py:224
-msgid "Export Fit"
-msgstr "导出装配"
+#: gui/characterEditor.py:356
+#, python-brace-format
+msgid "Sec Status: {0:.2f}"
+msgstr "安全等级: {0:.2f}"
 
-#: gui/mainFrame.py:806
-msgid "Export Skills Needed As..."
-msgstr "导出所需技能列表到..."
+#: gui/characterEditor.py:372
+msgid "Import skills from clipboard"
+msgstr "从剪贴板导入技能列表"
 
-#: gui/mainMenuBar.py:87
-msgid "Export a fit to the clipboard"
-msgstr "导出装配到剪贴板"
-
-#: gui/esiFittings.py:211
-msgid "Export fit to EVE"
-msgstr "导出装配到游戏"
-
-#: gui/mainMenuBar.py:74
-msgid "Export fits to HTML file (set in Preferences)"
-msgstr "导出装配到网页（通过偏好设置指定）"
-
-#: gui/mainMenuBar.py:92
-msgid "Export fitting to another format"
-msgstr "导出装配为其他格式"
-
-#: gui/mainMenuBar.py:119
-msgid "Export skills needed for this fitting"
-msgstr "导出使用本装配所需技能"
-
-#: gui/mainFrame.py:828
-msgid "Exporting skills needed..."
-msgstr "正在导出所需技能..."
-
-#: gui/builtinStatsViews/capacitorViewFull.py:90
-msgid "Extra stats"
-msgstr "额外状态"
-
-#: gui/esiFittings.py:294
-msgid "Failed to generate export data"
-msgstr "无法生成导出数据"
-
-#: gui/aboutData.py:34
-msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
-msgstr ""
-
-#: gui/esiFittings.py:44
-msgid "Fetch Fits"
-msgstr "获取装配"
-
-#: gui/esiFittings.py:111
-msgid "Fetching fits, please wait..."
-msgstr "正在获取装配，请稍候..."
-
-#: gui/mainMenuBar.py:81
-msgid "Fi&t"
-msgstr "装配(&T)"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:156
-msgid "Fighter bay"
-msgstr "铁骑舰载机仓库"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:114
-msgid "Fighter squadrons active"
-msgstr "激活的铁骑舰载机中队"
-
-#: gui/additionsPane.py:69
-msgid "Fighters"
-msgstr "铁骑舰载机"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:43
-msgid "Firepower"
-msgstr "火力"
-
-#: gui/mainFrame.py:186
-msgid "Fittings"
-msgstr "装配列表"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:110
-msgid "Fleet hangar"
-msgstr "舰队机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
-msgid "Fuel bay"
-msgstr "燃料机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
-msgid "Gas hold"
-msgstr "气态矿物仓库"
-
-#: gui/mainFrame.py:905
-msgid "Generating HTML file at: {}"
-msgstr ""
-
-#: gui/characterEditor.py:778
-msgid "Get Skills"
-msgstr "获取技能列表"
-
-#: gui/mainMenuBar.py:161
-msgid "Go to EVE Online Forum thread"
-msgstr "转到EvE Online论坛讨论贴"
-
-#: gui/mainMenuBar.py:160
-msgid "Go to wiki on GitHub"
-msgstr "转到GitHub上的百科页"
-
-#: gui/characterSelection.py:102
-msgid "Grant Missing Skills"
-msgstr ""
-
-#: gui/builtinShipBrowser/navigationPanel.py:53
-#: gui/builtinShipBrowser/navigationPanel.py:147
-msgid "Hide empty ship groups"
-msgstr "隐藏空的舰船类型"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:78
-msgid "Hull repair amount"
-msgstr "结构修量"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:114
-msgid "Hull resistance"
-msgstr "结构抗性"
-
-#: gui/setEditor.py:62
-msgid "Implant Set"
-msgstr "植入体配置"
-
-#: gui/setEditor.py:122
-msgid "Implant Set Editor"
-msgstr "植入体配置编辑器"
-
-#: gui/setEditor.py:50
-msgid "Implant Set name already in use, please choose another."
-msgstr "植入体配置名已使用，请选择其他名称。"
-
-#: gui/additionsPane.py:75 gui/characterEditor.py:161
-msgid "Implants"
-msgstr "植入体"
-
-#: gui/characterEditor.py:372 gui/propertyEditor.py:37
-msgid "Import"
-msgstr ""
-
-#: gui/mainFrame.py:947
-msgid "Import Error"
-msgstr "导入错误"
-
-#: gui/characterEditor.py:442
-msgid "Import Skills"
-msgstr "导入技能"
-
-#: gui/mainMenuBar.py:88
-msgid "Import a fit from the clipboard"
-msgstr "从剪贴板导入装配"
-
-#: gui/mainMenuBar.py:118
-msgid "Import characters into pyfa from file"
-msgstr "从文件导入角色信息"
-
-#: gui/mainMenuBar.py:91
-msgid "Import fittings into pyfa"
-msgstr "从文件导入装配"
-
-#: gui/propertyEditor.py:37 gui/propertyEditor.py:38
-msgid "Import overrides"
-msgstr "导入自定义属性"
-
-#: gui/propertyEditor.py:106
-msgid "Import pyfa override file"
-msgstr "导入Pyfa自定义配置文件"
-
-#: gui/esiFittings.py:64
-msgid "Import to pyfa"
-msgstr "导入到Pyfa"
-
-#: gui/mainFrame.py:1020
-msgid "Importing Character..."
-msgstr "正在导入角色..."
-
-#: gui/mainFrame.py:845
-msgid "Importing fits"
-msgstr "正在导入装配"
+#: gui/characterEditor.py:373
+msgid "Export skills from clipboard"
+msgstr "从剪贴板导出技能列表"
 
 #: gui/characterEditor.py:440
 msgid ""
@@ -746,216 +152,911 @@ msgstr ""
 "导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
 "窗口底部的保存按钮"
 
-#: gui/builtinStatsViews/resistancesViewFull.py:115
-msgid "Incoming damage pattern"
-msgstr "伤害分布"
+#: gui/characterEditor.py:442
+msgid "Import Skills"
+msgstr "导入技能"
 
-#: gui/targetProfileEditor.py:50
-msgid "Incorrect formatting (decimals only)"
-msgstr "格式无效（仅允许小数）"
+#: gui/characterEditor.py:463
+msgid "There was an error importing skills, please see log file"
+msgstr "导入技能列表出错，详见日志文件"
 
-#: gui/targetProfileEditor.py:52
-msgid "Incorrect range (must be 0-100)"
-msgstr "范围无效（必须是 0-100）"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
-msgid "Industrial ship hold"
-msgstr ""
-
-#: gui/mainFrame.py:893
-msgid "Invalid Path"
-msgstr "无效路径"
-
-#: gui/esiFittings.py:198
-msgid "Invalid Token"
-msgstr "无效登录信息"
-
-#: gui/itemStats.py:58
-msgid "Item stats"
-msgstr "物品属性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:87
-#: gui/targetProfileEditor.py:121
-msgid "Kinetic resistance"
-msgstr "动能抗性"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
-msgid "Large ship hold"
-msgstr ""
-
-#: gui/builtinStatsViews/capacitorViewFull.py:77
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Lasts "
-msgstr "可维持"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:112
-msgid "Launcher hardpoints"
-msgstr "发射器"
-
-#: gui/characterEditor.py:343
-msgid "Level"
-msgstr "技能等级"
+#: gui/characterEditor.py:532
+msgid "Level {}d"
+msgstr "等级"
 
 #: gui/characterEditor.py:591 gui/characterEditor.py:616
 #: gui/characterEditor.py:649
 msgid "Level {}"
 msgstr "等级"
 
-#: gui/characterEditor.py:532
-msgid "Level {}d"
-msgstr "等级"
+#: gui/characterEditor.py:614
+msgid "Unlearn"
+msgstr "忘掉"
 
-#: gui/mainFrame.py:273
-msgid "Loading previous fits..."
-msgstr "正在打开之前的装配..."
-
-#: gui/characterEditor.py:794
-msgid "Log In with EVE SSO"
-msgstr "通过EVE登录"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:111
-msgid "Maintenance bay"
-msgstr "维护机库"
-
-#: gui/mainFrame.py:672
-msgid "Manage Characters"
-msgstr "管理角色"
-
-#: gui/mainFrame.py:182
-msgid "Market"
-msgstr "市场"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
-msgid "Material bay"
-msgstr "矿物机库"
-
-#: gui/targetProfileEditor.py:124
-msgid "Maximum speed"
-msgstr "亚光速航速"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
-msgid "Medium ship hold"
-msgstr "中型舰船机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
-msgid "Mineral hold"
-msgstr "矿物机库"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:39
-msgid "Mining Yield"
-msgstr "矿物产出"
-
-#: gui/itemStats.py:170
-msgid "Mutations"
-msgstr "变质"
-
-#: gui/esiFittings.py:300
-msgid "Need at least one ESI character to export"
-msgstr "请为导出至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:114
-msgid "Need at least one ESI character to fetch"
-msgstr "请为获取至少选择一个游戏内角色"
-
-#: gui/builtinShipBrowser/navigationPanel.py:51
-msgid "New fitting"
-msgstr "新装配"
-
-#: gui/characterSelection.py:230
-msgid "No active fit"
-msgstr "没有选中的装配"
-
-#: gui/characterEditor.py:855
-msgid "None"
-msgstr ""
-
-#: gui/additionsPane.py:87
-msgid "Notes"
-msgstr "备注"
-
-#: gui/mainMenuBar.py:167
-msgid "Open &Dev Tools"
-msgstr "打开开发者工具(&D)"
-
-#: gui/characterSelection.py:150
-msgid "Open Character Editor"
-msgstr "打开角色编辑器"
-
-#: gui/mainFrame.py:1011
-msgid "Open One Or More Character Files"
-msgstr "打开多个角色文件"
-
-#: gui/mainFrame.py:835
-msgid "Open One Or More Fitting Files"
-msgstr "打开多个装配文件"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Wid&gets Inspect tool"
-msgstr "打开控件检查工具(&G)"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Widgets Inspect tool"
-msgstr "打开控件检查工具"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
-msgid "Ore hold"
-msgstr "矿石机库"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:75
-msgid "Passive shield recharge"
-msgstr "被动回充"
-
-#: gui/patternEditor.py:295
-msgid "Patterns exported to clipboard"
-msgstr "伤害模型已导出到剪贴板"
-
-#: gui/patternEditor.py:276 gui/setEditor.py:210
-msgid "Patterns successfully imported from clipboard"
-msgstr "从剪贴板导入伤害模型成功"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
-msgid "Planetary goods hold"
-msgstr "星系开发机库"
-
-#: gui/mainFrame.py:722
-msgid "Please Wait..."
-msgstr "请稍候..."
-
-#: gui/esiFittings.py:281
-msgid "Please select an active fitting in the main window"
-msgstr "请在主窗口选择一个装配"
+#: gui/characterEditor.py:757
+msgid "You cannot link All 0 or All 5 characters to an EVE character."
+msgstr "你不能关联全0级或全5级到一个EvE角色。"
 
 #: gui/characterEditor.py:758
 msgid "Please select another character or make a new one."
 msgstr "请选择另一角色或创建新角色。"
 
-#: gui/mainFrame.py:896
-msgid "Please verify path location pyfa's preferences."
-msgstr "请确认Pyfa偏好保存位置。"
+#: gui/characterEditor.py:771
+msgid "Character:"
+msgstr "角色："
 
-#: gui/builtinStatsViews/resourcesViewFull.py:154
-msgid "PowerGrid"
-msgstr "PG"
+#: gui/characterEditor.py:778
+msgid "Get Skills"
+msgstr "获取技能列表"
 
-#: gui/preferenceDialog.py:31
-msgid "Preferences"
-msgstr "偏好设置"
+#: gui/characterEditor.py:789
+msgid "Don't see your EVE character in the list?"
+msgstr "列表中没有你的EvE角色？"
 
+#: gui/characterEditor.py:794
+msgid "Log In with EVE SSO"
+msgstr "通过EVE登录"
+
+#: gui/characterEditor.py:855
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "None"
+msgstr ""
+
+#: gui/characterEditor.py:897 gui/characterSelection.py:173
+msgid "Error fetching skill information"
+msgstr "无法获取技能信息"
+
+#: gui/characterEditor.py:901
+msgid "Successfully fetched skills"
+msgstr "成功获取到技能列表"
+
+#: gui/characterEditor.py:901
+msgid "Success"
+msgstr "成功"
+
+#: gui/characterEditor.py:907
+msgid "Set Security Status"
+msgstr "设置安全等级"
+
+#: gui/characterEditor.py:914
+msgid "Security Status is used in some CONCORD hull calculations"
+msgstr "安全等级会用于计算CONCORD警察船体属性"
+
+#: gui/itemStats.py:58
+msgid "Item stats"
+msgstr "物品属性"
+
+#: gui/itemStats.py:87
+#, python-brace-format
+msgid "{context}Stats: {name}{debug_info}"
+msgstr ""
+
+#: gui/itemStats.py:166
+msgid "Traits"
+msgstr "特征"
+
+#: gui/itemStats.py:170
+msgid "Mutations"
+msgstr "变质"
+
+#: gui/itemStats.py:174
+msgid "Description"
+msgstr "简介"
+
+#: gui/itemStats.py:177
+msgid "Attributes"
+msgstr "属性"
+
+#: gui/itemStats.py:182
+msgid "Compare"
+msgstr "对比"
+
+#: gui/itemStats.py:185
+msgid "Requirements"
+msgstr "技能需求"
+
+#: gui/itemStats.py:189
+msgid "Dependents"
+msgstr ""
+
+#: gui/itemStats.py:192
+msgid "Effects"
+msgstr "效果"
+
+#: gui/itemStats.py:196
+msgid "Affected by"
+msgstr "影响因素"
+
+#: gui/updateDialog.py:54
+msgid "Update Available"
+msgstr "有更新可用"
+
+#: gui/updateDialog.py:102
+msgid "Don't remind me again for this release"
+msgstr "不再提示此更新"
+
+#: gui/updateDialog.py:113
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
+msgid "Download"
+msgstr "下载"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:13
+msgid "Database"
+msgstr "数据库"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
+msgid ""
+"(Cannot be changed while pyfa is running. Set via command line switches.)"
+msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
+msgid "Using Executable Path for Saved Fit Database and Settings"
+msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
+msgid "pyfa User Path:"
+msgstr "Pyfa自定义路径："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
+msgid "Fitting Database:"
+msgstr "装配数据库："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
+msgid "Game Database:"
+msgstr "游戏数据库："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
+msgid "Delete All Damage Pattern Profiles"
+msgstr "删除所有伤害模型配置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
+msgid "Delete All Target Profiles"
+msgstr "删除所有目标属性配置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
+msgid "Delete All Prices"
+msgstr "删除所有价格缓存数据"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
+msgid ""
+"This is a destructive action that will delete all damage pattern profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有伤害模型配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:108
+#: gui/mainFrame.py:648 gui/mainFrame.py:654
+msgid "Confirm"
+msgstr "确认"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+msgid ""
+"This is a destructive action that will delete all target profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有目标属性配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+msgid ""
+"This is a destructive action that will delete all cached prices out of the "
+"database.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有价格缓存数据。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:12
+msgid "Statistics Panel"
+msgstr "属性面板"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
+msgid "Changes require restart of pyfa to take effect."
+msgstr "变更将在重启Pyfa之后生效。"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinStatsViews/resourcesViewFull.py:84
+msgid "Resources"
+msgstr "装配资源"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Minimal"
+msgstr "简洁"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Full"
+msgstr "完整"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinStatsViews/resistancesViewFull.py:47
+msgid "Resistances"
+msgstr "抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+msgid "Shield/Armor Tank"
+msgstr "回充速度"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinStatsViews/firepowerViewFull.py:43
+msgid "Firepower"
+msgstr "火力"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinStatsViews/capacitorViewFull.py:37
+msgid "Capacitor"
+msgstr "电容"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Misc"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
 #: gui/builtinStatsViews/priceViewFull.py:40
 msgid "Price"
 msgstr "价格"
 
-#: gui/targetProfileEditor.py:372
-msgid "Profiles exported to clipboard"
-msgstr "目标属性已导出到剪贴板"
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinStatsViews/outgoingViewMinimal.py:65
+#: gui/builtinStatsViews/outgoingViewFull.py:66
+msgid "Remote Reps"
+msgstr "遥修"
 
-#: gui/targetProfileEditor.py:352
-msgid "Profiles successfully imported from clipboard"
-msgstr "已成功从剪贴板导入目标属性"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:12
+msgid "Context Menus"
+msgstr ""
 
-#: gui/additionsPane.py:81
-msgid "Projected"
-msgstr "环境效果"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
+msgid ""
+"Disabling context menus can improve responsiveness.\n"
+"You can hold {} key + right-click to show all menu items regardless of these "
+"settings."
+msgstr ""
+"关闭右键菜单可提升响应速度。\n"
+"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+msgid "Set as Damage Pattern"
+msgstr "设置为伤害模型"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Disabled"
+msgstr "关闭"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Enabled"
+msgstr "打开"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+msgid "Change Skills"
+msgstr "修改技能等级"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+msgid "Variations"
+msgstr "变种"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+msgid "Project onto Fit"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+msgid "Fill with module"
+msgstr "用该模块填满空白槽位"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+msgid "Spoolup"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Additions Panel Copy/Paste"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:17
+msgid "HTML Export"
+msgstr "HTML导出"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:18
+msgid ""
+"HTML Export (File > Export HTML) allows you to export your entire fitting "
+"database into an HTML file at the specified location. This file can be used "
+"to easily open your fits in a web-based fitting program"
+msgstr ""
+"HTML导出（文件>导出到所有装配到网页）可以导出你的所有装配为HTML网页，放在指定"
+"路径下。This file can be used to easily open your fits in a web-based "
+"fitting program"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:21
+msgid ""
+"Export Fittings in a minimal HTML Version, just containing the fittings "
+"links without any visual styling"
+msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
+#: gui/mainFrame.py:466
+msgid "Save Fitting As..."
+msgstr "保存装配为..."
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
+msgid "EVE IGB HTML fitting file (*.html)|*.html"
+msgstr "EvE IGB网页装配文件 (*.html)|*.html"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
+msgid "Set export destination"
+msgstr "设置导出路径"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
+msgid "Enable minimal format"
+msgstr "使用极简版风格"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:12
+msgid "Updates"
+msgstr "更新"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:13
+msgid ""
+"Pyfa can automatically check and notify you of new releases. This feature is "
+"toggled in the Network settings. Here, you may allow pre-release "
+"notifications and view suppressed release notifications, if any."
+msgstr ""
+"Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
+"布版本更新通知，并查看未提示的版本更新（如果有的话）。"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
+msgid "Allow pre-release notifications"
+msgstr "允许预发布版本更新通知"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
+#, python-brace-format
+msgid "Suppressing {0} Notifications"
+msgstr "有{0}个未提示的版本更新"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
+msgid ""
+"There is a release available which you have chosen to suppress. You can "
+"choose to reset notification suppression for this release, or download the "
+"new release from GitHub."
+msgstr ""
+"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
+msgid "Reset Suppression"
+msgstr "重置版本更新提示"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:17
+msgid "Logging"
+msgstr "日志"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
+msgid "Log file location:"
+msgstr "日志文件路径："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
+msgid "Cert Path:"
+msgstr "证书路径"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
+msgid "Debug Logging Enabled"
+msgstr "调试日子已开启"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
+msgid ""
+"Pressing this button will cause all logs in memory to write to the log file:"
+msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
+msgid "Dump All Logs"
+msgstr "将所有日志写入文件"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:18
+msgid "Market & Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:30
+msgid "Market && Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
+msgid "Market Search Delay (ms):"
+msgstr "市场搜索延迟（毫秒）："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
+msgid ""
+"The delay between a keystroke and the market search. Can help reduce lag "
+"when typing fast in the market search box."
+msgstr ""
+"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
+msgid "Show market shortcuts"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
+msgid "Default Market Prices:"
+msgstr "默认价格源："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
+msgid ""
+"The source you choose will be tried first, but subsequent sources will be "
+"used if the preferred source fails. The system you choose will also be tried "
+"first, and if no data is available, global price will be used."
+msgstr ""
+"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
+"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
+msgid "Total Price Includes"
+msgstr "价格总计包括"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
+#: gui/additionsPane.py:66
+msgid "Drones"
+msgstr "无人机"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
+#: gui/additionsPane.py:72 gui/builtinStatsViews/targetingMiscViewMinimal.py:88
+msgid "Cargo"
+msgstr "货舱"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
+msgid "Implants && Boosters"
+msgstr "植入体和增效剂"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
+msgid "Market Search && Recent Items"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "No changes to meta buttons"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+msgid "Enable all meta buttons for a duration of search / recents"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
+msgid "Enable all meta buttons"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
+msgid "Market Group Selection"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
+msgid "Empty Market View"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable leftmost available meta button"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable all available meta buttons"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
+msgid "Item Market Group Jump"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button, disable others"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:33
+msgid ""
+"Please see the pyfa wiki on GitHub for information regarding these options."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Login Authentication Method"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
+msgid "Local Server"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
+msgid "Manual"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:41
+msgid ""
+"This options starts a local webserver that the web application will call "
+"back to with information about the character login."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:43
+msgid ""
+"This option prompts users to copy and paste information from the web "
+"application to allow for character login. Use this if having issues with the "
+"local server."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "SSO Mode"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
+msgid "pyfa.io"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
+#, fuzzy
+#| msgid "Calibration"
+msgid "Custom application"
+msgstr "校准"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:48
+msgid ""
+"This options routes SSO Logins through pyfa.io, allowing you to easily login "
+"without any configuration. When in doubt, use this option."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:50
+msgid ""
+"This option goes through EVE SSO directly, but requires more configuration. "
+"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
+"route data throguh pyfa.io."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:64
+msgid "Custom Application"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:77
+msgid "Client ID:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:86
+msgid "Client Secret:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:19
+#, fuzzy
+#| msgid "Fittings"
+msgid "Fitting Engine"
+msgstr "装配列表"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:45
+msgid ""
+"Factor in reload time when calculating capacitor usage, damage, and tank."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:51
+msgid "Enforce strict skill level requirements"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:55
+msgid ""
+"When enabled, skills will check their dependencies' requirements when their "
+"levels change and reset skills that no longer meet the requirement.\n"
+"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
+"skill, as that requires Drones V"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:62
+msgid ""
+"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
+"behavior)."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:69
+msgid "Global Default Spoolup Percentage:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:73
+msgid ""
+"The amount of spoolup to use by default on module which support it. Can be "
+"changed on a per-module basis"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:15
+msgid "General"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
+#, fuzzy
+#| msgid "Remove Character"
+msgid "Use global character"
+msgstr "删除角色"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
+msgid "Use character implants by default for new fits"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
+#, fuzzy
+#| msgid "Incoming damage pattern"
+msgid "Use global damage pattern"
+msgstr "伤害分布"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
+#, fuzzy
+#| msgid "Export skills needed for this fitting"
+msgid "Compact skills needed tooltip"
+msgstr "导出使用本装配所需技能"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
+msgid "Color fitting view by slot"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
+msgid "Reopen previous fits on startup"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
+msgid "Separate Racks"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
+msgid "Show Rack Labels"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
+msgid "Show fitting tab tooltips"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
+msgid "Animate gauges"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
+msgid "Open fittings in a new page by default"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
+msgid "Show ship browser tooltip"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
+msgid "Change charge in all modules of the same type"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
+msgid ""
+"When disabled, reloads charges just in selected modules. Action can be "
+"reversed by holding Ctrl or Alt key while changing charge."
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
+msgid "Extra info in Additions panel tab names"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of active items"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of all items"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
+msgid "Language (restart required): "
+msgstr "语言（重启后生效）："
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:15
+msgid "Network"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:34
+msgid "Enable Network"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:38
+msgid "EVE Servers (API && CREST import)"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:42
+msgid "Pricing updates"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:45
+msgid "Pyfa Update checks"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:50
+#, fuzzy
+#| msgid "Browse EVE Fittings"
+msgid "Proxy settings"
+msgstr "浏览游戏内装配"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:84
+msgid "Mode:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
+msgid "No proxy"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
+msgid "Auto-detected proxy settings"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:88
+msgid "Manual proxy settings"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:102
+msgid "Addr:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:110
+msgid "Port:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:122
+msgid "Username:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:126
+msgid "Password:"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:137
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:159
+msgid "Auto-detected: "
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:145
+msgid "Apply Proxy Settings"
+msgstr ""
+
+#: gui/esiFittings.py:32
+msgid "Browse EVE Fittings"
+msgstr "浏览游戏内装配"
+
+#: gui/esiFittings.py:44
+msgid "Fetch Fits"
+msgstr "获取装配"
+
+#: gui/esiFittings.py:64
+msgid "Import to pyfa"
+msgstr "导入到Pyfa"
+
+#: gui/esiFittings.py:65
+msgid "Delete from EVE"
+msgstr "删除游戏内装配"
+
+#: gui/esiFittings.py:111
+msgid "Fetching fits, please wait..."
+msgstr "正在获取装配，请稍候..."
+
+#: gui/esiFittings.py:114
+msgid "Need at least one ESI character to fetch"
+msgstr "请为获取至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
+msgid "Connection error, please check your internet connection"
+msgstr "连接错误，请检查您的网络连接"
+
+#: gui/esiFittings.py:156
+msgid "Do you really want to delete {} ({}) from EVE?"
+msgstr "真的要从游戏内删除 {} ({})吗？"
+
+#: gui/esiFittings.py:179
+msgid ""
+"There was an issue starting up the localized server, try setting Login "
+"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
+"Authentication Method. If this doesn't fix the problem please file an issue "
+"on Github."
+msgstr ""
+"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
+"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
+
+#: gui/esiFittings.py:183
+msgid "Add Character Error"
+msgstr "添加角色错误"
+
+#: gui/esiFittings.py:196
+msgid ""
+"There was an error validating characters' SSO token. Please try logging into "
+"the character again to reset the token."
+msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
+
+#: gui/esiFittings.py:198
+msgid "Invalid Token"
+msgstr "无效登录信息"
+
+#: gui/esiFittings.py:211
+msgid "Export fit to EVE"
+msgstr "导出装配到游戏"
+
+#: gui/esiFittings.py:224
+msgid "Export Fit"
+msgstr "导出装配"
+
+#: gui/esiFittings.py:281
+msgid "Please select an active fitting in the main window"
+msgstr "请在主窗口选择一个装配"
+
+#: gui/esiFittings.py:284
+msgid "Sending request and awaiting response"
+msgstr "正在发送请求和接收响应"
+
+#: gui/esiFittings.py:294
+msgid "Failed to generate export data"
+msgstr "无法生成导出数据"
+
+#: gui/esiFittings.py:300
+msgid "Need at least one ESI character to export"
+msgstr "请为导出至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
+msgid "ERROR"
+msgstr "错误"
+
+#: gui/esiFittings.py:334
+msgid "SSO Character Management"
+msgstr "游戏内人物管理"
+
+#: gui/esiFittings.py:342
+msgid "Character ID"
+msgstr "角色ID"
+
+#: gui/esiFittings.py:350
+msgid "Add Character"
+msgstr "添加角色"
+
+#: gui/esiFittings.py:353
+msgid "Remove Character"
+msgstr "删除角色"
+
+#: gui/aboutData.py:31
+msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
+msgstr ""
+"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
+
+#: gui/aboutData.py:32
+msgid "All EVE-Online related materials are property of CCP hf."
+msgstr "所有 EvE Online 相关材料版权归CCP所有"
+
+#: gui/aboutData.py:33
+msgid ""
+"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
+msgstr ""
+
+#: gui/aboutData.py:34
+msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
+msgstr ""
 
 #: gui/aboutData.py:49
 msgid ""
@@ -968,221 +1069,218 @@ msgstr ""
 "于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
 "wxWidgets支持的所有平台运行。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
-msgid "Quafe hold"
-msgstr ""
-
-#: gui/targetProfileEditor.py:126
-msgid "Radius"
-msgstr "信号半径"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:61
-msgid "Range"
-msgstr "锁定范围"
-
-#: gui/mainFrame.py:653
-msgid ""
-"Re-enabling fitting restrictions for this fit will also remove any illegal "
-"items from the fit. Do you want to continue?"
-msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
-
-#: gui/builtinShipBrowser/navigationPanel.py:56
-msgid "Recent Fits"
-msgstr "最近使用的装配"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:43
-msgid "Recharge rates"
-msgstr "回充速度"
-
-#: gui/mainMenuBar.py:84
-msgid "Redo the most recent undone action"
-msgstr "恢复最近一次撤销的操作"
+#: gui/characterSelection.py:47
+msgid "Character: "
+msgstr "角色："
 
 #: gui/characterSelection.py:68
 msgid "Refresh Skills"
 msgstr "刷新技能"
 
-#: gui/builtinStatsViews/rechargeViewFull.py:86
-msgid "Reinforced"
-msgstr "加强回充"
-
-#: gui/builtinStatsViews/outgoingViewFull.py:66
-#: gui/builtinStatsViews/outgoingViewMinimal.py:65
-msgid "Remote Reps"
-msgstr "遥修"
-
-#: gui/esiFittings.py:353
-msgid "Remove Character"
-msgstr "删除角色"
-
-#: gui/propertyEditor.py:70
-msgid "Remove Overides for Item"
-msgstr "删除物品的自定义属性"
-
-#: gui/itemStats.py:185
-msgid "Requirements"
-msgstr "技能需求"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:47
-msgid "Resistances"
-msgstr "抗性"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:84
-msgid "Resources"
-msgstr "装配资源"
-
-#: gui/esiFittings.py:334
-msgid "SSO Character Management"
-msgstr "游戏内人物管理"
-
-#: gui/ssoLogin.py:13 gui/ssoLogin.py:47
-msgid "SSO Login"
-msgstr "通过EVE登录"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
-msgid "Salvage hold"
-msgstr "打捞件机库"
-
-#: gui/mainFrame.py:859
-msgid "Save Backup As..."
-msgstr "保存备份为..."
-
-#: gui/mainMenuBar.py:114
-msgid "Save Character &As..."
-msgstr "保存角色为...(&A)"
-
-#: gui/characterEditor.py:282
-msgid "Save Character As..."
-msgstr "保存角色为..."
-
-#: gui/mainFrame.py:466
-msgid "Save Fitting As..."
-msgstr "保存装配为..."
-
-#: gui/propertyEditor.py:129
-msgid "Save Overrides As..."
-msgstr "保存自定义属性为..."
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
-msgid "Scan res."
-msgstr "扫描精度"
-
-#: gui/builtinShipBrowser/navigationPanel.py:61
-msgid "Search fittings"
-msgstr "搜索装配"
-
-#: gui/characterEditor.py:356
-#, python-brace-format
-msgid "Sec Status: {0:.2f}"
-msgstr "安全等级: {0:.2f}"
-
-#: gui/characterEditor.py:914
-msgid "Security Status is used in some CONCORD hull calculations"
-msgstr "安全等级会用于计算CONCORD警察船体属性"
-
-#: gui/esiFittings.py:284
-msgid "Sending request and awaiting response"
-msgstr "正在发送请求和接收响应"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
-msgid "Sensor str."
-msgstr "传感器强度"
-
-#: gui/characterEditor.py:907
-msgid "Set Security Status"
-msgstr "设置安全等级"
-
-#: gui/setEditor.py:229
-msgid "Sets exported to clipboard"
-msgstr "植入体配置已导出到剪贴板"
-
-#: gui/characterEditor.py:326
-msgid ""
-"Setting an Alpha clone does not replace the character's skills, but rather "
-"caps them to Alpha levels."
-msgstr ""
-"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:112
-msgid "Shield resistance"
-msgstr "护盾抗性"
-
-#: gui/builtinShipBrowser/navigationPanel.py:48
-msgid "Ship groups"
-msgstr "舰船类型"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
-msgid "Ship hold"
+#: gui/characterSelection.py:102
+msgid "Grant Missing Skills"
 msgstr ""
 
-#: gui/builtinShipBrowser/navigationPanel.py:151
-msgid "Show empty ship groups"
-msgstr "显示空的舰船类型"
+#: gui/characterSelection.py:105
+msgid "Copy Missing Skills"
+msgstr "复制所需技能"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
-msgid "Signature"
-msgstr "信号半径"
+#: gui/characterSelection.py:150
+msgid "Open Character Editor"
+msgstr "打开角色编辑器"
 
-#: gui/targetProfileEditor.py:125
-msgid ""
-"Signature radius\n"
-"Leave blank for infinitely big value"
-msgstr ""
-"信号半径\n"
-"保持为空表示信号半径无限大"
+#: gui/characterSelection.py:230
+msgid "No active fit"
+msgstr "没有选中的装配"
 
-#: gui/aboutData.py:33
-msgid ""
-"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
-msgstr ""
-
-#: gui/characterEditor.py:342
-msgid "Skill"
-msgstr "技能"
-
-#: gui/characterEditor.py:160
-msgid "Skills"
-msgstr "技能列表"
+#: gui/characterSelection.py:238
+msgid "All skill prerequisites have been met"
+msgstr "已达到所有技能要求"
 
 #: gui/characterSelection.py:242
 msgid "Skills required:"
 msgstr "所需技能："
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
-msgid "Small ship hold"
-msgstr ""
+#: gui/patternEditor.py:51
+msgid "You must supply a name for your Damage Profile!"
+msgstr "您必须填写一个伤害模型名！"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:84
-msgid "Speed"
-msgstr "亚光速航速"
+#: gui/patternEditor.py:53
+msgid "Damage Profile name already in use, please choose another."
+msgstr "伤害模型名已占用，请使用其他名称。"
 
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Stable: "
-msgstr "稳定："
+#: gui/patternEditor.py:65
+msgid "Damage Profile"
+msgstr "伤害模型"
 
-#: gui/characterEditor.py:901
-msgid "Success"
-msgstr "成功"
+#: gui/patternEditor.py:99
+msgid "Damage Pattern Editor"
+msgstr "伤害模型编辑器"
 
-#: gui/characterEditor.py:901
-msgid "Successfully fetched skills"
-msgstr "成功获取到技能列表"
+#: gui/patternEditor.py:171
+#, fuzzy
+#| msgid "Import a fit from the clipboard"
+msgid "Import patterns from clipboard"
+msgstr "从剪贴板导入装配"
+
+#: gui/patternEditor.py:172
+#, fuzzy
+#| msgid "Export a fit to the clipboard"
+msgid "Export patterns to clipboard"
+msgstr "导出装配到剪贴板"
+
+#: gui/patternEditor.py:276 gui/setEditor.py:210
+msgid "Patterns successfully imported from clipboard"
+msgstr "从剪贴板导入伤害模型成功"
+
+#: gui/patternEditor.py:283 gui/setEditor.py:218
+msgid "Could not import from clipboard: unknown errors"
+msgstr "无法从剪贴板导入：未知错误"
+
+#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
+msgid "Could not import from clipboard"
+msgstr "无法从剪贴板导入"
+
+#: gui/patternEditor.py:295
+msgid "Patterns exported to clipboard"
+msgstr "伤害模型已导出到剪贴板"
+
+#: gui/additionsPane.py:45
+msgid "Additions"
+msgstr "附加装备"
+
+#: gui/additionsPane.py:69
+msgid "Fighters"
+msgstr "铁骑舰载机"
+
+#: gui/additionsPane.py:78
+msgid "Boosters"
+msgstr "增效剂"
+
+#: gui/additionsPane.py:81
+msgid "Projected"
+msgstr "环境效果"
+
+#: gui/additionsPane.py:84
+msgid "Command"
+msgstr "指令"
+
+#: gui/additionsPane.py:87
+msgid "Notes"
+msgstr "备注"
+
+#: gui/fitBrowserLite.py:17
+msgid "Add Fits"
+msgstr "添加装配"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:43
+msgid "Recharge rates"
+msgstr "回充速度"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:75
+msgid "Passive shield recharge"
+msgstr "被动回充"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:76
+msgid "Active shield boost"
+msgstr "主动维修"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:77
+msgid "Armor repair amount"
+msgstr "装甲修量"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:78
+msgid "Hull repair amount"
+msgstr "结构修量"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:86
+msgid "Reinforced"
+msgstr "加强回充"
 
 #: gui/builtinStatsViews/rechargeViewFull.py:87
 msgid "Sustained"
 msgstr "持续回充"
 
-#: gui/targetProfileEditor.py:86
-msgid "Target Profile"
-msgstr "目标属性"
+#: gui/builtinStatsViews/capacitorViewFull.py:57
+msgid "Capacitor stability"
+msgstr "电容稳定性"
 
-#: gui/targetProfileEditor.py:130
-msgid "Target Profile Editor"
-msgstr "目标属性编辑器"
+#: gui/builtinStatsViews/capacitorViewFull.py:67
+msgid "Total: "
+msgstr "总容量："
 
-#: gui/targetProfileEditor.py:73
-msgid "Target Profile name already in use, please choose another."
-msgstr "目标属性名已使用，请选择其他名称。"
+#: gui/builtinStatsViews/capacitorViewFull.py:77
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Lasts "
+msgstr "可维持"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:81
+msgid "0s"
+msgstr "0秒"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:90
+msgid "Extra stats"
+msgstr "额外状态"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Stable: "
+msgstr "稳定："
+
+#: gui/builtinStatsViews/firepowerViewFull.py:100
+msgid " Volley: "
+msgstr "齐射"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:107
+msgid " DPS: "
+msgstr " DPS: "
+
+#: gui/builtinStatsViews/firepowerViewFull.py:115
+msgid "Click to toggle to Mining Yield "
+msgstr "点击切换到矿物产出视图"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:111
+msgid "Turret hardpoints"
+msgstr "炮台"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:112
+msgid "Launcher hardpoints"
+msgstr "发射器"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:113
+msgid "Drones active"
+msgstr "激活的无人机"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:114
+msgid "Fighter squadrons active"
+msgstr "激活的铁骑舰载机中队"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:115
+msgid "Calibration"
+msgstr "校准"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:153
+msgid "CPU"
+msgstr "CPU"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:154
+msgid "PowerGrid"
+msgstr "PG"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:155
+msgid "Drone bay"
+msgstr "无人机仓库"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:156
+msgid "Fighter bay"
+msgstr "铁骑舰载机仓库"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:157
+msgid "Drone bandwidth"
+msgstr "无人机带宽"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:158
+msgid "Cargo bay"
+msgstr "货舱"
 
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:38
 msgid "Targeting && Misc"
@@ -1192,103 +1290,517 @@ msgstr "目标锁定和其他"
 msgid "Targets"
 msgstr "最大锁定数"
 
-#: gui/mainFrame.py:810
-msgid "Text skills training file"
-msgstr "技能列表文本文件"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:61
+msgid "Range"
+msgstr "锁定范围"
 
-#: gui/mainFrame.py:950
-msgid "The following error was generated"
-msgstr "Pyfa 遇到以下错误"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
+msgid "Scan res."
+msgstr "扫描精度"
 
-#: gui/mainFrame.py:894
-msgid "The following path is invalid or does not exist:"
-msgstr "下述路径无效或不存在："
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
+msgid "Sensor str."
+msgstr "传感器强度"
 
-#: gui/characterEditor.py:463
-msgid "There was an error importing skills, please see log file"
-msgstr "导入技能列表出错，详见日志文件"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
+msgid "Drone range"
+msgstr "无人机半径"
 
-#: gui/esiFittings.py:196
-msgid ""
-"There was an error validating characters' SSO token. Please try logging into "
-"the character again to reset the token."
-msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:84
+msgid "Speed"
+msgstr "亚光速航速"
 
-#: gui/esiFittings.py:179
-msgid ""
-"There was an issue starting up the localized server, try setting Login "
-"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
-"Authentication Method. If this doesn't fix the problem please file an issue "
-"on Github."
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:85
+msgid "Align time"
+msgstr "起跳时间"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
+msgid "Signature"
+msgstr "信号半径"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
+msgid "Warp Speed"
+msgstr "曲速航速"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:110
+msgid "Fleet hangar"
+msgstr "舰队机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:111
+msgid "Maintenance bay"
+msgstr "维护机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:112
+msgid "Ammo hold"
 msgstr ""
-"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
-"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
+msgid "Fuel bay"
+msgstr "燃料机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
+msgid "Ship hold"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
+msgid "Small ship hold"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
+msgid "Medium ship hold"
+msgstr "中型舰船机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
+msgid "Large ship hold"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
+msgid "Industrial ship hold"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
+msgid "Ore hold"
+msgstr "矿石机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
+msgid "Mineral hold"
+msgstr "矿物机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
+msgid "Material bay"
+msgstr "矿物机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
+msgid "Gas hold"
+msgstr "气态矿物仓库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
+msgid "Salvage hold"
+msgstr "打捞件机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
+msgid "Command center hold"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
+msgid "Planetary goods hold"
+msgstr "星系开发机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
+msgid "Quafe hold"
+msgstr ""
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:39
+msgid "Mining Yield"
+msgstr "矿物产出"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:89
+msgid "Total"
+msgstr "总容量"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:102
+msgid "Click to toggle to Firepower View"
+msgstr "点击切换到火力视图"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:61
+msgid "Effective HP"
+msgstr "有效HP"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:85
+msgid "Electromagnetic resistance"
+msgstr "电磁抗性"
 
 #: gui/builtinStatsViews/resistancesViewFull.py:86
 #: gui/targetProfileEditor.py:120
 msgid "Thermal resistance"
 msgstr "热能抗性"
 
-#: gui/builtinStatsViews/miningyieldViewFull.py:89
-msgid "Total"
-msgstr "总容量"
+#: gui/builtinStatsViews/resistancesViewFull.py:87
+#: gui/targetProfileEditor.py:121
+msgid "Kinetic resistance"
+msgstr "动能抗性"
 
-#: gui/builtinStatsViews/capacitorViewFull.py:67
-msgid "Total: "
-msgstr "总容量："
+#: gui/builtinStatsViews/resistancesViewFull.py:88
+#: gui/targetProfileEditor.py:122
+msgid "Explosive resistance"
+msgstr "爆炸抗性"
 
-#: gui/itemStats.py:166
-msgid "Traits"
-msgstr "特征"
+#: gui/builtinStatsViews/resistancesViewFull.py:97
+#: gui/builtinStatsViews/resistancesViewFull.py:169
+msgid "Click to toggle between effective HP and raw HP"
+msgstr "点击切换有效HP和原始HP"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:111
-msgid "Turret hardpoints"
-msgstr "炮台"
+#: gui/builtinStatsViews/resistancesViewFull.py:112
+msgid "Shield resistance"
+msgstr "护盾抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:113
+msgid "Armor resistance"
+msgstr "装甲抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:114
+msgid "Hull resistance"
+msgstr "结构抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:115
+msgid "Incoming damage pattern"
+msgstr "伤害分布"
+
+#: gui/mainMenuBar.py:66
+msgid "&File"
+msgstr "文件(&F)"
+
+#: gui/mainMenuBar.py:68
+msgid "&New Tab"
+msgstr "新标签页(&N)"
+
+#: gui/mainMenuBar.py:69
+msgid "&Close Tab"
+msgstr "关闭标签页(&C)"
+
+#: gui/mainMenuBar.py:70
+msgid "&Close All Tabs"
+msgstr "关闭所有标签页(&C)"
+
+#: gui/mainMenuBar.py:73
+msgid "&Backup All Fittings"
+msgstr "备份所有装配(&B)"
+
+#: gui/mainMenuBar.py:73
+msgid "Backup all fittings to a XML file"
+msgstr "备份所有装配到XML文件"
+
+#: gui/mainMenuBar.py:74
+msgid "Export All Fittings to &HTML"
+msgstr "导出所有装配到网页"
+
+#: gui/mainMenuBar.py:74
+msgid "Export fits to HTML file (set in Preferences)"
+msgstr "导出装配到网页（通过偏好设置指定）"
+
+#: gui/mainMenuBar.py:81
+msgid "Fi&t"
+msgstr "装配(&T)"
+
+#: gui/mainMenuBar.py:83
+msgid "&Undo"
+msgstr "撤销(&R)"
 
 #: gui/mainMenuBar.py:83
 msgid "Undo the most recent action"
 msgstr "撤销最近一次操作"
 
-#: gui/characterEditor.py:614
-msgid "Unlearn"
-msgstr "忘掉"
+#: gui/mainMenuBar.py:84
+msgid "&Redo"
+msgstr "恢复(&R)"
 
-#: gui/updateDialog.py:54
-msgid "Update Available"
-msgstr "有更新可用"
+#: gui/mainMenuBar.py:84
+msgid "Redo the most recent undone action"
+msgstr "恢复最近一次撤销的操作"
 
-#: gui/ssoLogin.py:60
-msgid "Waiting for character login through EVE Single Sign-On."
-msgstr "正在等待角色通过EvE登录。"
+#: gui/mainMenuBar.py:87
+msgid "&To Clipboard"
+msgstr "导出到剪贴板(&T)"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
-msgid "Warp Speed"
-msgstr "曲速航速"
+#: gui/mainMenuBar.py:87
+msgid "Export a fit to the clipboard"
+msgstr "导出装配到剪贴板"
 
-#: gui/characterEditor.py:757
-msgid "You cannot link All 0 or All 5 characters to an EVE character."
-msgstr "你不能关联全0级或全5级到一个EvE角色。"
+#: gui/mainMenuBar.py:88
+msgid "&From Clipboard"
+msgstr "从剪贴板导入(&F)"
 
-#: gui/characterEditor.py:76
-msgid "You must supply a name for the Character!"
-msgstr "您必须填写一个角色名！"
+#: gui/mainMenuBar.py:88
+msgid "Import a fit from the clipboard"
+msgstr "从剪贴板导入装配"
+
+#: gui/mainMenuBar.py:91
+msgid "&Import Fittings"
+msgstr "导入装配(&I)"
+
+#: gui/mainMenuBar.py:91
+msgid "Import fittings into pyfa"
+msgstr "从文件导入装配"
+
+#: gui/mainMenuBar.py:92
+msgid "&Export Fitting"
+msgstr "导出装配(&E)"
+
+#: gui/mainMenuBar.py:92
+msgid "Export fitting to another format"
+msgstr "导出装配为其他格式"
+
+#: gui/mainMenuBar.py:95
+msgid "&Optimize Fit Price"
+msgstr "优化装配价格(&O)"
+
+#: gui/mainMenuBar.py:96
+msgid "&Graphs"
+msgstr "图表(&G)"
+
+#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
+msgid "Disable Fitting Re&strictions"
+msgstr "关闭装配资源限制(&S)"
+
+#: gui/mainMenuBar.py:104
+msgid "&Browse ESI Fittings"
+msgstr "浏览游戏内装配(&B)"
+
+#: gui/mainMenuBar.py:105
+msgid "E&xport to ESI"
+msgstr "导出到游戏(&X)"
+
+#: gui/mainMenuBar.py:111
+msgid "&Character"
+msgstr "角色(&C)"
+
+#: gui/mainMenuBar.py:113
+msgid "&Save Character"
+msgstr "保存角色(&S)"
+
+#: gui/mainMenuBar.py:114
+msgid "Save Character &As..."
+msgstr "保存角色为...(&A)"
+
+#: gui/mainMenuBar.py:115
+msgid "&Revert Character"
+msgstr "还原角色(&R)"
+
+#: gui/mainMenuBar.py:118
+msgid "&Import Character File"
+msgstr "导入角色文件(&I)"
+
+#: gui/mainMenuBar.py:118
+msgid "Import characters into pyfa from file"
+msgstr "从文件导入角色信息"
+
+#: gui/mainMenuBar.py:119
+msgid "&Export Skills Needed"
+msgstr "导出所需技能列表(&E)"
+
+#: gui/mainMenuBar.py:119
+msgid "Export skills needed for this fitting"
+msgstr "导出使用本装配所需技能"
+
+#: gui/mainMenuBar.py:122
+msgid "&Manage ESI Characters"
+msgstr "管理游戏内角色(&M)"
+
+#: gui/mainMenuBar.py:128
+msgid "Attribute &Overrides"
+msgstr "自定义属性(&O)"
+
+#: gui/mainMenuBar.py:131 gui/mainFrame.py:689
+msgid "&Turn Overrides On"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainMenuBar.py:135
+msgid "&Global"
+msgstr "全局设置(&G)"
+
+#: gui/mainMenuBar.py:137
+msgid "&Preferences"
+msgstr "偏好设置(&P)"
+
+#: gui/mainMenuBar.py:143
+msgid "&Editors"
+msgstr "编辑器(&E)"
+
+#: gui/mainMenuBar.py:144
+msgid "&Character Editor"
+msgstr "角色编辑器(&C)"
+
+#: gui/mainMenuBar.py:147
+msgid "&Implant Set Editor"
+msgstr "植入体配置编辑器(&I)"
+
+#: gui/mainMenuBar.py:150
+msgid "&Damage Pattern Editor"
+msgstr "伤害模型编辑器(&D)"
+
+#: gui/mainMenuBar.py:153
+msgid "&Target Profile Editor"
+msgstr "目标属性编辑器(&T)"
+
+#: gui/mainMenuBar.py:159
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: gui/mainMenuBar.py:160
+msgid "&Wiki"
+msgstr "百科(&W)"
+
+#: gui/mainMenuBar.py:160
+msgid "Go to wiki on GitHub"
+msgstr "转到GitHub上的百科页"
+
+#: gui/mainMenuBar.py:161
+msgid "&Forums"
+msgstr "论坛(&F)"
+
+#: gui/mainMenuBar.py:161
+msgid "Go to EVE Online Forum thread"
+msgstr "转到EvE Online论坛讨论贴"
+
+#: gui/mainMenuBar.py:166
+msgid "Open Wid&gets Inspect tool"
+msgstr "打开控件检查工具(&G)"
+
+#: gui/mainMenuBar.py:166
+msgid "Open Widgets Inspect tool"
+msgstr "打开控件检查工具"
+
+#: gui/mainMenuBar.py:167
+msgid "Open &Dev Tools"
+msgstr "打开开发者工具(&D)"
+
+#: gui/mainMenuBar.py:167
+msgid "Dev Tools"
+msgstr "开发者工具"
+
+#: gui/mainMenuBar.py:200
+msgid "Enable Fitting Re&strictions"
+msgstr "开启装配限制(&S)"
+
+#: gui/builtinShipBrowser/navigationPanel.py:48
+msgid "Ship groups"
+msgstr "舰船类型"
+
+#: gui/builtinShipBrowser/navigationPanel.py:50
+msgid "Back"
+msgstr "返回"
+
+#: gui/builtinShipBrowser/navigationPanel.py:51
+msgid "New fitting"
+msgstr "新装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:53
+#: gui/builtinShipBrowser/navigationPanel.py:147
+msgid "Hide empty ship groups"
+msgstr "隐藏空的舰船类型"
+
+#: gui/builtinShipBrowser/navigationPanel.py:56
+#: gui/builtinShipBrowser/navigationPanel.py:129
+msgid "Recent Fits"
+msgstr "最近使用的装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:61
+msgid "Search fittings"
+msgstr "搜索装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:136
+#, fuzzy
+#| msgid "Recent Fits"
+msgid "Hide Recent Fits"
+msgstr "最近使用的装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:151
+msgid "Show empty ship groups"
+msgstr "显示空的舰船类型"
 
 #: gui/setEditor.py:48
 msgid "You must supply a name for the Implant Set!"
 msgstr "您必须填写一个植入体配置名！"
 
-#: gui/patternEditor.py:51
-msgid "You must supply a name for your Damage Profile!"
-msgstr "您必须填写一个伤害模型名！"
+#: gui/setEditor.py:50
+msgid "Implant Set name already in use, please choose another."
+msgstr "植入体配置名已使用，请选择其他名称。"
+
+#: gui/setEditor.py:62
+msgid "Implant Set"
+msgstr "植入体配置"
+
+#: gui/setEditor.py:122
+msgid "Implant Set Editor"
+msgstr "植入体配置编辑器"
+
+#: gui/setEditor.py:148 gui/targetProfileEditor.py:221
+msgid "from"
+msgstr ""
+
+#: gui/setEditor.py:149 gui/targetProfileEditor.py:222
+msgid "to"
+msgstr ""
+
+#: gui/setEditor.py:161
+msgid "{} implant sets {} clipboard"
+msgstr "{}植入体配置{}剪贴板"
+
+#: gui/setEditor.py:229
+msgid "Sets exported to clipboard"
+msgstr "植入体配置已导出到剪贴板"
+
+#: gui/targetProfileEditor.py:50
+msgid "Incorrect formatting (decimals only)"
+msgstr "格式无效（仅允许小数）"
+
+#: gui/targetProfileEditor.py:52
+msgid "Incorrect range (must be 0-100)"
+msgstr "范围无效（必须是 0-100）"
 
 #: gui/targetProfileEditor.py:71
 msgid "You must supply a name for your Target Profile!"
 msgstr "您必须填写一个目标属性名！"
 
-#: gui/characterEditor.py:372 gui/patternEditor.py:171 gui/setEditor.py:148
-#: gui/targetProfileEditor.py:221
-msgid "from"
+#: gui/targetProfileEditor.py:73
+msgid "Target Profile name already in use, please choose another."
+msgstr "目标属性名已使用，请选择其他名称。"
+
+#: gui/targetProfileEditor.py:86
+msgid "Target Profile"
+msgstr "目标属性"
+
+#: gui/targetProfileEditor.py:119
+msgid "EM resistance"
+msgstr "电磁抗性"
+
+#: gui/targetProfileEditor.py:124
+msgid "Maximum speed"
+msgstr "亚光速航速"
+
+#: gui/targetProfileEditor.py:125
+msgid ""
+"Signature radius\n"
+"Leave blank for infinitely big value"
 msgstr ""
+"信号半径\n"
+"保持为空表示信号半径无限大"
+
+#: gui/targetProfileEditor.py:126
+msgid "Radius"
+msgstr "信号半径"
+
+#: gui/targetProfileEditor.py:130
+msgid "Target Profile Editor"
+msgstr "目标属性编辑器"
+
+#: gui/targetProfileEditor.py:234
+msgid "{} profiles {} clipboard"
+msgstr "{}目标属性{}剪贴板"
+
+#: gui/targetProfileEditor.py:352
+msgid "Profiles successfully imported from clipboard"
+msgstr "已成功从剪贴板导入目标属性"
+
+#: gui/targetProfileEditor.py:359
+msgid "Could not import from clipboard:"
+msgstr "无法从剪贴板导入："
+
+#: gui/targetProfileEditor.py:372
+msgid "Profiles exported to clipboard"
+msgstr "目标属性已导出到剪贴板"
+
+#: gui/multiSwitch.py:41
+msgid "Empty Tab"
+msgstr "空白标签页"
+
+#: gui/preferenceDialog.py:31
+msgid "Preferences"
+msgstr "偏好设置"
+
+#: gui/errorDialog.py:68
+msgid "Error!"
+msgstr "错误！"
 
 #: gui/errorDialog.py:69
 msgid "pyfa error"
@@ -1305,32 +1817,157 @@ msgstr ""
 "Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
 "请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
 
-#: gui/aboutData.py:31
-msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
+#: gui/mainFrame.py:182
+msgid "Market"
+msgstr "市场"
+
+#: gui/mainFrame.py:186
+msgid "Fittings"
+msgstr "装配列表"
+
+#: gui/mainFrame.py:273
+msgid "Loading previous fits..."
+msgstr "正在打开之前的装配..."
+
+#: gui/mainFrame.py:467
+msgid "EVE XML fitting files (*.xml)|*.xml"
+msgstr "EvE装配XML文件 (*.xml)|*.xml"
+
+#: gui/mainFrame.py:646
+msgid ""
+"Are you sure you wish to ignore fitting restrictions for the current fit? "
+"This could lead to wildly inaccurate results and possible errors."
+msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
+
+#: gui/mainFrame.py:653
+msgid ""
+"Re-enabling fitting restrictions for this fit will also remove any illegal "
+"items from the fit. Do you want to continue?"
+msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
+
+#: gui/mainFrame.py:672
+msgid "Manage Characters"
+msgstr "管理角色"
+
+#: gui/mainFrame.py:689
+msgid "&Turn Overrides Off"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainFrame.py:722
+msgid "Please Wait..."
+msgstr "请稍候..."
+
+#: gui/mainFrame.py:806
+msgid "Export Skills Needed As..."
+msgstr "导出所需技能列表到..."
+
+#: gui/mainFrame.py:808
+msgid "EVEMon skills training file"
+msgstr "EvEMon技能训练文件"
+
+#: gui/mainFrame.py:809
+msgid "EVEMon skills training XML file"
+msgstr "EvEMon技能训练XML文件"
+
+#: gui/mainFrame.py:810
+msgid "Text skills training file"
+msgstr "技能列表文本文件"
+
+#: gui/mainFrame.py:828
+msgid "Exporting skills needed..."
+msgstr "正在导出所需技能..."
+
+#: gui/mainFrame.py:835
+msgid "Open One Or More Fitting Files"
+msgstr "打开多个装配文件"
+
+#: gui/mainFrame.py:837
+msgid "EVE XML fitting files"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:838
+msgid "EFT text fitting files"
+msgstr "EFT装配文本文件"
+
+#: gui/mainFrame.py:839 gui/mainFrame.py:1014
+msgid "All Files"
+msgstr "所有文件"
+
+#: gui/mainFrame.py:845
+msgid "Importing fits"
+msgstr "正在导入装配"
+
+#: gui/mainFrame.py:859
+msgid "Save Backup As..."
+msgstr "保存备份为..."
+
+#: gui/mainFrame.py:860
+msgid "EVE XML fitting file"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:873 gui/mainFrame.py:904
+msgid "Backup fits"
+msgstr "备份装配"
+
+#: gui/mainFrame.py:874
+msgid "Backing up {} fits to: {}"
 msgstr ""
-"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/characterEditor.py:373 gui/patternEditor.py:172 gui/setEditor.py:149
-#: gui/targetProfileEditor.py:222
-msgid "to"
+#: gui/mainFrame.py:893
+msgid "Invalid Path"
+msgstr "无效路径"
+
+#: gui/mainFrame.py:894
+msgid "The following path is invalid or does not exist:"
+msgstr "下述路径无效或不存在："
+
+#: gui/mainFrame.py:896
+msgid "Please verify path location pyfa's preferences."
+msgstr "请确认Pyfa偏好保存位置。"
+
+#: gui/mainFrame.py:905
+msgid "Generating HTML file at: {}"
 msgstr ""
 
-#: gui/itemStats.py:87
-#, python-brace-format
-msgid "{context}Stats: {name}{debug_info}"
+#: gui/mainFrame.py:947
+msgid "Import Error"
+msgstr "导入错误"
+
+#: gui/mainFrame.py:947
+msgid "Export Error"
+msgstr "导出错误"
+
+#: gui/mainFrame.py:950
+msgid "The following error was generated"
+msgstr "Pyfa 遇到以下错误"
+
+#: gui/mainFrame.py:952
+msgid "Be aware that already processed fits were not saved"
+msgstr "请注意已处理的装配未作保存"
+
+#: gui/mainFrame.py:1011
+msgid "Open One Or More Character Files"
+msgstr "打开多个角色文件"
+
+#: gui/mainFrame.py:1013
+msgid "EVE API XML character files"
 msgstr ""
 
-#: gui/characterEditor.py:284
-msgid "{} Copy"
-msgstr "复制{}"
+#: gui/mainFrame.py:1020
+msgid "Importing Character..."
+msgstr "正在导入角色..."
 
-#: gui/setEditor.py:161
-msgid "{} implant sets {} clipboard"
-msgstr "{}植入体配置{}剪贴板"
+#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
+msgid "SSO Login"
+msgstr "通过EVE登录"
 
-#: gui/targetProfileEditor.py:234
-msgid "{} profiles {} clipboard"
-msgstr "{}目标属性{}剪贴板"
+#: gui/ssoLogin.py:20
+msgid "Copy and paste the block of text provided by pyfa.io"
+msgstr "请复制和粘贴pyfa.io提供的字符串"
+
+#: gui/ssoLogin.py:62
+msgid "Waiting for character login through EVE Single Sign-On."
+msgstr "正在等待角色通过EvE登录。"
 
 #~ msgid "drone"
 #~ msgstr "无人机"

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyfa 2.22.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-22 17:50+0800\n"
-"PO-Revision-Date: 2020-06-22 17:51+0800\n"
+"POT-Creation-Date: 2020-06-22 19:38+0800\n"
+"PO-Revision-Date: 2020-06-22 20:01+0800\n"
 "Last-Translator: zhaoweny <zhaoweny@users.noreply.github.com>\n"
 "Language-Team: Chinese (simplified)\n"
 "Language: zh_CN\n"
@@ -25,7 +25,7 @@ msgstr ""
 
 #: gui/aboutData.py:32
 msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有。"
+msgstr "所有 EvE Online 相关材料版权归CCP所有"
 
 #: gui/aboutData.py:33
 msgid ""
@@ -86,6 +86,124 @@ msgstr "指令"
 #: gui/additionsPane.py:87
 msgid "Notes"
 msgstr "备注"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:67
+msgid "Expand All"
+msgstr "展开所有"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:70
+msgid "Toggle Names"
+msgstr "切换名称"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:73
+msgid "Toggle View"
+msgstr "切换视图"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:77
+#: gui/builtinItemStatsViews/itemAttributes.py:62
+#: gui/builtinItemStatsViews/itemCompare.py:79
+msgid "Refresh"
+msgstr "刷新"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:44
+#: gui/builtinItemStatsViews/itemProperties.py:56
+msgid "Attribute"
+msgstr "属性"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:45
+#: gui/builtinItemStatsViews/itemProperties.py:57
+msgid "Current Value"
+msgstr "当前值"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:47
+msgid "Base Value"
+msgstr "基础值"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:53
+msgid "View Raw Data"
+msgstr "显示原始数据"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:57
+msgid "Export Item Stats"
+msgstr "导出物品属性"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:117
+msgid "Save CSV file"
+msgstr "保存为CSV文件"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:118
+msgid "CSV files (*.csv)|*.csv"
+msgstr "逗号分隔符文件 (*.csv)|*.csv"
+
+#: gui/builtinItemStatsViews/itemCompare.py:75
+msgid "Toggle view mode"
+msgstr "切换显示模式"
+
+#: gui/builtinItemStatsViews/itemCompare.py:147
+msgid "Item"
+msgstr "物品"
+
+#: gui/builtinItemStatsViews/itemCompare.py:155
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinStatsViews/priceViewFull.py:40
+msgid "Price"
+msgstr "价格"
+
+#: gui/builtinItemStatsViews/itemDependants.py:46 gui/characterEditor.py:591
+#: gui/characterEditor.py:616 gui/characterEditor.py:649
+msgid "Level {}"
+msgstr "等级{}"
+
+#: gui/builtinItemStatsViews/itemDescription.py:43
+#: gui/builtinItemStatsViews/itemTraits.py:25
+msgid "Copy"
+msgstr "复制"
+
+#: gui/builtinItemStatsViews/itemEffects.py:30
+#: gui/builtinViewColumns/baseName.py:55
+msgid "Name"
+msgstr "名称"
+
+#: gui/builtinItemStatsViews/itemEffects.py:31
+msgid "Active"
+msgstr "激活"
+
+#: gui/builtinItemStatsViews/itemEffects.py:32
+msgid "Type"
+msgstr "类型"
+
+#: gui/builtinItemStatsViews/itemEffects.py:34
+msgid "Run Time"
+msgstr "运行时长"
+
+#: gui/builtinItemStatsViews/itemEffects.py:35
+msgid "ID"
+msgstr "ID"
+
+#: gui/builtinItemStatsViews/itemEffects.py:56
+msgid "Yes"
+msgstr "是"
+
+#: gui/builtinItemStatsViews/itemEffects.py:58
+msgid "No"
+msgstr "否"
+
+#: gui/builtinItemStatsViews/itemMutator.py:51
+msgid "Reset defaults"
+msgstr "重置为默认值"
+
+#: gui/builtinItemStatsViews/itemMutator.py:54
+msgid "Random stats"
+msgstr "随机化属性"
+
+#: gui/builtinItemStatsViews/itemMutator.py:57
+msgid "Revert changes"
+msgstr "还原到初始状态"
+
+#: gui/builtinItemStatsViews/itemProperties.py:98
+#, python-format
+msgid "%d attribute."
+msgstr "共%d个属性"
 
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
 msgid "Context Menus"
@@ -704,12 +822,7 @@ msgstr "电容"
 
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
 msgid "Misc"
-msgstr "其他"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinStatsViews/priceViewFull.py:40
-msgid "Price"
-msgstr "价格"
+msgstr "杂项"
 
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
 #: gui/builtinStatsViews/outgoingViewFull.py:66
@@ -1023,7 +1136,7 @@ msgstr "无人机带宽"
 
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:38
 msgid "Targeting && Misc"
-msgstr "目标和其他"
+msgstr "目标和杂项"
 
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:60
 msgid "Targets"
@@ -1129,6 +1242,18 @@ msgstr "星系物质仓"
 msgid "Quafe hold"
 msgstr "酷菲(Quafe)仓"
 
+#: gui/builtinViewColumns/abilities.py:37
+msgid "Active Abilities"
+msgstr "铁骑技能"
+
+#: gui/builtinViewColumns/misc.py:50
+msgid "Misc data"
+msgstr "杂项"
+
+#: gui/builtinViewColumns/sideEffects.py:37
+msgid "Active Side Effects"
+msgstr "副作用"
+
 #: gui/characterEditor.py:76
 msgid "You must supply a name for the Character!"
 msgstr "您必须填写一个角色名！"
@@ -1212,11 +1337,6 @@ msgstr "导入技能列表出错，详见日志文件"
 #: gui/characterEditor.py:532
 msgid "Level {}d"
 msgstr "等级{}d"
-
-#: gui/characterEditor.py:591 gui/characterEditor.py:616
-#: gui/characterEditor.py:649
-msgid "Level {}"
-msgstr "等级{}"
 
 #: gui/characterEditor.py:614
 msgid "Unlearn"

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyfa 2.22.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-22 19:38+0800\n"
-"PO-Revision-Date: 2020-06-22 20:01+0800\n"
+"POT-Creation-Date: 2020-06-23 01:17+0800\n"
+"PO-Revision-Date: 2020-06-23 01:34+0800\n"
 "Last-Translator: zhaoweny <zhaoweny@users.noreply.github.com>\n"
 "Language-Team: Chinese (simplified)\n"
 "Language: zh_CN\n"
@@ -18,192 +18,432 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gui/aboutData.py:31
-msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
-msgstr ""
-"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
+#: gui/propertyEditor.py:28
+msgid "Attribute Editor"
+msgstr "属性编辑器"
 
-#: gui/aboutData.py:32
-msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有"
+#: gui/propertyEditor.py:38
+msgid "Import"
+msgstr "导入"
 
-#: gui/aboutData.py:33
-msgid ""
-"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
-msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
+#: gui/propertyEditor.py:38 gui/propertyEditor.py:39
+msgid "Import overrides"
+msgstr "导入自定义属性"
 
-#: gui/aboutData.py:34
-msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
-msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
+#: gui/propertyEditor.py:39
+msgid "Export"
+msgstr "导出"
 
-#: gui/aboutData.py:49
-msgid ""
-"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
-"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
-"high degree of accuracy. Pyfa can run on all platforms where Python and "
-"wxWidgets are supported."
-msgstr ""
-"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
-"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
-"wxWidgets支持的所有平台运行。"
+#: gui/propertyEditor.py:40
+msgid "Clear All"
+msgstr "清除所有"
 
-#: gui/additionsPane.py:45
-msgid "Additions"
-msgstr "附加装备"
+#: gui/propertyEditor.py:40
+msgid "Clear all overrides"
+msgstr "清除所有自定义属性"
 
-#: gui/additionsPane.py:66
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
-#: gui/builtinStatsViews/priceViewFull.py:58
-msgid "Drones"
-msgstr "无人机"
+#: gui/propertyEditor.py:42 gui/mainMenuBar.py:66
+msgid "&File"
+msgstr "文件(&F)"
 
-#: gui/additionsPane.py:69
-msgid "Fighters"
-msgstr "铁骑舰载机"
+#: gui/propertyEditor.py:71
+msgid "Remove Overides for Item"
+msgstr "删除物品的自定义属性"
 
-#: gui/additionsPane.py:72
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:88
-msgid "Cargo"
-msgstr "货舱"
+#: gui/propertyEditor.py:107
+msgid "Import pyfa override file"
+msgstr "导入Pyfa属性自定义文件"
 
-#: gui/additionsPane.py:75 gui/characterEditor.py:161
+#: gui/propertyEditor.py:108
+msgid "pyfa override file"
+msgstr "Pyfa属性自定义文件"
+
+#: gui/propertyEditor.py:130
+msgid "Save Overrides As..."
+msgstr "保存自定义属性为..."
+
+#: gui/propertyEditor.py:131
+msgid "pyfa overrides"
+msgstr "Pyfa属性自定义文件"
+
+#: gui/propertyEditor.py:146
+msgid "Are you sure you want to delete all overrides?"
+msgstr "您确定要删除所有自定义属性吗？"
+
+#: gui/propertyEditor.py:147 gui/esiFittings.py:157
+msgid "Confirm Delete"
+msgstr "删除确认"
+
+#: gui/propertyEditor.py:271
+#, python-format
+msgid "Default Value: %0.3f"
+msgstr "默认值：%0.3f"
+
+#: gui/characterEditor.py:76
+msgid "You must supply a name for the Character!"
+msgstr "您必须填写一个角色名！"
+
+#: gui/characterEditor.py:78
+msgid "Character name already in use, please choose another."
+msgstr "角色名已占用，请使用其他名称。"
+
+#: gui/characterEditor.py:83 gui/characterEditor.py:463
+#: gui/characterEditor.py:898 gui/characterSelection.py:174
+#: gui/patternEditor.py:58 gui/setEditor.py:55 gui/targetProfileEditor.py:78
+#: gui/mainFrame.py:898
+msgid "Error"
+msgstr "错误"
+
+#: gui/characterEditor.py:90 gui/esiFittings.py:341
+#: gui/builtinStatsViews/priceViewFull.py:57
+msgid "Character"
+msgstr "角色"
+
+#: gui/characterEditor.py:137
+msgid "Character Editor"
+msgstr "角色编辑器"
+
+#: gui/characterEditor.py:160
+msgid "Skills"
+msgstr "技能列表"
+
+#: gui/characterEditor.py:161 gui/additionsPane.py:75
 msgid "Implants"
 msgstr "植入体"
 
-#: gui/additionsPane.py:78
-msgid "Boosters"
-msgstr "增效剂"
+#: gui/characterEditor.py:162
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
+msgid "EVE SSO"
+msgstr "EvE单点登录(SSO)"
 
-#: gui/additionsPane.py:81
-msgid "Projected"
-msgstr "环境效果"
+#: gui/characterEditor.py:281
+msgid "Enter a name for your new Character:"
+msgstr "请为新角色输入一个名称："
 
-#: gui/additionsPane.py:84
-msgid "Command"
-msgstr "指令"
+#: gui/characterEditor.py:282
+msgid "Save Character As..."
+msgstr "保存角色为..."
 
-#: gui/additionsPane.py:87
-msgid "Notes"
-msgstr "备注"
+#: gui/characterEditor.py:284
+msgid "{} Copy"
+msgstr "复制{}"
 
-#: gui/builtinItemStatsViews/itemAffectedBy.py:67
-msgid "Expand All"
-msgstr "展开所有"
+#: gui/characterEditor.py:326
+msgid ""
+"Setting an Alpha clone does not replace the character's skills, but rather "
+"caps them to Alpha levels."
+msgstr ""
+"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
 
-#: gui/builtinItemStatsViews/itemAffectedBy.py:70
-msgid "Toggle Names"
-msgstr "切换名称"
+#: gui/characterEditor.py:342
+msgid "Skill"
+msgstr "技能"
 
-#: gui/builtinItemStatsViews/itemAffectedBy.py:73
-msgid "Toggle View"
-msgstr "切换视图"
+#: gui/characterEditor.py:343
+msgid "Level"
+msgstr "技能等级"
 
-#: gui/builtinItemStatsViews/itemAffectedBy.py:77
-#: gui/builtinItemStatsViews/itemAttributes.py:62
-#: gui/builtinItemStatsViews/itemCompare.py:79
-msgid "Refresh"
-msgstr "刷新"
+#: gui/characterEditor.py:356
+#, python-brace-format
+msgid "Sec Status: {0:.2f}"
+msgstr "安全等级: {0:.2f}"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:44
-#: gui/builtinItemStatsViews/itemProperties.py:56
-msgid "Attribute"
-msgstr "属性"
+#: gui/characterEditor.py:372
+msgid "Import skills from clipboard"
+msgstr "从剪贴板导入技能列表"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:45
-#: gui/builtinItemStatsViews/itemProperties.py:57
-msgid "Current Value"
-msgstr "当前值"
+#: gui/characterEditor.py:373
+msgid "Export skills from clipboard"
+msgstr "导出技能列表到剪贴板"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:47
-msgid "Base Value"
-msgstr "基础值"
+#: gui/characterEditor.py:440
+msgid ""
+"Importing skills into this character will set the skill levels as pending. "
+"To save the skills permanently, please click the Save button at the bottom "
+"of the window after importing"
+msgstr ""
+"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
+"窗口底部的保存按钮"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:53
-msgid "View Raw Data"
-msgstr "显示原始数据"
+#: gui/characterEditor.py:442
+msgid "Import Skills"
+msgstr "导入技能"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:57
-msgid "Export Item Stats"
-msgstr "导出物品属性"
+#: gui/characterEditor.py:463
+msgid "There was an error importing skills, please see log file"
+msgstr "导入技能列表出错，详见日志文件"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:117
-msgid "Save CSV file"
-msgstr "保存为CSV文件"
+#: gui/characterEditor.py:532
+msgid "Level {}d"
+msgstr "等级{}d"
 
-#: gui/builtinItemStatsViews/itemAttributes.py:118
-msgid "CSV files (*.csv)|*.csv"
-msgstr "逗号分隔符文件 (*.csv)|*.csv"
-
-#: gui/builtinItemStatsViews/itemCompare.py:75
-msgid "Toggle view mode"
-msgstr "切换显示模式"
-
-#: gui/builtinItemStatsViews/itemCompare.py:147
-msgid "Item"
-msgstr "物品"
-
-#: gui/builtinItemStatsViews/itemCompare.py:155
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinStatsViews/priceViewFull.py:40
-msgid "Price"
-msgstr "价格"
-
-#: gui/builtinItemStatsViews/itemDependants.py:46 gui/characterEditor.py:591
-#: gui/characterEditor.py:616 gui/characterEditor.py:649
+#: gui/characterEditor.py:591 gui/characterEditor.py:616
+#: gui/characterEditor.py:649 gui/builtinItemStatsViews/itemDependants.py:46
 msgid "Level {}"
 msgstr "等级{}"
 
-#: gui/builtinItemStatsViews/itemDescription.py:43
-#: gui/builtinItemStatsViews/itemTraits.py:25
-msgid "Copy"
-msgstr "复制"
+#: gui/characterEditor.py:614
+msgid "Unlearn"
+msgstr "未学习"
 
-#: gui/builtinItemStatsViews/itemEffects.py:30
-#: gui/builtinViewColumns/baseName.py:55
-msgid "Name"
-msgstr "名称"
+#: gui/characterEditor.py:757
+msgid "You cannot link All 0 or All 5 characters to an EVE character."
+msgstr "你不能关联全0级或全5级到一个EvE角色。"
 
-#: gui/builtinItemStatsViews/itemEffects.py:31
-msgid "Active"
-msgstr "激活"
+#: gui/characterEditor.py:758
+msgid "Please select another character or make a new one."
+msgstr "请选择另一角色或创建新角色。"
 
-#: gui/builtinItemStatsViews/itemEffects.py:32
-msgid "Type"
-msgstr "类型"
+#: gui/characterEditor.py:771
+msgid "Character:"
+msgstr "角色："
 
-#: gui/builtinItemStatsViews/itemEffects.py:34
-msgid "Run Time"
-msgstr "运行时长"
+#: gui/characterEditor.py:778
+msgid "Get Skills"
+msgstr "获取技能列表"
 
-#: gui/builtinItemStatsViews/itemEffects.py:35
-msgid "ID"
-msgstr "ID"
+#: gui/characterEditor.py:789
+msgid "Don't see your EVE character in the list?"
+msgstr "列表中没有你的EvE角色？"
 
-#: gui/builtinItemStatsViews/itemEffects.py:56
-msgid "Yes"
-msgstr "是"
+#: gui/characterEditor.py:794
+msgid "Log In with EVE SSO"
+msgstr "通过EVE登录"
 
-#: gui/builtinItemStatsViews/itemEffects.py:58
-msgid "No"
-msgstr "否"
+#: gui/characterEditor.py:855
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "None"
+msgstr "无"
 
-#: gui/builtinItemStatsViews/itemMutator.py:51
-msgid "Reset defaults"
-msgstr "重置为默认值"
+#: gui/characterEditor.py:897 gui/characterSelection.py:173
+msgid "Error fetching skill information"
+msgstr "无法获取技能信息"
 
-#: gui/builtinItemStatsViews/itemMutator.py:54
-msgid "Random stats"
-msgstr "随机化属性"
+#: gui/characterEditor.py:901
+msgid "Successfully fetched skills"
+msgstr "成功获取到技能列表"
 
-#: gui/builtinItemStatsViews/itemMutator.py:57
-msgid "Revert changes"
-msgstr "还原到初始状态"
+#: gui/characterEditor.py:901
+msgid "Success"
+msgstr "成功"
 
-#: gui/builtinItemStatsViews/itemProperties.py:98
-#, python-format
-msgid "%d attribute."
-msgstr "共%d个属性"
+#: gui/characterEditor.py:907
+msgid "Set Security Status"
+msgstr "设置安全等级"
+
+#: gui/characterEditor.py:914
+msgid "Security Status is used in some CONCORD hull calculations"
+msgstr "安全等级会用于计算CONCORD警察船体属性"
+
+#: gui/itemStats.py:58
+msgid "Item stats"
+msgstr "物品属性"
+
+#: gui/itemStats.py:87
+#, python-brace-format
+msgid "{context}Stats: {name}{debug_info}"
+msgstr "{context}属性：{name}{debug_info}"
+
+#: gui/itemStats.py:166
+msgid "Traits"
+msgstr "特征"
+
+#: gui/itemStats.py:170
+msgid "Mutations"
+msgstr "变质"
+
+#: gui/itemStats.py:174
+msgid "Description"
+msgstr "简介"
+
+#: gui/itemStats.py:177
+msgid "Attributes"
+msgstr "属性"
+
+#: gui/itemStats.py:182
+msgid "Compare"
+msgstr "对比"
+
+#: gui/itemStats.py:185
+msgid "Requirements"
+msgstr "技能需求"
+
+#: gui/itemStats.py:189
+msgid "Dependents"
+msgstr "依赖"
+
+#: gui/itemStats.py:192
+msgid "Effects"
+msgstr "效果"
+
+#: gui/itemStats.py:196
+msgid "Affected by"
+msgstr "影响因素"
+
+#: gui/itemStats.py:200
+msgid "Properties"
+msgstr "属性"
+
+#: gui/updateDialog.py:54
+msgid "Update Available"
+msgstr "有更新可用"
+
+#: gui/updateDialog.py:102
+msgid "Don't remind me again for this release"
+msgstr "不再提示此更新"
+
+#: gui/updateDialog.py:113
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
+msgid "Download"
+msgstr "下载"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
+msgid "Database"
+msgstr "数据库"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
+msgid ""
+"(Cannot be changed while pyfa is running. Set via command line switches.)"
+msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
+msgid "Using Executable Path for Saved Fit Database and Settings"
+msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
+msgid "pyfa User Path:"
+msgstr "pyfa用户数据路径："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
+msgid "Fitting Database:"
+msgstr "装配数据库："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
+msgid "Game Database:"
+msgstr "游戏数据库："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
+msgid "Delete All Damage Pattern Profiles"
+msgstr "删除所有伤害模型配置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
+msgid "Delete All Target Profiles"
+msgstr "删除所有目标属性配置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
+msgid "Delete All Prices"
+msgstr "删除所有价格缓存数据"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
+msgid ""
+"This is a destructive action that will delete all damage pattern profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有伤害模型配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:108
+#: gui/mainFrame.py:649 gui/mainFrame.py:655
+msgid "Confirm"
+msgstr "确认"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+msgid ""
+"This is a destructive action that will delete all target profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有目标属性配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+msgid ""
+"This is a destructive action that will delete all cached prices out of the "
+"database.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有价格缓存数据。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
+msgid "Statistics Panel"
+msgstr "属性面板"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
+msgid "Changes require restart of pyfa to take effect."
+msgstr "变更将在重启Pyfa之后生效。"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinStatsViews/resourcesViewFull.py:84
+msgid "Resources"
+msgstr "装配资源"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+msgid "Minimal"
+msgstr "简洁"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+msgid "Full"
+msgstr "完整"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinStatsViews/resistancesViewFull.py:47
+msgid "Resistances"
+msgstr "抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+msgid "Shield/Armor Tank"
+msgstr "恢复"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinStatsViews/firepowerViewFull.py:43
+msgid "Firepower"
+msgstr "火力"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinStatsViews/capacitorViewFull.py:37
+msgid "Capacitor"
+msgstr "电容"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Misc"
+msgstr "杂项"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinStatsViews/priceViewFull.py:40
+#: gui/builtinItemStatsViews/itemCompare.py:155
+msgid "Price"
+msgstr "价格"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinStatsViews/outgoingViewMinimal.py:65
+#: gui/builtinStatsViews/outgoingViewFull.py:66
+msgid "Remote Reps"
+msgstr "遥修"
 
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
 msgid "Context Menus"
@@ -266,119 +506,203 @@ msgstr "预热"
 msgid "Additions Panel Copy/Paste"
 msgstr "附加装备栏复制/粘贴"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
-msgid "Database"
-msgstr "数据库"
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:19
+msgid "HTML Export"
+msgstr "HTML导出"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:20
 msgid ""
-"(Cannot be changed while pyfa is running. Set via command line switches.)"
-msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
-msgid "Using Executable Path for Saved Fit Database and Settings"
-msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
-msgid "pyfa User Path:"
-msgstr "pyfa用户数据路径："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
-msgid "Fitting Database:"
-msgstr "装配数据库："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
-msgid "Game Database:"
-msgstr "游戏数据库："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
-msgid "Delete All Damage Pattern Profiles"
-msgstr "删除所有伤害模型配置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
-msgid "Delete All Target Profiles"
-msgstr "删除所有目标属性配置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
-msgid "Delete All Prices"
-msgstr "删除所有价格缓存数据"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
-msgid ""
-"This is a destructive action that will delete all damage pattern profiles.\n"
-"Are you sure you want to do this?"
+"HTML Export (File > Export HTML) allows you to export your entire fitting "
+"database into an HTML file at the specified location. This file can be used "
+"to easily open your fits in a web-based fitting program"
 msgstr ""
-"本操作将永久删除所有伤害模型配置。\n"
-"您确定要继续吗？"
+"HTML导出（文件>导出到所有装配到网页）可以导出你的所有装配为HTML网页，放在指定"
+"路径下。网页版装配应用可以很容易的打开该HTML网页。"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:108
-#: gui/mainFrame.py:648 gui/mainFrame.py:654
-msgid "Confirm"
-msgstr "确认"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
 msgid ""
-"This is a destructive action that will delete all target profiles.\n"
-"Are you sure you want to do this?"
+"Export Fittings in a minimal HTML Version, just containing the fittings "
+"links without any visual styling"
+msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
+#: gui/mainFrame.py:467
+msgid "Save Fitting As..."
+msgstr "保存装配为..."
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
+msgid "EVE IGB HTML fitting file"
+msgstr "EvE IGB 装配HTML网页文件"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
+msgid "Set export destination"
+msgstr "设置导出路径"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
+msgid "Enable minimal format"
+msgstr "使用极简风格"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
+msgid "Updates"
+msgstr "更新"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
+msgid ""
+"Pyfa can automatically check and notify you of new releases. This feature is "
+"toggled in the Network settings. Here, you may allow pre-release "
+"notifications and view suppressed release notifications, if any."
 msgstr ""
-"本操作将永久删除所有目标属性配置。\n"
-"您确定要继续吗？"
+"Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
+"布版本更新通知，并查看未提示的版本更新（如果有的话）。"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
+msgid "Allow pre-release notifications"
+msgstr "允许预发布版本更新通知"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
+#, python-brace-format
+msgid "Suppressing {0} Notifications"
+msgstr "有{0}个未提示的版本更新"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
 msgid ""
-"This is a destructive action that will delete all cached prices out of the "
-"database.\n"
-"Are you sure you want to do this?"
+"There is a release available which you have chosen to suppress. You can "
+"choose to reset notification suppression for this release, or download the "
+"new release from GitHub."
 msgstr ""
-"本操作将永久删除所有价格缓存数据。\n"
-"您确定要继续吗？"
+"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
-msgid "Fitting Engine"
-msgstr "装配引擎"
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
+msgid "Reset Suppression"
+msgstr "重置版本更新提示"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
+msgid "Logging"
+msgstr "日志"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
+msgid "Log file location:"
+msgstr "日志文件路径："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
+msgid "Cert Path:"
+msgstr "证书路径："
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
+msgid "Debug Logging Enabled"
+msgstr "调试日子已开启"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
 msgid ""
-"Factor in reload time when calculating capacitor usage, damage, and tank."
-msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
+"Pressing this button will cause all logs in memory to write to the log file:"
+msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
-msgid "Enforce strict skill level requirements"
-msgstr "使用严格的技能等级检查"
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
+msgid "Dump All Logs"
+msgstr "将所有日志写入文件"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:23
+msgid "Market & Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:30
+msgid "Market && Prices"
+msgstr "市场和价格"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
+msgid "Market Search Delay (ms):"
+msgstr "市场搜索延迟（毫秒）："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
 msgid ""
-"When enabled, skills will check their dependencies' requirements when their "
-"levels change and reset skills that no longer meet the requirement.\n"
-"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
-"skill, as that requires Drones V"
+"The delay between a keystroke and the market search. Can help reduce lag "
+"when typing fast in the market search box."
 msgstr ""
-"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
-"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
+"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
+msgid "Show market shortcuts"
+msgstr "显示市场快捷方式"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
+msgid "Default Market Prices:"
+msgstr "默认价格源："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
 msgid ""
-"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
-"behavior)."
-msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
+"The source you choose will be tried first, but subsequent sources will be "
+"used if the preferred source fails. The system you choose will also be tried "
+"first, and if no data is available, global price will be used."
+msgstr ""
+"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
+"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
-msgid "Global Default Spoolup Percentage:"
-msgstr "全局默认预热百分比"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
+msgid "Total Price Includes"
+msgstr "价格总计包括"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
-msgid ""
-"The amount of spoolup to use by default on module which support it. Can be "
-"changed on a per-module basis"
-msgstr "默认模块预热量。可以分模块单独设置。"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
+#: gui/additionsPane.py:66 gui/builtinStatsViews/priceViewFull.py:58
+msgid "Drones"
+msgstr "无人机"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
-#: gui/characterEditor.py:162
-msgid "EVE SSO"
-msgstr "EvE单点登录(SSO)"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
+#: gui/additionsPane.py:72 gui/builtinStatsViews/targetingMiscViewMinimal.py:88
+msgid "Cargo"
+msgstr "货舱"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
+msgid "Implants && Boosters"
+msgstr "植入体和增效剂"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
+msgid "Market Search && Recent Items"
+msgstr "搜索和显示最近使用列表时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "No changes to meta buttons"
+msgstr "不改变衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+msgid "Enable all meta buttons for a duration of search / recents"
+msgstr "一段时间内启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
+msgid "Enable all meta buttons"
+msgstr "启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
+msgid "Market Group Selection"
+msgstr "选择物品类别时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
+msgid "Empty Market View"
+msgstr "空白搜索结果时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable leftmost available meta button"
+msgstr "启用最左侧可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable all available meta buttons"
+msgstr "启用所有可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
+msgid "Item Market Group Jump"
+msgstr "切换物品分类时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button"
+msgstr "启用该物品所在衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button, disable others"
+msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
 
 #: gui/builtinPreferenceViews/pyfaEsiPreferences.py:32
 msgid ""
@@ -453,6 +777,45 @@ msgstr "客户ID(Client ID)："
 msgid "Client Secret:"
 msgstr "客户密钥(Client Secret)："
 
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
+msgid "Fitting Engine"
+msgstr "装配引擎"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
+msgid ""
+"Factor in reload time when calculating capacitor usage, damage, and tank."
+msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
+msgid "Enforce strict skill level requirements"
+msgstr "使用严格的技能等级检查"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
+msgid ""
+"When enabled, skills will check their dependencies' requirements when their "
+"levels change and reset skills that no longer meet the requirement.\n"
+"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
+"skill, as that requires Drones V"
+msgstr ""
+"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
+"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
+msgid ""
+"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
+"behavior)."
+msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
+msgid "Global Default Spoolup Percentage:"
+msgstr "全局默认预热百分比"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
+msgid ""
+"The amount of spoolup to use by default on module which support it. Can be "
+"changed on a per-module basis"
+msgstr "默认模块预热量。可以分模块单独设置。"
+
 #: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
 msgid "General"
 msgstr "通用"
@@ -522,19 +885,6 @@ msgid "Extra info in Additions panel tab names"
 msgstr "附加装备标签名显示额外信息"
 
 #: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/characterEditor.py:855
-msgid "None"
-msgstr "无"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
 msgid "Quantity of active items"
 msgstr "激活的物品数量"
 
@@ -545,161 +895,6 @@ msgstr "所有物品数量"
 #: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
 msgid "Language (restart required):"
 msgstr "语言（重启后生效）："
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:19
-msgid "HTML Export"
-msgstr "HTML导出"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:20
-msgid ""
-"HTML Export (File > Export HTML) allows you to export your entire fitting "
-"database into an HTML file at the specified location. This file can be used "
-"to easily open your fits in a web-based fitting program"
-msgstr ""
-"HTML导出（文件>导出到所有装配到网页）可以导出你的所有装配为HTML网页，放在指定"
-"路径下。This file can be used to easily open your fits in a web-based "
-"fitting program"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
-msgid ""
-"Export Fittings in a minimal HTML Version, just containing the fittings "
-"links without any visual styling"
-msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
-#: gui/mainFrame.py:466
-msgid "Save Fitting As..."
-msgstr "保存装配为..."
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
-msgid "EVE IGB HTML fitting file (*.html)|*.html"
-msgstr "EvE IGB网页装配文件 (*.html)|*.html"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
-msgid "Set export destination"
-msgstr "设置导出路径"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
-msgid "Enable minimal format"
-msgstr "使用极简风格"
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
-msgid "Logging"
-msgstr "日志"
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
-msgid "Log file location:"
-msgstr "日志文件路径："
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
-msgid "Cert Path:"
-msgstr "证书路径："
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
-msgid "Debug Logging Enabled"
-msgstr "调试日子已开启"
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
-msgid ""
-"Pressing this button will cause all logs in memory to write to the log file:"
-msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
-
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
-msgid "Dump All Logs"
-msgstr "将所有日志写入文件"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:23
-msgid "Market & Prices"
-msgstr "市场和价格"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:30
-msgid "Market && Prices"
-msgstr "市场和价格"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
-msgid "Market Search Delay (ms):"
-msgstr "市场搜索延迟（毫秒）："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
-msgid ""
-"The delay between a keystroke and the market search. Can help reduce lag "
-"when typing fast in the market search box."
-msgstr ""
-"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
-msgid "Show market shortcuts"
-msgstr "显示市场快捷方式"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
-msgid "Default Market Prices:"
-msgstr "默认价格源："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
-msgid ""
-"The source you choose will be tried first, but subsequent sources will be "
-"used if the preferred source fails. The system you choose will also be tried "
-"first, and if no data is available, global price will be used."
-msgstr ""
-"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
-"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
-msgid "Total Price Includes"
-msgstr "价格总计包括"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
-msgid "Implants && Boosters"
-msgstr "植入体和增效剂"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
-msgid "Market Search && Recent Items"
-msgstr "搜索和显示最近使用列表时"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "No changes to meta buttons"
-msgstr "不改变衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-msgid "Enable all meta buttons for a duration of search / recents"
-msgstr "一段时间内启用所有衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
-msgid "Enable all meta buttons"
-msgstr "启用所有衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
-msgid "Market Group Selection"
-msgstr "选择物品类别时"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
-msgid "Empty Market View"
-msgstr "空白搜索结果时"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable leftmost available meta button"
-msgstr "启用最左侧可用衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable all available meta buttons"
-msgstr "启用所有可用衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
-msgid "Item Market Group Jump"
-msgstr "切换物品分类时"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button"
-msgstr "启用该物品所在衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button, disable others"
-msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
 
 #: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
 msgid "Network"
@@ -766,142 +961,279 @@ msgstr "自动检测结果："
 msgid "Apply Proxy Settings"
 msgstr "应用代理配置"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
-msgid "Statistics Panel"
-msgstr "属性面板"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
-msgid "Changes require restart of pyfa to take effect."
-msgstr "变更将在重启Pyfa之后生效。"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinStatsViews/resourcesViewFull.py:84
-msgid "Resources"
-msgstr "装配资源"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-msgid "Minimal"
-msgstr "简洁"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-msgid "Full"
-msgstr "完整"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinStatsViews/resistancesViewFull.py:47
-msgid "Resistances"
-msgstr "抗性"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-msgid "Shield/Armor Tank"
-msgstr "恢复"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinStatsViews/firepowerViewFull.py:43
-msgid "Firepower"
-msgstr "火力"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinStatsViews/capacitorViewFull.py:37
-msgid "Capacitor"
-msgstr "电容"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Misc"
+#: gui/builtinViewColumns/misc.py:50
+msgid "Misc data"
 msgstr "杂项"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/builtinStatsViews/outgoingViewFull.py:66
-#: gui/builtinStatsViews/outgoingViewMinimal.py:65
-msgid "Remote Reps"
-msgstr "遥修"
+#: gui/builtinViewColumns/abilities.py:37
+msgid "Active Abilities"
+msgstr "铁骑技能"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
-msgid "Updates"
-msgstr "更新"
+#: gui/builtinViewColumns/sideEffects.py:37
+msgid "Active Side Effects"
+msgstr "副作用"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
+#: gui/builtinViewColumns/baseName.py:55
+#: gui/builtinItemStatsViews/itemEffects.py:30
+msgid "Name"
+msgstr "名称"
+
+#: gui/esiFittings.py:32
+msgid "Browse EVE Fittings"
+msgstr "浏览游戏内装配"
+
+#: gui/esiFittings.py:44
+msgid "Fetch Fits"
+msgstr "获取装配"
+
+#: gui/esiFittings.py:64
+msgid "Import to pyfa"
+msgstr "导入到Pyfa"
+
+#: gui/esiFittings.py:65
+msgid "Delete from EVE"
+msgstr "删除游戏内装配"
+
+#: gui/esiFittings.py:111
+msgid "Fetching fits, please wait..."
+msgstr "正在获取装配，请稍候..."
+
+#: gui/esiFittings.py:114
+msgid "Need at least one ESI character to fetch"
+msgstr "请为获取至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
+msgid "Connection error, please check your internet connection"
+msgstr "连接错误，请检查您的网络连接"
+
+#: gui/esiFittings.py:156
+msgid "Do you really want to delete {} ({}) from EVE?"
+msgstr "真的要从游戏内删除 {} ({})吗？"
+
+#: gui/esiFittings.py:179
 msgid ""
-"Pyfa can automatically check and notify you of new releases. This feature is "
-"toggled in the Network settings. Here, you may allow pre-release "
-"notifications and view suppressed release notifications, if any."
+"There was an issue starting up the localized server, try setting Login "
+"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
+"Authentication Method. If this doesn't fix the problem please file an issue "
+"on Github."
 msgstr ""
-"Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
-"布版本更新通知，并查看未提示的版本更新（如果有的话）。"
+"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
+"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
-msgid "Allow pre-release notifications"
-msgstr "允许预发布版本更新通知"
+#: gui/esiFittings.py:183
+msgid "Add Character Error"
+msgstr "添加角色错误"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
-#, python-brace-format
-msgid "Suppressing {0} Notifications"
-msgstr "有{0}个未提示的版本更新"
-
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
+#: gui/esiFittings.py:196
 msgid ""
-"There is a release available which you have chosen to suppress. You can "
-"choose to reset notification suppression for this release, or download the "
-"new release from GitHub."
+"There was an error validating characters' SSO token. Please try logging into "
+"the character again to reset the token."
+msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
+
+#: gui/esiFittings.py:198
+msgid "Invalid Token"
+msgstr "无效登录信息"
+
+#: gui/esiFittings.py:211
+msgid "Export fit to EVE"
+msgstr "导出装配到游戏"
+
+#: gui/esiFittings.py:224
+msgid "Export Fit"
+msgstr "导出装配"
+
+#: gui/esiFittings.py:281
+msgid "Please select an active fitting in the main window"
+msgstr "请在主窗口选择一个装配"
+
+#: gui/esiFittings.py:284
+msgid "Sending request and awaiting response"
+msgstr "正在发送请求和接收响应"
+
+#: gui/esiFittings.py:294
+msgid "Failed to generate export data"
+msgstr "无法生成导出数据"
+
+#: gui/esiFittings.py:300
+msgid "Need at least one ESI character to export"
+msgstr "请为导出至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
+msgid "ERROR"
+msgstr "错误"
+
+#: gui/esiFittings.py:334
+msgid "SSO Character Management"
+msgstr "游戏内人物管理"
+
+#: gui/esiFittings.py:342
+msgid "Character ID"
+msgstr "角色ID"
+
+#: gui/esiFittings.py:350
+msgid "Add Character"
+msgstr "添加角色"
+
+#: gui/esiFittings.py:353
+msgid "Remove Character"
+msgstr "删除角色"
+
+#: gui/aboutData.py:31
+msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
 msgstr ""
-"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
+"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
-#: gui/updateDialog.py:113
-msgid "Download"
-msgstr "下载"
+#: gui/aboutData.py:32
+msgid "All EVE-Online related materials are property of CCP hf."
+msgstr "所有 EvE Online 相关材料版权归CCP所有"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
-msgid "Reset Suppression"
-msgstr "重置版本更新提示"
+#: gui/aboutData.py:33
+msgid ""
+"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
+msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
 
-#: gui/builtinShipBrowser/navigationPanel.py:48
-msgid "Ship groups"
-msgstr "舰船类型"
+#: gui/aboutData.py:34
+msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
+msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
 
-#: gui/builtinShipBrowser/navigationPanel.py:50
-msgid "Back"
-msgstr "返回"
+#: gui/aboutData.py:49
+msgid ""
+"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
+"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
+"high degree of accuracy. Pyfa can run on all platforms where Python and "
+"wxWidgets are supported."
+msgstr ""
+"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
+"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
+"wxWidgets支持的所有平台运行。"
 
-#: gui/builtinShipBrowser/navigationPanel.py:51
-msgid "New fitting"
-msgstr "新装配"
+#: gui/characterSelection.py:47
+msgid "Character: "
+msgstr "角色："
 
-#: gui/builtinShipBrowser/navigationPanel.py:53
-#: gui/builtinShipBrowser/navigationPanel.py:147
-msgid "Hide empty ship groups"
-msgstr "隐藏空的舰船类型"
+#: gui/characterSelection.py:68
+msgid "Refresh Skills"
+msgstr "刷新技能"
 
-#: gui/builtinShipBrowser/navigationPanel.py:56
-#: gui/builtinShipBrowser/navigationPanel.py:129
-msgid "Recent Fits"
-msgstr "最近使用的装配"
+#: gui/characterSelection.py:102
+msgid "Grant Missing Skills"
+msgstr "习得所需技能"
 
-#: gui/builtinShipBrowser/navigationPanel.py:61
-msgid "Search fittings"
-msgstr "搜索装配"
+#: gui/characterSelection.py:105
+msgid "Copy Missing Skills"
+msgstr "复制所需技能"
 
-#: gui/builtinShipBrowser/navigationPanel.py:136
-msgid "Hide Recent Fits"
-msgstr "隐藏最近使用的装配"
+#: gui/characterSelection.py:150
+msgid "Open Character Editor"
+msgstr "打开角色编辑器"
 
-#: gui/builtinShipBrowser/navigationPanel.py:151
-msgid "Show empty ship groups"
-msgstr "显示空的舰船类型"
+#: gui/characterSelection.py:230
+msgid "No active fit"
+msgstr "没有选中的装配"
+
+#: gui/characterSelection.py:238
+msgid "All skill prerequisites have been met"
+msgstr "已达到所有技能要求"
+
+#: gui/characterSelection.py:242
+msgid "Skills required:"
+msgstr "所需技能："
+
+#: gui/patternEditor.py:51
+msgid "You must supply a name for your Damage Profile!"
+msgstr "您必须填写一个伤害模型名！"
+
+#: gui/patternEditor.py:53
+msgid "Damage Profile name already in use, please choose another."
+msgstr "伤害模型名已占用，请使用其他名称。"
+
+#: gui/patternEditor.py:65
+msgid "Damage Profile"
+msgstr "伤害模型"
+
+#: gui/patternEditor.py:99
+msgid "Damage Pattern Editor"
+msgstr "伤害模型编辑器"
+
+#: gui/patternEditor.py:171
+msgid "Import patterns from clipboard"
+msgstr "从剪贴板导入伤害模型"
+
+#: gui/patternEditor.py:172
+msgid "Export patterns to clipboard"
+msgstr "导出伤害模型到剪贴板"
+
+#: gui/patternEditor.py:276 gui/setEditor.py:210
+msgid "Patterns successfully imported from clipboard"
+msgstr "从剪贴板导入伤害模型成功"
+
+#: gui/patternEditor.py:283 gui/setEditor.py:218
+msgid "Could not import from clipboard: unknown errors"
+msgstr "无法从剪贴板导入：未知错误"
+
+#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
+msgid "Could not import from clipboard"
+msgstr "无法从剪贴板导入"
+
+#: gui/patternEditor.py:295
+msgid "Patterns exported to clipboard"
+msgstr "伤害模型已导出到剪贴板"
+
+#: gui/additionsPane.py:45
+msgid "Additions"
+msgstr "附加装备"
+
+#: gui/additionsPane.py:69
+msgid "Fighters"
+msgstr "铁骑舰载机"
+
+#: gui/additionsPane.py:78
+msgid "Boosters"
+msgstr "增效剂"
+
+#: gui/additionsPane.py:81
+msgid "Projected"
+msgstr "环境效果"
+
+#: gui/additionsPane.py:84
+msgid "Command"
+msgstr "指令"
+
+#: gui/additionsPane.py:87
+msgid "Notes"
+msgstr "备注"
+
+#: gui/fitBrowserLite.py:17
+msgid "Add Fits"
+msgstr "添加装配"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:43
+msgid "Recharge rates"
+msgstr "回充速度"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:75
+msgid "Passive shield recharge"
+msgstr "被动回充"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:76
+msgid "Active shield boost"
+msgstr "主动维修"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:77
+msgid "Armor repair amount"
+msgstr "装甲修量"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:78
+msgid "Hull repair amount"
+msgstr "结构修量"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:86
+msgid "Reinforced"
+msgstr "加强回充"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:87
+msgid "Sustained"
+msgstr "持续回充"
 
 #: gui/builtinStatsViews/capacitorViewFull.py:57
 msgid "Capacitor stability"
@@ -948,20 +1280,6 @@ msgstr " DPS: "
 msgid "Click to toggle to Mining Yield"
 msgstr "点击切换到矿物产出视图"
 
-#: gui/builtinStatsViews/miningyieldViewFull.py:39
-msgid "Mining Yield"
-msgstr "矿物产出"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:89
-#: gui/builtinStatsViews/priceViewFull.py:58
-#: gui/builtinStatsViews/priceViewMinimal.py:57
-msgid "Total"
-msgstr "总计"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:102
-msgid "Click to toggle to Firepower View"
-msgstr "点击切换到火力视图"
-
 #: gui/builtinStatsViews/priceViewFull.py:57
 #: gui/builtinStatsViews/priceViewMinimal.py:57
 msgid "Ship"
@@ -972,127 +1290,16 @@ msgstr "船体"
 msgid "Fittings"
 msgstr "装配"
 
-#: gui/builtinStatsViews/priceViewFull.py:57 gui/characterEditor.py:90
-#: gui/esiFittings.py:341
-msgid "Character"
-msgstr "角色"
-
 #: gui/builtinStatsViews/priceViewFull.py:58
 #: gui/builtinStatsViews/resourcesViewFull.py:158
 msgid "Cargo bay"
 msgstr "货舱"
 
-#: gui/builtinStatsViews/rechargeViewFull.py:43
-msgid "Recharge rates"
-msgstr "回充速度"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:75
-msgid "Passive shield recharge"
-msgstr "被动回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:76
-msgid "Active shield boost"
-msgstr "主动维修"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:77
-msgid "Armor repair amount"
-msgstr "装甲修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:78
-msgid "Hull repair amount"
-msgstr "结构修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:86
-msgid "Reinforced"
-msgstr "加强回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:87
-msgid "Sustained"
-msgstr "持续回充"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:61
-#: gui/builtinStatsViews/resistancesViewFull.py:219
-msgid "Effective HP: "
-msgstr "有效HP："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:85
-msgid "Electromagnetic resistance"
-msgstr "电磁抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:86
-#: gui/targetProfileEditor.py:120
-msgid "Thermal resistance"
-msgstr "热能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:87
-#: gui/targetProfileEditor.py:121
-msgid "Kinetic resistance"
-msgstr "动能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:88
-#: gui/targetProfileEditor.py:122
-msgid "Explosive resistance"
-msgstr "爆炸抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:96
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "EHP"
-msgstr "有效HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:97
-#: gui/builtinStatsViews/resistancesViewFull.py:169
-msgid "Click to toggle between effective HP and raw HP"
-msgstr "点击切换有效HP和原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:112
-msgid "Shield resistance"
-msgstr "护盾抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:113
-msgid "Armor resistance"
-msgstr "装甲抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:114
-msgid "Hull resistance"
-msgstr "结构抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:115
-msgid "Incoming damage pattern"
-msgstr "伤害分布"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "HP"
-msgstr "原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Shield: "
-msgstr "护盾："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Armor: "
-msgstr "装甲："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Hull: "
-msgstr "结构："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:213
-msgid "Resist Multiplier: "
-msgstr "抗性倍率："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:220
-#, python-format
-msgid "Effective: %d HP"
-msgstr "有效：%dHP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:222
-msgid "Raw HP: "
-msgstr "原始HP："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:223
-#, python-format
-msgid "Raw: %d HP"
-msgstr "原始：%dHP"
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+#: gui/builtinStatsViews/miningyieldViewFull.py:89
+msgid "Total"
+msgstr "总计"
 
 #: gui/builtinStatsViews/resourcesViewFull.py:111
 msgid "Turret hardpoints"
@@ -1242,501 +1449,97 @@ msgstr "星系物质仓"
 msgid "Quafe hold"
 msgstr "酷菲(Quafe)仓"
 
-#: gui/builtinViewColumns/abilities.py:37
-msgid "Active Abilities"
-msgstr "铁骑技能"
-
-#: gui/builtinViewColumns/misc.py:50
-msgid "Misc data"
-msgstr "杂项"
-
-#: gui/builtinViewColumns/sideEffects.py:37
-msgid "Active Side Effects"
-msgstr "副作用"
-
-#: gui/characterEditor.py:76
-msgid "You must supply a name for the Character!"
-msgstr "您必须填写一个角色名！"
-
-#: gui/characterEditor.py:78
-msgid "Character name already in use, please choose another."
-msgstr "角色名已占用，请使用其他名称。"
-
-#: gui/characterEditor.py:83 gui/characterEditor.py:463
-#: gui/characterEditor.py:898 gui/characterSelection.py:174
-#: gui/mainFrame.py:897 gui/patternEditor.py:58 gui/setEditor.py:55
-#: gui/targetProfileEditor.py:78
-msgid "Error"
-msgstr "错误"
-
-#: gui/characterEditor.py:137
-msgid "Character Editor"
-msgstr "角色编辑器"
-
-#: gui/characterEditor.py:160
-msgid "Skills"
-msgstr "技能列表"
-
-#: gui/characterEditor.py:281
-msgid "Enter a name for your new Character:"
-msgstr "请为新角色输入一个名称："
-
-#: gui/characterEditor.py:282
-msgid "Save Character As..."
-msgstr "保存角色为..."
-
-#: gui/characterEditor.py:284
-msgid "{} Copy"
-msgstr "复制{}"
-
-#: gui/characterEditor.py:326
-msgid ""
-"Setting an Alpha clone does not replace the character's skills, but rather "
-"caps them to Alpha levels."
-msgstr ""
-"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
-
-#: gui/characterEditor.py:342
-msgid "Skill"
-msgstr "技能"
-
-#: gui/characterEditor.py:343
-msgid "Level"
-msgstr "技能等级"
-
-#: gui/characterEditor.py:356
-#, python-brace-format
-msgid "Sec Status: {0:.2f}"
-msgstr "安全等级: {0:.2f}"
-
-#: gui/characterEditor.py:372
-msgid "Import skills from clipboard"
-msgstr "从剪贴板导入技能列表"
-
-#: gui/characterEditor.py:373
-msgid "Export skills from clipboard"
-msgstr "导出技能列表到剪贴板"
-
-#: gui/characterEditor.py:440
-msgid ""
-"Importing skills into this character will set the skill levels as pending. "
-"To save the skills permanently, please click the Save button at the bottom "
-"of the window after importing"
-msgstr ""
-"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
-"窗口底部的保存按钮"
-
-#: gui/characterEditor.py:442
-msgid "Import Skills"
-msgstr "导入技能"
-
-#: gui/characterEditor.py:463
-msgid "There was an error importing skills, please see log file"
-msgstr "导入技能列表出错，详见日志文件"
-
-#: gui/characterEditor.py:532
-msgid "Level {}d"
-msgstr "等级{}d"
-
-#: gui/characterEditor.py:614
-msgid "Unlearn"
-msgstr "未学习"
-
-#: gui/characterEditor.py:757
-msgid "You cannot link All 0 or All 5 characters to an EVE character."
-msgstr "你不能关联全0级或全5级到一个EvE角色。"
-
-#: gui/characterEditor.py:758
-msgid "Please select another character or make a new one."
-msgstr "请选择另一角色或创建新角色。"
-
-#: gui/characterEditor.py:771
-msgid "Character:"
-msgstr "角色："
-
-#: gui/characterEditor.py:778
-msgid "Get Skills"
-msgstr "获取技能列表"
-
-#: gui/characterEditor.py:789
-msgid "Don't see your EVE character in the list?"
-msgstr "列表中没有你的EvE角色？"
-
-#: gui/characterEditor.py:794
-msgid "Log In with EVE SSO"
-msgstr "通过EVE登录"
-
-#: gui/characterEditor.py:897 gui/characterSelection.py:173
-msgid "Error fetching skill information"
-msgstr "无法获取技能信息"
-
-#: gui/characterEditor.py:901
-msgid "Successfully fetched skills"
-msgstr "成功获取到技能列表"
-
-#: gui/characterEditor.py:901
-msgid "Success"
-msgstr "成功"
-
-#: gui/characterEditor.py:907
-msgid "Set Security Status"
-msgstr "设置安全等级"
-
-#: gui/characterEditor.py:914
-msgid "Security Status is used in some CONCORD hull calculations"
-msgstr "安全等级会用于计算CONCORD警察船体属性"
-
-#: gui/characterSelection.py:47
-msgid "Character: "
-msgstr "角色："
-
-#: gui/characterSelection.py:68
-msgid "Refresh Skills"
-msgstr "刷新技能"
-
-#: gui/characterSelection.py:102
-msgid "Grant Missing Skills"
-msgstr "习得所需技能"
-
-#: gui/characterSelection.py:105
-msgid "Copy Missing Skills"
-msgstr "复制所需技能"
-
-#: gui/characterSelection.py:150
-msgid "Open Character Editor"
-msgstr "打开角色编辑器"
-
-#: gui/characterSelection.py:230
-msgid "No active fit"
-msgstr "没有选中的装配"
-
-#: gui/characterSelection.py:238
-msgid "All skill prerequisites have been met"
-msgstr "已达到所有技能要求"
-
-#: gui/characterSelection.py:242
-msgid "Skills required:"
-msgstr "所需技能："
-
-#: gui/errorDialog.py:68
-msgid "Error!"
-msgstr "错误！"
-
-#: gui/errorDialog.py:69
-msgid "pyfa error"
-msgstr "Pyfa错误"
-
-#: gui/errorDialog.py:76
-msgid ""
-"pyfa has experienced an unexpected issue. Below is a message that contains "
-"crucial \n"
-"information about how this was triggered. Please contact the developers with "
-"the \n"
-"information provided through the EVE Online forums or file a GitHub issue."
-msgstr ""
-"Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
-"请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
-
-#: gui/esiFittings.py:32
-msgid "Browse EVE Fittings"
-msgstr "浏览游戏内装配"
-
-#: gui/esiFittings.py:44
-msgid "Fetch Fits"
-msgstr "获取装配"
-
-#: gui/esiFittings.py:64
-msgid "Import to pyfa"
-msgstr "导入到Pyfa"
-
-#: gui/esiFittings.py:65
-msgid "Delete from EVE"
-msgstr "删除游戏内装配"
-
-#: gui/esiFittings.py:111
-msgid "Fetching fits, please wait..."
-msgstr "正在获取装配，请稍候..."
-
-#: gui/esiFittings.py:114
-msgid "Need at least one ESI character to fetch"
-msgstr "请为获取至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
-msgid "Connection error, please check your internet connection"
-msgstr "连接错误，请检查您的网络连接"
-
-#: gui/esiFittings.py:156
-msgid "Do you really want to delete {} ({}) from EVE?"
-msgstr "真的要从游戏内删除 {} ({})吗？"
-
-#: gui/esiFittings.py:157 gui/propertyEditor.py:148
-msgid "Confirm Delete"
-msgstr "删除确认"
-
-#: gui/esiFittings.py:179
-msgid ""
-"There was an issue starting up the localized server, try setting Login "
-"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
-"Authentication Method. If this doesn't fix the problem please file an issue "
-"on Github."
-msgstr ""
-"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
-"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
-
-#: gui/esiFittings.py:183
-msgid "Add Character Error"
-msgstr "添加角色错误"
-
-#: gui/esiFittings.py:196
-msgid ""
-"There was an error validating characters' SSO token. Please try logging into "
-"the character again to reset the token."
-msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
-
-#: gui/esiFittings.py:198
-msgid "Invalid Token"
-msgstr "无效登录信息"
-
-#: gui/esiFittings.py:211
-msgid "Export fit to EVE"
-msgstr "导出装配到游戏"
-
-#: gui/esiFittings.py:224
-msgid "Export Fit"
-msgstr "导出装配"
-
-#: gui/esiFittings.py:281
-msgid "Please select an active fitting in the main window"
-msgstr "请在主窗口选择一个装配"
-
-#: gui/esiFittings.py:284
-msgid "Sending request and awaiting response"
-msgstr "正在发送请求和接收响应"
-
-#: gui/esiFittings.py:294
-msgid "Failed to generate export data"
-msgstr "无法生成导出数据"
-
-#: gui/esiFittings.py:300
-msgid "Need at least one ESI character to export"
-msgstr "请为导出至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
-msgid "ERROR"
-msgstr "错误"
-
-#: gui/esiFittings.py:334
-msgid "SSO Character Management"
-msgstr "游戏内人物管理"
-
-#: gui/esiFittings.py:342
-msgid "Character ID"
-msgstr "角色ID"
-
-#: gui/esiFittings.py:350
-msgid "Add Character"
-msgstr "添加角色"
-
-#: gui/esiFittings.py:353
-msgid "Remove Character"
-msgstr "删除角色"
-
-#: gui/fitBrowserLite.py:17
-msgid "Add Fits"
-msgstr "添加装配"
-
-#: gui/itemStats.py:58
-msgid "Item stats"
-msgstr "物品属性"
-
-#: gui/itemStats.py:87
-#, python-brace-format
-msgid "{context}Stats: {name}{debug_info}"
-msgstr "{context}属性：{name}{debug_info}"
-
-#: gui/itemStats.py:166
-msgid "Traits"
-msgstr "特征"
-
-#: gui/itemStats.py:170
-msgid "Mutations"
-msgstr "变质"
-
-#: gui/itemStats.py:174
-msgid "Description"
-msgstr "简介"
-
-#: gui/itemStats.py:177
-msgid "Attributes"
-msgstr "属性"
-
-#: gui/itemStats.py:182
-msgid "Compare"
-msgstr "对比"
-
-#: gui/itemStats.py:185
-msgid "Requirements"
-msgstr "技能需求"
-
-#: gui/itemStats.py:189
-msgid "Dependents"
-msgstr "依赖"
-
-#: gui/itemStats.py:192
-msgid "Effects"
-msgstr "效果"
-
-#: gui/itemStats.py:196
-msgid "Affected by"
-msgstr "影响因素"
-
-#: gui/itemStats.py:200
-msgid "Properties"
-msgstr "属性"
-
-#: gui/mainFrame.py:182
-msgid "Market"
-msgstr "市场"
-
-#: gui/mainFrame.py:273
-msgid "Loading previous fits..."
-msgstr "正在打开之前的装配..."
-
-#: gui/mainFrame.py:467
-msgid "EVE XML fitting files (*.xml)|*.xml"
-msgstr "EvE装配XML文件 (*.xml)|*.xml"
-
-#: gui/mainFrame.py:646
-msgid ""
-"Are you sure you wish to ignore fitting restrictions for the current fit? "
-"This could lead to wildly inaccurate results and possible errors."
-msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
-
-#: gui/mainFrame.py:653
-msgid ""
-"Re-enabling fitting restrictions for this fit will also remove any illegal "
-"items from the fit. Do you want to continue?"
-msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
-
-#: gui/mainFrame.py:672
-msgid "Manage Characters"
-msgstr "管理角色"
-
-#: gui/mainFrame.py:689
-msgid "&Turn Overrides Off"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:689 gui/mainMenuBar.py:131
-msgid "&Turn Overrides On"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:722
-msgid "Please Wait..."
-msgstr "请稍候..."
-
-#: gui/mainFrame.py:806
-msgid "Export Skills Needed As..."
-msgstr "导出所需技能列表到..."
-
-#: gui/mainFrame.py:808
-msgid "EVEMon skills training file"
-msgstr "EvEMon技能训练文件"
-
-#: gui/mainFrame.py:809
-msgid "EVEMon skills training XML file"
-msgstr "EvEMon技能训练XML文件"
-
-#: gui/mainFrame.py:810
-msgid "Text skills training file"
-msgstr "技能列表文本文件"
-
-#: gui/mainFrame.py:828
-msgid "Exporting skills needed..."
-msgstr "正在导出所需技能..."
-
-#: gui/mainFrame.py:835
-msgid "Open One Or More Fitting Files"
-msgstr "打开多个装配文件"
-
-#: gui/mainFrame.py:837
-msgid "EVE XML fitting files"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:838
-msgid "EFT text fitting files"
-msgstr "EFT装配文本文件"
-
-#: gui/mainFrame.py:839 gui/mainFrame.py:1014
-msgid "All Files"
-msgstr "所有文件"
-
-#: gui/mainFrame.py:845
-msgid "Importing fits"
-msgstr "正在导入装配"
-
-#: gui/mainFrame.py:859
-msgid "Save Backup As..."
-msgstr "保存备份为..."
-
-#: gui/mainFrame.py:860
-msgid "EVE XML fitting file"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:873 gui/mainFrame.py:904
-msgid "Backup fits"
-msgstr "备份装配"
-
-#: gui/mainFrame.py:874
-msgid "Backing up {} fits to: {}"
-msgstr "正在备份{}个装配到：{}"
-
-#: gui/mainFrame.py:893
-msgid "Invalid Path"
-msgstr "无效路径"
-
-#: gui/mainFrame.py:894
-msgid "The following path is invalid or does not exist:"
-msgstr "下述路径无效或不存在："
-
-#: gui/mainFrame.py:896
-msgid "Please verify path location pyfa's preferences."
-msgstr "请确认Pyfa偏好保存位置。"
-
-#: gui/mainFrame.py:905
-msgid "Generating HTML file at: {}"
-msgstr "正在生成网页到：{}"
-
-#: gui/mainFrame.py:947
-msgid "Import Error"
-msgstr "导入错误"
-
-#: gui/mainFrame.py:947
-msgid "Export Error"
-msgstr "导出错误"
-
-#: gui/mainFrame.py:950
-msgid "The following error was generated"
-msgstr "Pyfa 遇到以下错误"
-
-#: gui/mainFrame.py:952
-msgid "Be aware that already processed fits were not saved"
-msgstr "请注意已处理的装配未作保存"
-
-#: gui/mainFrame.py:1011
-msgid "Open One Or More Character Files"
-msgstr "打开多个角色文件"
-
-#: gui/mainFrame.py:1013
-msgid "EVE API XML character files"
-msgstr "EvE API XML角色文件"
-
-#: gui/mainFrame.py:1020
-msgid "Importing Character..."
-msgstr "正在导入角色..."
-
-#: gui/mainMenuBar.py:66 gui/propertyEditor.py:43
-msgid "&File"
-msgstr "文件(&F)"
+#: gui/builtinStatsViews/miningyieldViewFull.py:39
+msgid "Mining Yield"
+msgstr "矿物产出"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:102
+msgid "Click to toggle to Firepower View"
+msgstr "点击切换到火力视图"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:61
+#: gui/builtinStatsViews/resistancesViewFull.py:219
+msgid "Effective HP: "
+msgstr "有效HP："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:85
+msgid "Electromagnetic resistance"
+msgstr "电磁抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:86
+#: gui/targetProfileEditor.py:120
+msgid "Thermal resistance"
+msgstr "热能抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:87
+#: gui/targetProfileEditor.py:121
+msgid "Kinetic resistance"
+msgstr "动能抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:88
+#: gui/targetProfileEditor.py:122
+msgid "Explosive resistance"
+msgstr "爆炸抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:96
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "EHP"
+msgstr "有效HP"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:97
+#: gui/builtinStatsViews/resistancesViewFull.py:169
+msgid "Click to toggle between effective HP and raw HP"
+msgstr "点击切换有效HP和原始HP"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:112
+msgid "Shield resistance"
+msgstr "护盾抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:113
+msgid "Armor resistance"
+msgstr "装甲抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:114
+msgid "Hull resistance"
+msgstr "结构抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:115
+msgid "Incoming damage pattern"
+msgstr "伤害分布"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "HP"
+msgstr "原始HP"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Shield: "
+msgstr "护盾："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Armor: "
+msgstr "装甲："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Hull: "
+msgstr "结构："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:213
+msgid "Resist Multiplier: "
+msgstr "抗性倍率："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:220
+#, python-format
+msgid "Effective: %d HP"
+msgstr "有效：%dHP"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:222
+msgid "Raw HP: "
+msgstr "原始HP："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:223
+#, python-format
+msgid "Raw: %d HP"
+msgstr "原始：%dHP"
 
 #: gui/mainMenuBar.py:68
 msgid "&New Tab"
@@ -1764,7 +1567,7 @@ msgstr "导出所有装配到网页"
 
 #: gui/mainMenuBar.py:74
 msgid "Export fits to HTML file (set in Preferences)"
-msgstr "导出装配到网页（通过偏好设置指定）"
+msgstr "导出装配到HTML网页文件（通过偏好设置指定）"
 
 #: gui/mainMenuBar.py:81
 msgid "Fi&t"
@@ -1878,6 +1681,10 @@ msgstr "管理游戏内角色(&M)"
 msgid "Attribute &Overrides"
 msgstr "自定义属性(&O)"
 
+#: gui/mainMenuBar.py:131 gui/mainFrame.py:690
+msgid "&Turn Overrides On"
+msgstr "启用自定义属性(&T)"
+
 #: gui/mainMenuBar.py:135
 msgid "&Global"
 msgstr "全局设置(&G)"
@@ -1946,106 +1753,141 @@ msgstr "开发者工具"
 msgid "Enable Fitting Re&strictions"
 msgstr "开启装配限制(&S)"
 
-#: gui/multiSwitch.py:41
-msgid "Empty Tab"
-msgstr "空白标签页"
+#: gui/builtinShipBrowser/navigationPanel.py:48
+msgid "Ship groups"
+msgstr "舰船类型"
 
-#: gui/patternEditor.py:51
-msgid "You must supply a name for your Damage Profile!"
-msgstr "您必须填写一个伤害模型名！"
+#: gui/builtinShipBrowser/navigationPanel.py:50
+msgid "Back"
+msgstr "返回"
 
-#: gui/patternEditor.py:53
-msgid "Damage Profile name already in use, please choose another."
-msgstr "伤害模型名已占用，请使用其他名称。"
+#: gui/builtinShipBrowser/navigationPanel.py:51
+msgid "New fitting"
+msgstr "新装配"
 
-#: gui/patternEditor.py:65
-msgid "Damage Profile"
-msgstr "伤害模型"
+#: gui/builtinShipBrowser/navigationPanel.py:53
+#: gui/builtinShipBrowser/navigationPanel.py:147
+msgid "Hide empty ship groups"
+msgstr "隐藏空的舰船类型"
 
-#: gui/patternEditor.py:99
-msgid "Damage Pattern Editor"
-msgstr "伤害模型编辑器"
+#: gui/builtinShipBrowser/navigationPanel.py:56
+#: gui/builtinShipBrowser/navigationPanel.py:129
+msgid "Recent Fits"
+msgstr "最近使用的装配"
 
-#: gui/patternEditor.py:171
-msgid "Import patterns from clipboard"
-msgstr "从剪贴板导入伤害模型"
+#: gui/builtinShipBrowser/navigationPanel.py:61
+msgid "Search fittings"
+msgstr "搜索装配"
 
-#: gui/patternEditor.py:172
-msgid "Export patterns to clipboard"
-msgstr "导出伤害模型到剪贴板"
+#: gui/builtinShipBrowser/navigationPanel.py:136
+msgid "Hide Recent Fits"
+msgstr "隐藏最近使用的装配"
 
-#: gui/patternEditor.py:276 gui/setEditor.py:210
-msgid "Patterns successfully imported from clipboard"
-msgstr "从剪贴板导入伤害模型成功"
+#: gui/builtinShipBrowser/navigationPanel.py:151
+msgid "Show empty ship groups"
+msgstr "显示空的舰船类型"
 
-#: gui/patternEditor.py:283 gui/setEditor.py:218
-msgid "Could not import from clipboard: unknown errors"
-msgstr "无法从剪贴板导入：未知错误"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:67
+msgid "Expand All"
+msgstr "展开所有"
 
-#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
-msgid "Could not import from clipboard"
-msgstr "无法从剪贴板导入"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:70
+msgid "Toggle Names"
+msgstr "切换名称"
 
-#: gui/patternEditor.py:295
-msgid "Patterns exported to clipboard"
-msgstr "伤害模型已导出到剪贴板"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:73
+msgid "Toggle View"
+msgstr "切换视图"
 
-#: gui/preferenceDialog.py:31
-msgid "Preferences"
-msgstr "偏好设置"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:77
+#: gui/builtinItemStatsViews/itemAttributes.py:62
+#: gui/builtinItemStatsViews/itemCompare.py:79
+msgid "Refresh"
+msgstr "刷新"
 
-#: gui/propertyEditor.py:29
-msgid "Attribute Editor"
-msgstr "属性编辑器"
+#: gui/builtinItemStatsViews/itemEffects.py:31
+msgid "Active"
+msgstr "激活"
 
-#: gui/propertyEditor.py:39
-msgid "Import"
-msgstr "导入"
+#: gui/builtinItemStatsViews/itemEffects.py:32
+msgid "Type"
+msgstr "类型"
 
-#: gui/propertyEditor.py:39 gui/propertyEditor.py:40
-msgid "Import overrides"
-msgstr "导入自定义属性"
+#: gui/builtinItemStatsViews/itemEffects.py:34
+msgid "Run Time"
+msgstr "运行时长"
 
-#: gui/propertyEditor.py:40
-msgid "Export"
-msgstr "导出"
+#: gui/builtinItemStatsViews/itemEffects.py:35
+msgid "ID"
+msgstr "ID"
 
-#: gui/propertyEditor.py:41
-msgid "Clear All"
-msgstr "清除所有"
+#: gui/builtinItemStatsViews/itemEffects.py:56
+msgid "Yes"
+msgstr "是"
 
-#: gui/propertyEditor.py:41
-msgid "Clear all overrides"
-msgstr "清除所有自定义属性"
+#: gui/builtinItemStatsViews/itemEffects.py:58
+msgid "No"
+msgstr "否"
 
-#: gui/propertyEditor.py:72
-msgid "Remove Overides for Item"
-msgstr "删除物品的自定义属性"
+#: gui/builtinItemStatsViews/itemTraits.py:25
+#: gui/builtinItemStatsViews/itemDescription.py:43
+msgid "Copy"
+msgstr "复制"
 
-#: gui/propertyEditor.py:108
-msgid "Import pyfa override file"
-msgstr "导入Pyfa属性自定义文件"
+#: gui/builtinItemStatsViews/itemProperties.py:56
+#: gui/builtinItemStatsViews/itemAttributes.py:44
+msgid "Attribute"
+msgstr "属性"
 
-#: gui/propertyEditor.py:109
-msgid "pyfa override file (*.csv)|*.csv"
-msgstr "Pyfa属性自定义文件(*.csv)|*.csv"
+#: gui/builtinItemStatsViews/itemProperties.py:57
+#: gui/builtinItemStatsViews/itemAttributes.py:45
+msgid "Current Value"
+msgstr "当前值"
 
-#: gui/propertyEditor.py:131
-msgid "Save Overrides As..."
-msgstr "保存自定义属性为..."
-
-#: gui/propertyEditor.py:132
-msgid "pyfa overrides (*.csv)|*.csv"
-msgstr "Pyfa属性自定义文件(*.csv)|*.csv"
-
-#: gui/propertyEditor.py:147
-msgid "Are you sure you want to delete all overrides?"
-msgstr "您确定要删除所有自定义属性吗？"
-
-#: gui/propertyEditor.py:272
+#: gui/builtinItemStatsViews/itemProperties.py:98
 #, python-format
-msgid "Default Value: %0.3f"
-msgstr "默认值：%0.3f"
+msgid "%d attribute."
+msgstr "共%d个属性"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:47
+msgid "Base Value"
+msgstr "基础值"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:53
+msgid "View Raw Data"
+msgstr "显示原始数据"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:57
+msgid "Export Item Stats"
+msgstr "导出物品属性"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:117
+msgid "Save CSV file"
+msgstr "保存为逗号分隔符(CSV)文件"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:118
+msgid "CSV files"
+msgstr "逗号分隔符(CSV)文件"
+
+#: gui/builtinItemStatsViews/itemMutator.py:51
+msgid "Reset defaults"
+msgstr "重置为默认值"
+
+#: gui/builtinItemStatsViews/itemMutator.py:54
+msgid "Random stats"
+msgstr "随机化属性"
+
+#: gui/builtinItemStatsViews/itemMutator.py:57
+msgid "Revert changes"
+msgstr "还原到初始状态"
+
+#: gui/builtinItemStatsViews/itemCompare.py:75
+msgid "Toggle view mode"
+msgstr "切换显示模式"
+
+#: gui/builtinItemStatsViews/itemCompare.py:147
+msgid "Item"
+msgstr "物品"
 
 #: gui/setEditor.py:48
 msgid "You must supply a name for the Implant Set!"
@@ -2074,18 +1916,6 @@ msgstr "导出植入体配置到剪贴板"
 #: gui/setEditor.py:229
 msgid "Sets exported to clipboard"
 msgstr "植入体配置已导出到剪贴板"
-
-#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
-msgid "SSO Login"
-msgstr "通过EVE登录"
-
-#: gui/ssoLogin.py:20
-msgid "Copy and paste the block of text provided by pyfa.io"
-msgstr "请复制和粘贴pyfa.io提供的字符串"
-
-#: gui/ssoLogin.py:62
-msgid "Waiting for character login through EVE Single Sign-On."
-msgstr "正在等待角色通过EvE登录。"
 
 #: gui/targetProfileEditor.py:50
 msgid "Incorrect formatting (decimals only)"
@@ -2151,43 +1981,173 @@ msgstr "无法从剪贴板导入："
 msgid "Profiles exported to clipboard"
 msgstr "目标属性已导出到剪贴板"
 
-#: gui/updateDialog.py:54
-msgid "Update Available"
-msgstr "有更新可用"
+#: gui/multiSwitch.py:41
+msgid "Empty Tab"
+msgstr "空白标签页"
 
-#: gui/updateDialog.py:102
-msgid "Don't remind me again for this release"
-msgstr "不再提示此更新"
+#: gui/preferenceDialog.py:31
+msgid "Preferences"
+msgstr "偏好设置"
 
-#~ msgid "Cargo Bay"
-#~ msgstr "货舱"
+#: gui/errorDialog.py:68
+msgid "Error!"
+msgstr "错误！"
 
-#~ msgid "ship"
-#~ msgstr "船体"
+#: gui/errorDialog.py:69
+msgid "pyfa error"
+msgstr "Pyfa错误"
 
-#~ msgid "fittings"
-#~ msgstr "装配"
+#: gui/errorDialog.py:76
+msgid ""
+"pyfa has experienced an unexpected issue. Below is a message that contains "
+"crucial \n"
+"information about how this was triggered. Please contact the developers with "
+"the \n"
+"information provided through the EVE Online forums or file a GitHub issue."
+msgstr ""
+"Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
+"请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
 
-#~ msgid "character"
-#~ msgstr "角色"
+#: gui/mainFrame.py:182
+msgid "Market"
+msgstr "市场"
 
-#~ msgid "drones"
-#~ msgstr "无人机"
+#: gui/mainFrame.py:273
+msgid "Loading previous fits..."
+msgstr "正在打开之前的装配..."
 
-#~ msgid "cargoBay"
-#~ msgstr "货舱"
+#: gui/mainFrame.py:468 gui/mainFrame.py:838
+msgid "EVE XML fitting files"
+msgstr "EvE装配XML文件"
 
-#~ msgid "total"
-#~ msgstr "总计"
+#: gui/mainFrame.py:647
+msgid ""
+"Are you sure you wish to ignore fitting restrictions for the current fit? "
+"This could lead to wildly inaccurate results and possible errors."
+msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
 
-#~ msgid "{} implant sets {} clipboard"
-#~ msgstr "{}植入体配置{}剪贴板"
+#: gui/mainFrame.py:654
+msgid ""
+"Re-enabling fitting restrictions for this fit will also remove any illegal "
+"items from the fit. Do you want to continue?"
+msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
 
-#~ msgid "{} profiles {} clipboard"
-#~ msgstr "{}目标属性{}剪贴板"
+#: gui/mainFrame.py:673
+msgid "Manage Characters"
+msgstr "管理角色"
 
-#~ msgid "miner"
-#~ msgstr "采矿器"
+#: gui/mainFrame.py:690
+msgid "&Turn Overrides Off"
+msgstr "启用自定义属性(&T)"
 
-#~ msgid "turret"
-#~ msgstr "炮台"
+#: gui/mainFrame.py:723
+msgid "Please Wait..."
+msgstr "请稍候..."
+
+#: gui/mainFrame.py:807
+msgid "Export Skills Needed As..."
+msgstr "导出所需技能列表到..."
+
+#: gui/mainFrame.py:809
+msgid "EVEMon skills training file"
+msgstr "EvEMon技能训练文件"
+
+#: gui/mainFrame.py:810
+msgid "EVEMon skills training XML file"
+msgstr "EvEMon技能训练XML文件"
+
+#: gui/mainFrame.py:811
+msgid "Text skills training file"
+msgstr "技能列表文本文件"
+
+#: gui/mainFrame.py:829
+msgid "Exporting skills needed..."
+msgstr "正在导出所需技能..."
+
+#: gui/mainFrame.py:836
+msgid "Open One Or More Fitting Files"
+msgstr "打开装配文件"
+
+#: gui/mainFrame.py:839
+msgid "EFT text fitting files"
+msgstr "EFT装配文本文件"
+
+#: gui/mainFrame.py:840 gui/mainFrame.py:1015
+msgid "All Files"
+msgstr "所有文件"
+
+#: gui/mainFrame.py:846
+msgid "Importing fits"
+msgstr "正在导入装配"
+
+#: gui/mainFrame.py:860
+msgid "Save Backup As..."
+msgstr "保存备份为..."
+
+#: gui/mainFrame.py:861
+msgid "EVE XML fitting file"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:874 gui/mainFrame.py:905
+msgid "Backup fits"
+msgstr "备份装配"
+
+#: gui/mainFrame.py:875
+msgid "Backing up {} fits to: {}"
+msgstr "正在备份{}个装配到：{}"
+
+#: gui/mainFrame.py:894
+msgid "Invalid Path"
+msgstr "无效路径"
+
+#: gui/mainFrame.py:895
+msgid "The following path is invalid or does not exist:"
+msgstr "下述路径无效或不存在："
+
+#: gui/mainFrame.py:897
+msgid "Please verify path location pyfa's preferences."
+msgstr "请确认Pyfa偏好保存位置。"
+
+#: gui/mainFrame.py:906
+msgid "Generating HTML file at: {}"
+msgstr "正在生成HTML网页到：{}"
+
+#: gui/mainFrame.py:948
+msgid "Import Error"
+msgstr "导入错误"
+
+#: gui/mainFrame.py:948
+msgid "Export Error"
+msgstr "导出错误"
+
+#: gui/mainFrame.py:951
+msgid "The following error was generated"
+msgstr "Pyfa 遇到以下错误"
+
+#: gui/mainFrame.py:953
+msgid "Be aware that already processed fits were not saved"
+msgstr "请注意已处理的装配未作保存"
+
+#: gui/mainFrame.py:1012
+msgid "Open One Or More Character Files"
+msgstr "打开角色文件"
+
+#: gui/mainFrame.py:1014
+msgid "EVE API XML character files"
+msgstr "EvE API 角色XML文件"
+
+#: gui/mainFrame.py:1021
+msgid "Importing Character..."
+msgstr "正在导入角色..."
+
+#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
+msgid "SSO Login"
+msgstr "通过EVE登录"
+
+#: gui/ssoLogin.py:20
+msgid "Copy and paste the block of text provided by pyfa.io"
+msgstr "请复制和粘贴pyfa.io提供的字符串"
+
+#: gui/ssoLogin.py:62
+msgid "Waiting for character login through EVE Single Sign-On."
+msgstr "正在等待角色通过EvE登录。"

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pyfa 2.22.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-23 01:17+0800\n"
-"PO-Revision-Date: 2020-06-23 01:34+0800\n"
+"POT-Creation-Date: 2020-06-23 16:36+0800\n"
+"PO-Revision-Date: 2020-06-23 16:43+0800\n"
 "Last-Translator: zhaoweny <zhaoweny@users.noreply.github.com>\n"
 "Language-Team: Chinese (simplified)\n"
 "Language: zh_CN\n"
@@ -18,21 +18,503 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#: gui/builtinStatsViews/firepowerViewFull.py:107
+msgid " DPS: "
+msgstr " DPS: "
+
+#: gui/builtinContextMenus/itemRemove.py:44
+msgid " Stack"
+msgstr "小队"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:100
+msgid " Volley: "
+msgstr "齐射"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
+msgid " chance to be jammed"
+msgstr "概率丢失目标"
+
+#: gui/builtinItemStatsViews/itemProperties.py:98
+#, python-format
+msgid "%d attribute."
+msgstr "共%d个属性。"
+
+#: gui/mainMenuBar.py:73
+msgid "&Backup All Fittings"
+msgstr "备份所有装配(&B)"
+
+#: gui/mainMenuBar.py:104
+msgid "&Browse ESI Fittings"
+msgstr "浏览游戏内装配(&B)"
+
+#: gui/mainMenuBar.py:111
+msgid "&Character"
+msgstr "角色(&C)"
+
+#: gui/mainMenuBar.py:144
+msgid "&Character Editor"
+msgstr "角色编辑器(&C)"
+
+#: gui/mainMenuBar.py:70
+msgid "&Close All Tabs"
+msgstr "关闭所有标签页(&C)"
+
+#: gui/mainMenuBar.py:69
+msgid "&Close Tab"
+msgstr "关闭标签页(&C)"
+
+#: gui/mainMenuBar.py:150
+msgid "&Damage Pattern Editor"
+msgstr "伤害模型编辑器(&D)"
+
+#: gui/mainMenuBar.py:143
+msgid "&Editors"
+msgstr "编辑器(&E)"
+
+#: gui/mainMenuBar.py:92
+msgid "&Export Fitting"
+msgstr "导出装配(&E)"
+
+#: gui/mainMenuBar.py:119
+msgid "&Export Skills Needed"
+msgstr "导出所需技能列表(&E)"
+
+#: gui/mainMenuBar.py:66 gui/propertyEditor.py:42
+msgid "&File"
+msgstr "文件(&F)"
+
+#: gui/mainMenuBar.py:161
+msgid "&Forums"
+msgstr "论坛(&F)"
+
+#: gui/mainMenuBar.py:88
+msgid "&From Clipboard"
+msgstr "从剪贴板导入(&F)"
+
+#: gui/mainMenuBar.py:135
+msgid "&Global"
+msgstr "全局设置(&G)"
+
+#: gui/mainMenuBar.py:96
+msgid "&Graphs"
+msgstr "图表(&G)"
+
+#: gui/mainMenuBar.py:159
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: gui/mainMenuBar.py:147
+msgid "&Implant Set Editor"
+msgstr "植入体配置编辑器(&I)"
+
+#: gui/mainMenuBar.py:118
+msgid "&Import Character File"
+msgstr "导入角色文件(&I)"
+
+#: gui/mainMenuBar.py:91
+msgid "&Import Fittings"
+msgstr "导入装配(&I)"
+
+#: gui/mainMenuBar.py:122
+msgid "&Manage ESI Characters"
+msgstr "管理游戏内角色(&M)"
+
+#: gui/mainMenuBar.py:68
+msgid "&New Tab"
+msgstr "新标签页(&N)"
+
+#: gui/mainMenuBar.py:95
+msgid "&Optimize Fit Price"
+msgstr "优化装配价格(&O)"
+
+#: gui/mainMenuBar.py:137
+msgid "&Preferences"
+msgstr "偏好设置(&P)"
+
+#: gui/mainMenuBar.py:84
+msgid "&Redo"
+msgstr "恢复(&R)"
+
+#: gui/mainMenuBar.py:115
+msgid "&Revert Character"
+msgstr "还原角色(&R)"
+
+#: gui/mainMenuBar.py:113
+msgid "&Save Character"
+msgstr "保存角色(&S)"
+
+#: gui/mainMenuBar.py:153
+msgid "&Target Profile Editor"
+msgstr "目标属性编辑器(&T)"
+
+#: gui/mainMenuBar.py:87
+msgid "&To Clipboard"
+msgstr "导出到剪贴板(&T)"
+
+#: gui/mainFrame.py:690
+msgid "&Turn Overrides Off"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainFrame.py:690 gui/mainMenuBar.py:131
+msgid "&Turn Overrides On"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainMenuBar.py:83
+msgid "&Undo"
+msgstr "撤销(&R)"
+
+#: gui/mainMenuBar.py:160
+msgid "&Wiki"
+msgstr "百科(&W)"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
+msgid ""
+"(Cannot be changed while pyfa is running. Set via command line switches.)"
+msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:81
+msgid "0s"
+msgstr "0秒"
+
+#: gui/builtinContextMenus/fighterAbilities.py:33
+msgid "Abilities"
+msgstr "铁骑技能"
+
+#: gui/builtinItemStatsViews/itemEffects.py:31
+msgid "Active"
+msgstr "激活"
+
+#: gui/builtinViewColumns/abilities.py:37
+msgid "Active Abilities"
+msgstr "铁骑技能"
+
+#: gui/builtinViewColumns/sideEffects.py:37
+msgid "Active Side Effects"
+msgstr "副作用"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:76
+msgid "Active shield boost"
+msgstr "主动维修"
+
+#: gui/esiFittings.py:350
+msgid "Add Character"
+msgstr "添加角色"
+
+#: gui/esiFittings.py:183
+msgid "Add Character Error"
+msgstr "添加角色错误"
+
+#: gui/builtinContextMenus/fitAddCurrentlyOpen.py:29
+msgid "Add Currently Open Fit"
+msgstr "添加当前装配"
+
+#: gui/builtinContextMenus/envEffectAdd.py:56
+msgid "Add Environmental Effect"
+msgstr "添加环境效果"
+
+#: gui/builtinContextMenus/fitAddBrowse.py:22
+msgid "Add Fit..."
+msgstr "添加装配..."
+
+#: gui/fitBrowserLite.py:17
+msgid "Add Fits"
+msgstr "添加装配"
+
+#: gui/builtinContextMenus/cargoAddAmmo.py:28
+#, python-brace-format
+msgid "Add {0} to Cargo (x1000)"
+msgstr "添加 {0} 到货舱(x1000)"
+
+#: gui/builtinContextMenus/cargoAdd.py:33
+msgid "Add {} to Cargo"
+msgstr "添加{}到货舱"
+
+#: gui/builtinContextMenus/droneAddStack.py:40
+msgid "Add {} to Drone Bay{}"
+msgstr "添加{}到无人机机库{}"
+
+#: gui/additionsPane.py:45
+msgid "Additions"
+msgstr "附加装备"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Additions Panel Copy/Paste"
+msgstr "附加装备栏复制/粘贴"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:101
+msgid "Addr:"
+msgstr "地址："
+
+#: gui/itemStats.py:196
+msgid "Affected by"
+msgstr "影响因素"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:226
+#, python-format
+msgid "Agility:\t%.3fx"
+msgstr "灵活性：%.3fx"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
+msgid "Align time"
+msgstr "起跳时间"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:224
+#, python-format
+msgid "Align:\t%.3fs"
+msgstr "起跳时间：%.3fs"
+
+#: gui/aboutData.py:32
+msgid "All EVE-Online related materials are property of CCP hf."
+msgstr "所有 EvE Online 相关材料版权归CCP所有"
+
+#: gui/mainFrame.py:840 gui/mainFrame.py:1015
+msgid "All Files"
+msgstr "所有文件"
+
+#: gui/characterSelection.py:238
+msgid "All skill prerequisites have been met"
+msgstr "已达到所有技能要求"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
+msgid "Allow pre-release notifications"
+msgstr "允许预发布版本更新通知"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
+msgid "Ammo hold"
+msgstr "弹药仓"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
+msgid "Animate gauges"
+msgstr "启用属性进度条动画"
+
+#: gui/builtinContextMenus/implantSetApply.py:25
+msgid "Apply Implant Set"
+msgstr "应用植入体配置"
+
+#: gui/builtinContextMenus/moduleMutations.py:33
+msgid "Apply Mutaplasmid"
+msgstr "使用突变质体"
+
+#: gui/builtinContextMenus/graphDmgApplyProjected.py:23
+msgid "Apply Projected Items"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:144
+msgid "Apply Proxy Settings"
+msgstr "应用代理配置"
+
+#: gui/propertyEditor.py:146
+msgid "Are you sure you want to delete all overrides?"
+msgstr "您确定要删除所有自定义属性吗？"
+
+#: gui/mainFrame.py:647
+msgid ""
+"Are you sure you wish to ignore fitting restrictions for the current fit? "
+"This could lead to wildly inaccurate results and possible errors."
+msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:77
+msgid "Armor repair amount"
+msgstr "装甲修量"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:113
+msgid "Armor resistance"
+msgstr "装甲抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Armor: "
+msgstr "装甲："
+
+#: gui/builtinItemStatsViews/itemAttributes.py:44
+#: gui/builtinItemStatsViews/itemProperties.py:56
+msgid "Attribute"
+msgstr "属性"
+
+#: gui/mainMenuBar.py:128
+msgid "Attribute &Overrides"
+msgstr "自定义属性(&O)"
+
 #: gui/propertyEditor.py:28
 msgid "Attribute Editor"
 msgstr "属性编辑器"
 
-#: gui/propertyEditor.py:38
-msgid "Import"
-msgstr "导入"
+#: gui/itemStats.py:177
+msgid "Attributes"
+msgstr "属性"
 
-#: gui/propertyEditor.py:38 gui/propertyEditor.py:39
-msgid "Import overrides"
-msgstr "导入自定义属性"
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Auto-detected proxy settings"
+msgstr "自动检测代理设置"
 
-#: gui/propertyEditor.py:39
-msgid "Export"
-msgstr "导出"
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:136
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:158
+msgid "Auto-detected: "
+msgstr "自动检测结果："
+
+#: gui/builtinShipBrowser/navigationPanel.py:50
+msgid "Back"
+msgstr "返回"
+
+#: gui/mainFrame.py:875
+msgid "Backing up {} fits to: {}"
+msgstr "正在备份{}个装配到：{}"
+
+#: gui/mainMenuBar.py:73
+msgid "Backup all fittings to a XML file"
+msgstr "备份所有装配到XML文件"
+
+#: gui/mainFrame.py:874 gui/mainFrame.py:905
+msgid "Backup fits"
+msgstr "备份装配"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:47
+msgid "Base Value"
+msgstr "基础值"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
+msgid "Battlecruiser"
+msgstr "战巡"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
+msgid "Battleship"
+msgstr "战列"
+
+#: gui/mainFrame.py:953
+msgid "Be aware that already processed fits were not saved"
+msgstr "请注意已处理的装配未作保存"
+
+#: gui/builtinAdditionPanes/boosterView.py:215
+msgid "Booster"
+msgstr "增效剂"
+
+#: gui/additionsPane.py:78 gui/builtinContextMenus/additionsExportAll.py:23
+#: gui/builtinContextMenus/additionsExportSelection.py:23
+#: gui/builtinContextMenus/additionsImport.py:24
+msgid "Boosters"
+msgstr "增效剂"
+
+#: gui/esiFittings.py:32
+msgid "Browse EVE Fittings"
+msgstr "浏览游戏内装配"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:153
+msgid "CPU"
+msgstr "CPU"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:118
+msgid "CSV files"
+msgstr "逗号分隔符(CSV)文件"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:115
+msgid "Calibration"
+msgstr "校准"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinStatsViews/capacitorViewFull.py:37
+msgid "Capacitor"
+msgstr "电容"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:57
+msgid "Capacitor stability"
+msgstr "电容稳定性"
+
+#: gui/additionsPane.py:72 gui/builtinContextMenus/priceOptions.py:47
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:90
+msgid "Cargo"
+msgstr "货舱"
+
+#: gui/builtinContextMenus/additionsExportAll.py:20
+#: gui/builtinContextMenus/additionsExportSelection.py:20
+#: gui/builtinContextMenus/additionsImport.py:21
+msgid "Cargo Items"
+msgstr "货舱物品"
+
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/resourcesViewFull.py:158
+msgid "Cargo bay"
+msgstr "货舱"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:229
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:254
+msgid "Cargohold: "
+msgstr "货舱："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:167
+msgid "Carrier"
+msgstr "航母"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
+msgid "Cert Path:"
+msgstr "证书路径："
+
+#: gui/builtinContextMenus/skillAffectors.py:73
+#, python-format
+msgid "Change %s Skills"
+msgstr "修改%s技能等级"
+
+#: gui/builtinContextMenus/itemAmountChange.py:92
+msgid "Change Amount"
+msgstr "更改数量"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+msgid "Change Skills"
+msgstr "修改技能等级"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
+msgid "Change charge in all modules of the same type"
+msgstr "同时更换所有同类型模块的弹药"
+
+#: gui/builtinContextMenus/itemAmountChange.py:34
+#, python-brace-format
+msgid "Change {0} Quantity"
+msgstr "更改{0}数量"
+
+#: gui/builtinContextMenus/itemProjectionRange.py:34
+msgid "Change {} Range"
+msgstr "变更{}半径"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
+msgid "Changes require restart of pyfa to take effect."
+msgstr "变更将在重启Pyfa之后生效。"
+
+#: gui/builtinStatsViews/priceViewFull.py:57 gui/characterEditor.py:90
+#: gui/esiFittings.py:341
+msgid "Character"
+msgstr "角色"
+
+#: gui/characterEditor.py:137
+msgid "Character Editor"
+msgstr "角色编辑器"
+
+#: gui/esiFittings.py:342
+msgid "Character ID"
+msgstr "角色ID"
+
+#: gui/characterEditor.py:78
+msgid "Character name already in use, please choose another."
+msgstr "角色名已占用，请使用其他名称。"
+
+#: gui/characterEditor.py:771
+msgid "Character:"
+msgstr "角色："
+
+#: gui/characterSelection.py:47
+msgid "Character: "
+msgstr "角色："
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:40
+msgid "Charge"
+msgstr "弹药"
+
+#: gui/builtinViews/fittingView.py:661
+msgid "Citadel"
+msgstr "堡垒"
+
+#: gui/builtinContextMenus/fitSystemSecurity.py:38
+msgid "Citadel System Security"
+msgstr ""
 
 #: gui/propertyEditor.py:40
 msgid "Clear All"
@@ -42,314 +524,54 @@ msgstr "清除所有"
 msgid "Clear all overrides"
 msgstr "清除所有自定义属性"
 
-#: gui/propertyEditor.py:42 gui/mainMenuBar.py:66
-msgid "&File"
-msgstr "文件(&F)"
+#: gui/builtinStatsViews/resistancesViewFull.py:97
+#: gui/builtinStatsViews/resistancesViewFull.py:169
+msgid "Click to toggle between effective HP and raw HP"
+msgstr "点击切换有效HP和原始HP"
 
-#: gui/propertyEditor.py:71
-msgid "Remove Overides for Item"
-msgstr "删除物品的自定义属性"
+#: gui/builtinStatsViews/miningyieldViewFull.py:102
+msgid "Click to toggle to Firepower View"
+msgstr "点击切换到火力视图"
 
-#: gui/propertyEditor.py:107
-msgid "Import pyfa override file"
-msgstr "导入Pyfa属性自定义文件"
+#: gui/builtinStatsViews/firepowerViewFull.py:115
+msgid "Click to toggle to Mining Yield"
+msgstr "点击切换到矿物产出视图"
 
-#: gui/propertyEditor.py:108
-msgid "pyfa override file"
-msgstr "Pyfa属性自定义文件"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:76
+msgid "Client ID:"
+msgstr "客户ID(Client ID)："
 
-#: gui/propertyEditor.py:130
-msgid "Save Overrides As..."
-msgstr "保存自定义属性为..."
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:85
+msgid "Client Secret:"
+msgstr "客户密钥(Client Secret)："
 
-#: gui/propertyEditor.py:131
-msgid "pyfa overrides"
-msgstr "Pyfa属性自定义文件"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
+msgid "Color fitting view by slot"
+msgstr "用背景色区分槽位"
 
-#: gui/propertyEditor.py:146
-msgid "Are you sure you want to delete all overrides?"
-msgstr "您确定要删除所有自定义属性吗？"
+#: gui/additionsPane.py:84
+msgid "Command"
+msgstr "指令"
 
-#: gui/propertyEditor.py:147 gui/esiFittings.py:157
-msgid "Confirm Delete"
-msgstr "删除确认"
-
-#: gui/propertyEditor.py:271
-#, python-format
-msgid "Default Value: %0.3f"
-msgstr "默认值：%0.3f"
-
-#: gui/characterEditor.py:76
-msgid "You must supply a name for the Character!"
-msgstr "您必须填写一个角色名！"
-
-#: gui/characterEditor.py:78
-msgid "Character name already in use, please choose another."
-msgstr "角色名已占用，请使用其他名称。"
-
-#: gui/characterEditor.py:83 gui/characterEditor.py:463
-#: gui/characterEditor.py:898 gui/characterSelection.py:174
-#: gui/patternEditor.py:58 gui/setEditor.py:55 gui/targetProfileEditor.py:78
-#: gui/mainFrame.py:898
-msgid "Error"
-msgstr "错误"
-
-#: gui/characterEditor.py:90 gui/esiFittings.py:341
-#: gui/builtinStatsViews/priceViewFull.py:57
-msgid "Character"
-msgstr "角色"
-
-#: gui/characterEditor.py:137
-msgid "Character Editor"
-msgstr "角色编辑器"
-
-#: gui/characterEditor.py:160
-msgid "Skills"
-msgstr "技能列表"
-
-#: gui/characterEditor.py:161 gui/additionsPane.py:75
-msgid "Implants"
-msgstr "植入体"
-
-#: gui/characterEditor.py:162
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
-msgid "EVE SSO"
-msgstr "EvE单点登录(SSO)"
-
-#: gui/characterEditor.py:281
-msgid "Enter a name for your new Character:"
-msgstr "请为新角色输入一个名称："
-
-#: gui/characterEditor.py:282
-msgid "Save Character As..."
-msgstr "保存角色为..."
-
-#: gui/characterEditor.py:284
-msgid "{} Copy"
-msgstr "复制{}"
-
-#: gui/characterEditor.py:326
-msgid ""
-"Setting an Alpha clone does not replace the character's skills, but rather "
-"caps them to Alpha levels."
+#: gui/builtinAdditionPanes/commandView.py:201
+msgid "Command Fit"
 msgstr ""
-"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
 
-#: gui/characterEditor.py:342
-msgid "Skill"
-msgstr "技能"
-
-#: gui/characterEditor.py:343
-msgid "Level"
-msgstr "技能等级"
-
-#: gui/characterEditor.py:356
-#, python-brace-format
-msgid "Sec Status: {0:.2f}"
-msgstr "安全等级: {0:.2f}"
-
-#: gui/characterEditor.py:372
-msgid "Import skills from clipboard"
-msgstr "从剪贴板导入技能列表"
-
-#: gui/characterEditor.py:373
-msgid "Export skills from clipboard"
-msgstr "导出技能列表到剪贴板"
-
-#: gui/characterEditor.py:440
-msgid ""
-"Importing skills into this character will set the skill levels as pending. "
-"To save the skills permanently, please click the Save button at the bottom "
-"of the window after importing"
+#: gui/builtinContextMenus/commandFitAdd.py:51
+msgid "Command Fits"
 msgstr ""
-"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
-"窗口底部的保存按钮"
 
-#: gui/characterEditor.py:442
-msgid "Import Skills"
-msgstr "导入技能"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:127
+msgid "Command center hold"
+msgstr "指挥中心仓"
 
-#: gui/characterEditor.py:463
-msgid "There was an error importing skills, please see log file"
-msgstr "导入技能列表出错，详见日志文件"
-
-#: gui/characterEditor.py:532
-msgid "Level {}d"
-msgstr "等级{}d"
-
-#: gui/characterEditor.py:591 gui/characterEditor.py:616
-#: gui/characterEditor.py:649 gui/builtinItemStatsViews/itemDependants.py:46
-msgid "Level {}"
-msgstr "等级{}"
-
-#: gui/characterEditor.py:614
-msgid "Unlearn"
-msgstr "未学习"
-
-#: gui/characterEditor.py:757
-msgid "You cannot link All 0 or All 5 characters to an EVE character."
-msgstr "你不能关联全0级或全5级到一个EvE角色。"
-
-#: gui/characterEditor.py:758
-msgid "Please select another character or make a new one."
-msgstr "请选择另一角色或创建新角色。"
-
-#: gui/characterEditor.py:771
-msgid "Character:"
-msgstr "角色："
-
-#: gui/characterEditor.py:778
-msgid "Get Skills"
-msgstr "获取技能列表"
-
-#: gui/characterEditor.py:789
-msgid "Don't see your EVE character in the list?"
-msgstr "列表中没有你的EvE角色？"
-
-#: gui/characterEditor.py:794
-msgid "Log In with EVE SSO"
-msgstr "通过EVE登录"
-
-#: gui/characterEditor.py:855
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "None"
-msgstr "无"
-
-#: gui/characterEditor.py:897 gui/characterSelection.py:173
-msgid "Error fetching skill information"
-msgstr "无法获取技能信息"
-
-#: gui/characterEditor.py:901
-msgid "Successfully fetched skills"
-msgstr "成功获取到技能列表"
-
-#: gui/characterEditor.py:901
-msgid "Success"
-msgstr "成功"
-
-#: gui/characterEditor.py:907
-msgid "Set Security Status"
-msgstr "设置安全等级"
-
-#: gui/characterEditor.py:914
-msgid "Security Status is used in some CONCORD hull calculations"
-msgstr "安全等级会用于计算CONCORD警察船体属性"
-
-#: gui/itemStats.py:58
-msgid "Item stats"
-msgstr "物品属性"
-
-#: gui/itemStats.py:87
-#, python-brace-format
-msgid "{context}Stats: {name}{debug_info}"
-msgstr "{context}属性：{name}{debug_info}"
-
-#: gui/itemStats.py:166
-msgid "Traits"
-msgstr "特征"
-
-#: gui/itemStats.py:170
-msgid "Mutations"
-msgstr "变质"
-
-#: gui/itemStats.py:174
-msgid "Description"
-msgstr "简介"
-
-#: gui/itemStats.py:177
-msgid "Attributes"
-msgstr "属性"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
+msgid "Compact skills needed tooltip"
+msgstr "简洁技能需求提示"
 
 #: gui/itemStats.py:182
 msgid "Compare"
 msgstr "对比"
-
-#: gui/itemStats.py:185
-msgid "Requirements"
-msgstr "技能需求"
-
-#: gui/itemStats.py:189
-msgid "Dependents"
-msgstr "依赖"
-
-#: gui/itemStats.py:192
-msgid "Effects"
-msgstr "效果"
-
-#: gui/itemStats.py:196
-msgid "Affected by"
-msgstr "影响因素"
-
-#: gui/itemStats.py:200
-msgid "Properties"
-msgstr "属性"
-
-#: gui/updateDialog.py:54
-msgid "Update Available"
-msgstr "有更新可用"
-
-#: gui/updateDialog.py:102
-msgid "Don't remind me again for this release"
-msgstr "不再提示此更新"
-
-#: gui/updateDialog.py:113
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
-msgid "Download"
-msgstr "下载"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
-msgid "Database"
-msgstr "数据库"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
-msgid ""
-"(Cannot be changed while pyfa is running. Set via command line switches.)"
-msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
-msgid "Using Executable Path for Saved Fit Database and Settings"
-msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
-msgid "pyfa User Path:"
-msgstr "pyfa用户数据路径："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
-msgid "Fitting Database:"
-msgstr "装配数据库："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
-msgid "Game Database:"
-msgstr "游戏数据库："
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
-msgid "Delete All Damage Pattern Profiles"
-msgstr "删除所有伤害模型配置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
-msgid "Delete All Target Profiles"
-msgstr "删除所有目标属性配置"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
-msgid "Delete All Prices"
-msgstr "删除所有价格缓存数据"
-
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
-msgid ""
-"This is a destructive action that will delete all damage pattern profiles.\n"
-"Are you sure you want to do this?"
-msgstr ""
-"本操作将永久删除所有伤害模型配置。\n"
-"您确定要继续吗？"
 
 #: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
 #: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
@@ -358,46 +580,541 @@ msgstr ""
 msgid "Confirm"
 msgstr "确认"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+#: gui/esiFittings.py:157 gui/propertyEditor.py:147
+msgid "Confirm Delete"
+msgstr "删除确认"
+
+#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
+msgid "Connection error, please check your internet connection"
+msgstr "连接错误，请检查您的网络连接"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
+msgid "Context Menus"
+msgstr "右键菜单"
+
+#: gui/builtinItemStatsViews/itemDescription.py:43
+#: gui/builtinItemStatsViews/itemTraits.py:25
+msgid "Copy"
+msgstr "复制"
+
+#: gui/builtinContextMenus/additionsExportAll.py:39
+msgid "Copy All {}"
+msgstr "复制所有{}"
+
+#: gui/characterSelection.py:105
+msgid "Copy Missing Skills"
+msgstr "复制所需技能"
+
+#: gui/builtinContextMenus/moduleMutatedExport.py:28
+msgid "Copy Module to Clipboard"
+msgstr "复制模块到剪贴板"
+
+#: gui/builtinContextMenus/additionsExportSelection.py:39
+msgid "Copy Selected {}"
+msgstr "拷贝选中的{}"
+
+#: gui/ssoLogin.py:20
+msgid "Copy and paste the block of text provided by pyfa.io"
+msgstr "请复制和粘贴pyfa.io提供的字符串"
+
+#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
+msgid "Could not import from clipboard"
+msgstr "无法从剪贴板导入"
+
+#: gui/targetProfileEditor.py:359
+msgid "Could not import from clipboard:"
+msgstr "无法从剪贴板导入："
+
+#: gui/patternEditor.py:283 gui/setEditor.py:218
+msgid "Could not import from clipboard: unknown errors"
+msgstr "无法从剪贴板导入：未知错误"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
+msgid "Cruiser"
+msgstr "巡洋"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:45
+#: gui/builtinItemStatsViews/itemProperties.py:57
+msgid "Current Value"
+msgstr "当前值"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:63
+msgid "Custom Application"
+msgstr "自定义应用"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "Custom application"
+msgstr "自定义应用"
+
+#: gui/patternEditor.py:99
+msgid "Damage Pattern Editor"
+msgstr "伤害模型编辑器"
+
+#: gui/patternEditor.py:65
+msgid "Damage Profile"
+msgstr "伤害模型"
+
+#: gui/patternEditor.py:53
+msgid "Damage Profile name already in use, please choose another."
+msgstr "伤害模型名已占用，请使用其他名称。"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
+msgid "Database"
+msgstr "数据库"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
+msgid "Debug Logging Enabled"
+msgstr "调试日子已开启"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
+msgid "Default Market Prices:"
+msgstr "默认价格源："
+
+#: gui/propertyEditor.py:271
+#, python-format
+msgid "Default Value: %0.3f"
+msgstr "默认值：%0.3f"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
+msgid "Delete All Damage Pattern Profiles"
+msgstr "删除所有伤害模型配置"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
+msgid "Delete All Prices"
+msgstr "删除所有价格缓存数据"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
+msgid "Delete All Target Profiles"
+msgstr "删除所有目标属性配置"
+
+#: gui/esiFittings.py:65
+msgid "Delete from EVE"
+msgstr "删除游戏内装配"
+
+#: gui/itemStats.py:189
+msgid "Dependents"
+msgstr "依赖"
+
+#: gui/itemStats.py:174
+msgid "Description"
+msgstr "简介"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
+msgid "Destroyer"
+msgstr "驱逐"
+
+#: gui/mainMenuBar.py:167
+msgid "Dev Tools"
+msgstr "开发者工具"
+
+#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
+msgid "Disable Fitting Re&strictions"
+msgstr "关闭装配资源限制(&S)"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Disabled"
+msgstr "关闭"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
 msgid ""
-"This is a destructive action that will delete all target profiles.\n"
-"Are you sure you want to do this?"
+"Disabling context menus can improve responsiveness.\n"
+"You can hold {} key + right-click to show all menu items regardless of these "
+"settings."
 msgstr ""
-"本操作将永久删除所有目标属性配置。\n"
-"您确定要继续吗？"
+"关闭右键菜单可提升响应速度。\n"
+"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+#: gui/esiFittings.py:156
+msgid "Do you really want to delete {} ({}) from EVE?"
+msgstr "真的要从游戏内删除 {} ({})吗？"
+
+#: gui/updateDialog.py:102
+msgid "Don't remind me again for this release"
+msgstr "不再提示此更新"
+
+#: gui/characterEditor.py:789
+msgid "Don't see your EVE character in the list?"
+msgstr "列表中没有你的EvE角色？"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
+#: gui/updateDialog.py:113
+msgid "Download"
+msgstr "下载"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Drone"
+msgstr "无人机"
+
+#: gui/builtinContextMenus/graphDmgDroneMode.py:26
+msgid "Drone Mode"
+msgstr "无人机模式"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:157
+msgid "Drone bandwidth"
+msgstr "无人机带宽"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:155
+msgid "Drone bay"
+msgstr "无人机仓库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:66
+msgid "Drone range"
+msgstr "无人机半径"
+
+#: gui/additionsPane.py:66 gui/builtinContextMenus/additionsExportAll.py:18
+#: gui/builtinContextMenus/additionsExportSelection.py:18
+#: gui/builtinContextMenus/additionsImport.py:19
+#: gui/builtinContextMenus/priceOptions.py:40
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
+#: gui/builtinStatsViews/priceViewFull.py:58
+msgid "Drones"
+msgstr "无人机"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:113
+msgid "Drones active"
+msgstr "激活的无人机"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
+msgid "Dump All Logs"
+msgstr "将所有日志写入文件"
+
+#: gui/mainMenuBar.py:105
+msgid "E&xport to ESI"
+msgstr "导出到游戏(&X)"
+
+#: gui/mainFrame.py:839
+msgid "EFT text fitting files"
+msgstr "EFT装配文本文件"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:96
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "EHP"
+msgstr "EHP"
+
+#: gui/targetProfileEditor.py:119
+msgid "EM resistance"
+msgstr "电磁抗性"
+
+#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
+msgid "ERROR"
+msgstr "错误"
+
+#: gui/mainFrame.py:1014
+msgid "EVE API XML character files"
+msgstr "EvE API XML角色文件"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
+msgid "EVE IGB HTML fitting file"
+msgstr "EvE IGB 装配HTML网页文件"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
+#: gui/characterEditor.py:162
+msgid "EVE SSO"
+msgstr "EvE单点登录(SSO)"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:37
+msgid "EVE Servers (API && CREST import)"
+msgstr "连接到EvE服务器（API 和 CREST 导入）"
+
+#: gui/mainFrame.py:861
+msgid "EVE XML fitting file"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:468 gui/mainFrame.py:838
+msgid "EVE XML fitting files"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:810
+msgid "EVEMon skills training XML file"
+msgstr "EvEMon技能训练XML文件"
+
+#: gui/mainFrame.py:809
+msgid "EVEMon skills training file"
+msgstr "EvEMon技能训练文件"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:61
+#: gui/builtinStatsViews/resistancesViewFull.py:219
+msgid "Effective HP: "
+msgstr "有效HP："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:220
+#, python-format
+msgid "Effective: %d HP"
+msgstr "有效：%dHP"
+
+#: gui/itemStats.py:192
+msgid "Effects"
+msgstr "效果"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:85
+msgid "Electromagnetic resistance"
+msgstr "电磁抗性"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
+msgid "Empty Market View"
+msgstr "空白搜索结果时"
+
+#: gui/multiSwitch.py:41
+msgid "Empty Tab"
+msgstr "空白标签页"
+
+#: gui/mainMenuBar.py:200
+msgid "Enable Fitting Re&strictions"
+msgstr "开启装配限制(&S)"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:33
+msgid "Enable Network"
+msgstr "启用网络功能"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable all available meta buttons"
+msgstr "启用所有可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
+msgid "Enable all meta buttons"
+msgstr "启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+msgid "Enable all meta buttons for a duration of search / recents"
+msgstr "一段时间内启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button"
+msgstr "启用该物品所在衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button, disable others"
+msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable leftmost available meta button"
+msgstr "启用最左侧可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
+msgid "Enable minimal format"
+msgstr "使用极简风格"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Enabled"
+msgstr "打开"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
+msgid "Enforce strict skill level requirements"
+msgstr "使用严格的技能等级检查"
+
+#: gui/characterEditor.py:281
+msgid "Enter a name for your new Character:"
+msgstr "请为新角色输入一个名称："
+
+#: gui/builtinContextMenus/implantSetSave.py:51
+msgid "Enter a name for your new Implant Set:"
+msgstr "请为新植入体配置输入一个名称："
+
+#: gui/characterEditor.py:83 gui/characterEditor.py:463
+#: gui/characterEditor.py:898 gui/characterSelection.py:174
+#: gui/mainFrame.py:898 gui/patternEditor.py:58 gui/setEditor.py:55
+#: gui/targetProfileEditor.py:78
+msgid "Error"
+msgstr "错误"
+
+#: gui/characterEditor.py:897 gui/characterSelection.py:173
+msgid "Error fetching skill information"
+msgstr "无法获取技能信息"
+
+#: gui/errorDialog.py:68
+msgid "Error!"
+msgstr "错误！"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:67
+msgid "Expand All"
+msgstr "展开所有"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:88
+#: gui/targetProfileEditor.py:122
+msgid "Explosive resistance"
+msgstr "爆炸抗性"
+
+#: gui/propertyEditor.py:39
+msgid "Export"
+msgstr "导出"
+
+#: gui/mainMenuBar.py:74
+msgid "Export All Fittings to &HTML"
+msgstr "导出所有装配到网页"
+
+#: gui/mainFrame.py:948
+msgid "Export Error"
+msgstr "导出错误"
+
+#: gui/esiFittings.py:224
+msgid "Export Fit"
+msgstr "导出装配"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
 msgid ""
-"This is a destructive action that will delete all cached prices out of the "
-"database.\n"
-"Are you sure you want to do this?"
-msgstr ""
-"本操作将永久删除所有价格缓存数据。\n"
-"您确定要继续吗？"
+"Export Fittings in a minimal HTML Version, just containing the fittings "
+"links without any visual styling"
+msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
-msgid "Statistics Panel"
-msgstr "属性面板"
+#: gui/builtinItemStatsViews/itemAttributes.py:57
+msgid "Export Item Stats"
+msgstr "导出物品属性"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
-msgid "Changes require restart of pyfa to take effect."
-msgstr "变更将在重启Pyfa之后生效。"
+#: gui/mainFrame.py:807
+msgid "Export Skills Needed As..."
+msgstr "导出所需技能列表到..."
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinStatsViews/resourcesViewFull.py:84
-msgid "Resources"
-msgstr "装配资源"
+#: gui/mainMenuBar.py:87
+msgid "Export a fit to the clipboard"
+msgstr "导出装配到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/esiFittings.py:211
+msgid "Export fit to EVE"
+msgstr "导出装配到游戏"
+
+#: gui/mainMenuBar.py:74
+msgid "Export fits to HTML file (set in Preferences)"
+msgstr "导出装配到HTML网页文件（通过偏好设置指定）"
+
+#: gui/mainMenuBar.py:92
+msgid "Export fitting to another format"
+msgstr "导出装配为其他格式"
+
+#: gui/setEditor.py:149
+msgid "Export implant sets to clipboard"
+msgstr "导出植入体配置到剪贴板"
+
+#: gui/patternEditor.py:172
+msgid "Export patterns to clipboard"
+msgstr "导出伤害模型到剪贴板"
+
+#: gui/targetProfileEditor.py:222
+msgid "Export profiles to clipboard"
+msgstr "导出目标属性到剪贴板"
+
+#: gui/characterEditor.py:373
+msgid "Export skills from clipboard"
+msgstr "导出技能列表到剪贴板"
+
+#: gui/mainMenuBar.py:119
+msgid "Export skills needed for this fitting"
+msgstr "导出使用本装配所需技能"
+
+#: gui/mainFrame.py:829
+msgid "Exporting skills needed..."
+msgstr "正在导出所需技能..."
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
+msgid "Extra info in Additions panel tab names"
+msgstr "附加装备标签名显示额外信息"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:90
+msgid "Extra stats"
+msgstr "额外状态"
+
+#: gui/builtinContextMenus/factorReload.py:26
+msgid "Factor in Reload Time"
+msgstr "考虑换弹时间"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
+msgid ""
+"Factor in reload time when calculating capacitor usage, damage, and tank."
+msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
+
+#: gui/esiFittings.py:294
+msgid "Failed to generate export data"
+msgstr "无法生成导出数据"
+
+#: gui/aboutData.py:34
+msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
+msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
+
+#: gui/esiFittings.py:44
+msgid "Fetch Fits"
+msgstr "获取装配"
+
+#: gui/esiFittings.py:111
+msgid "Fetching fits, please wait..."
+msgstr "正在获取装配，请稍候..."
+
+#: gui/mainMenuBar.py:81
+msgid "Fi&t"
+msgstr "装配(&T)"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:156
+msgid "Fighter bay"
+msgstr "铁骑舰载机仓库"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:114
+msgid "Fighter squadrons active"
+msgstr "激活的铁骑舰载机中队"
+
+#: gui/additionsPane.py:69 gui/builtinContextMenus/additionsExportAll.py:19
+#: gui/builtinContextMenus/additionsExportSelection.py:19
+#: gui/builtinContextMenus/additionsImport.py:20
+msgid "Fighters"
+msgstr "铁骑舰载机"
+
+#: gui/builtinContextMenus/itemFill.py:32
+msgid "Fill With Module"
+msgstr "用该模块填满空白槽位"
+
+#: gui/builtinContextMenus/moduleFill.py:24
+#, python-brace-format
+msgid "Fill With {0}"
+msgstr "用{0}填满"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+msgid "Fill with module"
+msgstr "用该模块填满空白槽位"
+
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-msgid "Minimal"
-msgstr "简洁"
+#: gui/builtinStatsViews/firepowerViewFull.py:43
+msgid "Firepower"
+msgstr "火力"
+
+#: graphs/gui/lists.py:305
+msgid "Fit"
+msgstr "装配"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
+msgid "Fitting Database:"
+msgstr "装配数据库："
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
+msgid "Fitting Engine"
+msgstr "装配引擎"
+
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57 gui/mainFrame.py:186
+msgid "Fittings"
+msgstr "装配"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
+msgid "Fleet hangar"
+msgstr "舰队机库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Frigate"
+msgstr "护卫"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
+msgid "Fuel bay"
+msgstr "燃料仓"
 
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
@@ -410,101 +1127,46 @@ msgstr "简洁"
 msgid "Full"
 msgstr "完整"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinStatsViews/resistancesViewFull.py:47
-msgid "Resistances"
-msgstr "抗性"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
+msgid "Game Database:"
+msgstr "游戏数据库："
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-msgid "Shield/Armor Tank"
-msgstr "恢复"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
+msgid "Gas hold"
+msgstr "气体矿物仓库"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinStatsViews/firepowerViewFull.py:43
-msgid "Firepower"
-msgstr "火力"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
+msgid "General"
+msgstr "通用"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinStatsViews/capacitorViewFull.py:37
-msgid "Capacitor"
-msgstr "电容"
+#: gui/mainFrame.py:906
+msgid "Generating HTML file at: {}"
+msgstr "正在生成HTML网页到：{}"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Misc"
-msgstr "杂项"
+#: gui/characterEditor.py:778
+msgid "Get Skills"
+msgstr "获取技能列表"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinStatsViews/priceViewFull.py:40
-#: gui/builtinItemStatsViews/itemCompare.py:155
-msgid "Price"
-msgstr "价格"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
+msgid "Global Default Spoolup Percentage:"
+msgstr "全局默认预热百分比："
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/builtinStatsViews/outgoingViewMinimal.py:65
-#: gui/builtinStatsViews/outgoingViewFull.py:66
-msgid "Remote Reps"
-msgstr "遥修"
+#: gui/mainMenuBar.py:161
+msgid "Go to EVE Online Forum thread"
+msgstr "转到EvE Online论坛讨论贴"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
-msgid "Context Menus"
-msgstr "右键菜单"
+#: gui/mainMenuBar.py:160
+msgid "Go to wiki on GitHub"
+msgstr "转到GitHub上的百科页"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
-msgid ""
-"Disabling context menus can improve responsiveness.\n"
-"You can hold {} key + right-click to show all menu items regardless of these "
-"settings."
-msgstr ""
-"关闭右键菜单可提升响应速度。\n"
-"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
+#: gui/characterSelection.py:102
+msgid "Grant Missing Skills"
+msgstr "习得所需技能"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-msgid "Set as Damage Pattern"
-msgstr "设置为伤害模型"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Disabled"
-msgstr "关闭"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Enabled"
-msgstr "打开"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-msgid "Change Skills"
-msgstr "修改技能等级"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-msgid "Variations"
-msgstr "变种"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-msgid "Project onto Fit"
-msgstr ""
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-msgid "Fill with module"
-msgstr "用该模块填满空白槽位"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-msgid "Spoolup"
-msgstr "预热"
-
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Additions Panel Copy/Paste"
-msgstr "附加装备栏复制/粘贴"
+#: gui/builtinStatsViews/resistancesViewFull.py:172
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "HP"
+msgstr "HP"
 
 #: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:19
 msgid "HTML Export"
@@ -517,89 +1179,266 @@ msgid ""
 "to easily open your fits in a web-based fitting program"
 msgstr ""
 "HTML导出（文件>导出到所有装配到网页）可以导出你的所有装配为HTML网页，放在指定"
-"路径下。网页版装配应用可以很容易的打开该HTML网页。"
+"路径下。网页版装配应用可以很容易的打开该HTML网页"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
+#: gui/builtinShipBrowser/navigationPanel.py:136
+msgid "Hide Recent Fits"
+msgstr "隐藏最近使用的装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:53
+#: gui/builtinShipBrowser/navigationPanel.py:147
+msgid "Hide empty ship groups"
+msgstr "隐藏空的舰船类型"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:78
+msgid "Hull repair amount"
+msgstr "结构修量"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:114
+msgid "Hull resistance"
+msgstr "结构抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Hull: "
+msgstr "结构："
+
+#: gui/builtinItemStatsViews/itemEffects.py:35
+msgid "ID"
+msgstr "ID"
+
+#: gui/builtinContextMenus/graphDroneControlRange.py:23
+msgid "Ignore Drone Control Range"
+msgstr "忽略无人机控制半径"
+
+#: gui/builtinContextMenus/graphLockRange.py:23
+msgid "Ignore Lock Range"
+msgstr "忽略锁定半径"
+
+#: gui/builtinContextMenus/graphDmgIgnoreResists.py:23
+msgid "Ignore Target Resists"
+msgstr "忽略目标抗性"
+
+#: gui/setEditor.py:62
+msgid "Implant Set"
+msgstr "植入体配置"
+
+#: gui/setEditor.py:122
+msgid "Implant Set Editor"
+msgstr "植入体配置编辑器"
+
+#: gui/setEditor.py:50
+msgid "Implant Set name already in use, please choose another."
+msgstr "植入体配置名已使用，请选择其他名称。"
+
+#: gui/additionsPane.py:75 gui/builtinContextMenus/additionsExportAll.py:21
+#: gui/builtinContextMenus/additionsExportAll.py:22
+#: gui/builtinContextMenus/additionsExportSelection.py:21
+#: gui/builtinContextMenus/additionsExportSelection.py:22
+#: gui/builtinContextMenus/additionsImport.py:22
+#: gui/builtinContextMenus/additionsImport.py:23 gui/characterEditor.py:161
+msgid "Implants"
+msgstr "植入体"
+
+#: gui/builtinContextMenus/priceOptions.py:54
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
+msgid "Implants && Boosters"
+msgstr "植入体和增效剂"
+
+#: gui/propertyEditor.py:38
+msgid "Import"
+msgstr "导入"
+
+#: gui/mainFrame.py:948
+msgid "Import Error"
+msgstr "导入错误"
+
+#: gui/characterEditor.py:442
+msgid "Import Skills"
+msgstr "导入技能"
+
+#: gui/mainMenuBar.py:88
+msgid "Import a fit from the clipboard"
+msgstr "从剪贴板导入装配"
+
+#: gui/mainMenuBar.py:118
+msgid "Import characters into pyfa from file"
+msgstr "从文件导入角色信息"
+
+#: gui/mainMenuBar.py:91
+msgid "Import fittings into pyfa"
+msgstr "从文件导入装配"
+
+#: gui/setEditor.py:148
+msgid "Import implant sets from clipboard"
+msgstr "从剪贴板导入植入体配置"
+
+#: gui/propertyEditor.py:38 gui/propertyEditor.py:39
+msgid "Import overrides"
+msgstr "导入自定义属性"
+
+#: gui/patternEditor.py:171
+msgid "Import patterns from clipboard"
+msgstr "从剪贴板导入伤害模型"
+
+#: gui/targetProfileEditor.py:221
+msgid "Import profiles from clipboard"
+msgstr "从剪贴板导入目标属性"
+
+#: gui/propertyEditor.py:107
+msgid "Import pyfa override file"
+msgstr "导入Pyfa属性自定义文件"
+
+#: gui/characterEditor.py:372
+msgid "Import skills from clipboard"
+msgstr "从剪贴板导入技能列表"
+
+#: gui/esiFittings.py:64
+msgid "Import to pyfa"
+msgstr "导入到Pyfa"
+
+#: gui/mainFrame.py:1021
+msgid "Importing Character..."
+msgstr "正在导入角色..."
+
+#: gui/mainFrame.py:846
+msgid "Importing fits"
+msgstr "正在导入装配"
+
+#: gui/characterEditor.py:440
 msgid ""
-"Export Fittings in a minimal HTML Version, just containing the fittings "
-"links without any visual styling"
-msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
-#: gui/mainFrame.py:467
-msgid "Save Fitting As..."
-msgstr "保存装配为..."
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
-msgid "EVE IGB HTML fitting file"
-msgstr "EvE IGB 装配HTML网页文件"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
-msgid "Set export destination"
-msgstr "设置导出路径"
-
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
-msgid "Enable minimal format"
-msgstr "使用极简风格"
-
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
-msgid "Updates"
-msgstr "更新"
-
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
-msgid ""
-"Pyfa can automatically check and notify you of new releases. This feature is "
-"toggled in the Network settings. Here, you may allow pre-release "
-"notifications and view suppressed release notifications, if any."
+"Importing skills into this character will set the skill levels as pending. "
+"To save the skills permanently, please click the Save button at the bottom "
+"of the window after importing"
 msgstr ""
-"Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
-"布版本更新通知，并查看未提示的版本更新（如果有的话）。"
+"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
+"窗口底部的保存按钮"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
-msgid "Allow pre-release notifications"
-msgstr "允许预发布版本更新通知"
+#: gui/builtinStatsViews/resistancesViewFull.py:115
+msgid "Incoming damage pattern"
+msgstr "伤害分布"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
-#, python-brace-format
-msgid "Suppressing {0} Notifications"
-msgstr "有{0}个未提示的版本更新"
+#: gui/targetProfileEditor.py:50
+msgid "Incorrect formatting (decimals only)"
+msgstr "格式无效（仅允许小数）"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
-msgid ""
-"There is a release available which you have chosen to suppress. You can "
-"choose to reset notification suppression for this release, or download the "
-"new release from GitHub."
-msgstr ""
-"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
+#: gui/targetProfileEditor.py:52
+msgid "Incorrect range (must be 0-100)"
+msgstr "范围无效（必须是 0-100）"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
-msgid "Reset Suppression"
-msgstr "重置版本更新提示"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
+msgid "Industrial ship hold"
+msgstr "工业舰船仓"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
-msgid "Logging"
-msgstr "日志"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Interceptor"
+msgstr "截击"
+
+#: gui/mainFrame.py:894
+msgid "Invalid Path"
+msgstr "无效路径"
+
+#: gui/esiFittings.py:198
+msgid "Invalid Token"
+msgstr "无效登录信息"
+
+#: gui/builtinContextMenus/ammoToDmgPattern.py:32
+#: gui/builtinContextMenus/itemMarketJump.py:44
+#: gui/builtinContextMenus/itemRemove.py:43
+#: gui/builtinContextMenus/itemStats.py:38
+#: gui/builtinItemStatsViews/itemCompare.py:147
+msgid "Item"
+msgstr "物品"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
+msgid "Item Market Group Jump"
+msgstr "切换物品分类时"
+
+#: gui/itemStats.py:58
+msgid "Item stats"
+msgstr "物品属性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:87
+#: gui/targetProfileEditor.py:121
+msgid "Kinetic resistance"
+msgstr "动能抗性"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
+msgid "Language (restart required):"
+msgstr "语言（重启后生效）："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
+msgid "Large ship hold"
+msgstr "大型舰船仓"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:77
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Lasts "
+msgstr "可维持"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:112
+msgid "Launcher hardpoints"
+msgstr "发射器"
+
+#: gui/characterEditor.py:343
+msgid "Level"
+msgstr "技能等级"
+
+#: gui/builtinItemStatsViews/itemDependants.py:46 gui/characterEditor.py:591
+#: gui/characterEditor.py:616 gui/characterEditor.py:649
+msgid "Level {}"
+msgstr "等级{}"
+
+#: gui/characterEditor.py:532
+msgid "Level {}d"
+msgstr "等级{}d"
+
+#: gui/mainFrame.py:273
+msgid "Loading previous fits..."
+msgstr "正在打开之前的装配..."
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Local Server"
+msgstr "本地服务器"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:201
+msgid "Lock Times"
+msgstr "锁定时间"
+
+#: gui/characterEditor.py:794
+msgid "Log In with EVE SSO"
+msgstr "通过EVE登录"
 
 #: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
 msgid "Log file location:"
 msgstr "日志文件路径："
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
-msgid "Cert Path:"
-msgstr "证书路径："
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
+msgid "Logging"
+msgstr "日志"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
-msgid "Debug Logging Enabled"
-msgstr "调试日子已开启"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:38
+msgid "Login Authentication Method"
+msgstr "登录鉴权模式"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
-msgid ""
-"Pressing this button will cause all logs in memory to write to the log file:"
-msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
+msgid "Maintenance bay"
+msgstr "维护舱"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
-msgid "Dump All Logs"
-msgstr "将所有日志写入文件"
+#: gui/mainFrame.py:673
+msgid "Manage Characters"
+msgstr "管理角色"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Manual"
+msgstr "手动"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Manual proxy settings"
+msgstr "手动配置代理"
+
+#: gui/mainFrame.py:182
+msgid "Market"
+msgstr "市场"
 
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:23
 msgid "Market & Prices"
@@ -609,55 +1448,119 @@ msgstr "市场和价格"
 msgid "Market && Prices"
 msgstr "市场和价格"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
-msgid "Market Search Delay (ms):"
-msgstr "市场搜索延迟（毫秒）："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
-msgid ""
-"The delay between a keystroke and the market search. Can help reduce lag "
-"when typing fast in the market search box."
-msgstr ""
-"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
-msgid "Show market shortcuts"
-msgstr "显示市场快捷方式"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
-msgid "Default Market Prices:"
-msgstr "默认价格源："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
-msgid ""
-"The source you choose will be tried first, but subsequent sources will be "
-"used if the preferred source fails. The system you choose will also be tried "
-"first, and if no data is available, global price will be used."
-msgstr ""
-"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
-"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
-msgid "Total Price Includes"
-msgstr "价格总计包括"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
-#: gui/additionsPane.py:66 gui/builtinStatsViews/priceViewFull.py:58
-msgid "Drones"
-msgstr "无人机"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
-#: gui/additionsPane.py:72 gui/builtinStatsViews/targetingMiscViewMinimal.py:88
-msgid "Cargo"
-msgstr "货舱"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
-msgid "Implants && Boosters"
-msgstr "植入体和增效剂"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
+msgid "Market Group Selection"
+msgstr "选择物品类别时"
 
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
 msgid "Market Search && Recent Items"
 msgstr "搜索和显示最近使用列表时"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
+msgid "Market Search Delay (ms):"
+msgstr "市场搜索延迟（毫秒）："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:225
+msgid "Mass:\t{:,.0f}kg"
+msgstr "质量：{:,.0f}kg"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
+msgid "Material bay"
+msgstr "物料仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:208
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:241
+#, python-format
+msgid "Max Warp Distance: %.1f AU"
+msgstr "最大跃迁距离：%.1f AU"
+
+#: gui/targetProfileEditor.py:124
+msgid "Maximum speed"
+msgstr "亚光速航速"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
+msgid "Medium ship hold"
+msgstr "中型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
+msgid "Mineral hold"
+msgstr "矿物仓"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+msgid "Minimal"
+msgstr "简洁"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:39
+msgid "Mining Yield"
+msgstr "矿物产出"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Misc"
+msgstr "杂项"
+
+#: gui/builtinViewColumns/misc.py:50
+msgid "Misc data"
+msgstr "杂项"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:83
+msgid "Mode:"
+msgstr "模式"
+
+#: gui/builtinContextMenus/moduleFill.py:24
+msgid "Module"
+msgstr "模块"
+
+#: gui/itemStats.py:170
+msgid "Mutations"
+msgstr "变质"
+
+#: gui/builtinItemStatsViews/itemEffects.py:30
+#: gui/builtinViewColumns/baseName.py:55
+msgid "Name"
+msgstr "名称"
+
+#: gui/esiFittings.py:300
+msgid "Need at least one ESI character to export"
+msgstr "请为导出至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:114
+msgid "Need at least one ESI character to fetch"
+msgstr "请为获取至少选择一个游戏内角色"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
+msgid "Network"
+msgstr "网络"
+
+#: gui/builtinContextMenus/itemAmountChange.py:98
+msgid "New Amount ({}-{})"
+msgstr "新数量 ({}-{})"
+
+#: gui/builtinContextMenus/itemAmountChange.py:98
+msgid "New Amount:"
+msgstr "新数量："
+
+#: gui/builtinContextMenus/implantSetSave.py:45
+msgid "New Implant Set"
+msgstr "新建植入体配置"
+
+#: gui/builtinShipBrowser/navigationPanel.py:51
+msgid "New fitting"
+msgstr "新装配"
+
+#: gui/builtinItemStatsViews/itemEffects.py:58
+msgid "No"
+msgstr "否"
+
+#: gui/characterSelection.py:230
+msgid "No active fit"
+msgstr "没有选中的装配"
 
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
@@ -666,435 +1569,187 @@ msgstr "搜索和显示最近使用列表时"
 msgid "No changes to meta buttons"
 msgstr "不改变衍生分类按钮"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-msgid "Enable all meta buttons for a duration of search / recents"
-msgstr "一段时间内启用所有衍生分类按钮"
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "No proxy"
+msgstr "无代理"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
-msgid "Enable all meta buttons"
-msgstr "启用所有衍生分类按钮"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/characterEditor.py:855
+msgid "None"
+msgstr "无"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
-msgid "Market Group Selection"
-msgstr "选择物品类别时"
+#: gui/additionsPane.py:87
+msgid "Notes"
+msgstr "备注"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
-msgid "Empty Market View"
-msgstr "空白搜索结果时"
+#: gui/mainMenuBar.py:167
+msgid "Open &Dev Tools"
+msgstr "打开开发者工具(&D)"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable leftmost available meta button"
-msgstr "启用最左侧可用衍生分类按钮"
+#: gui/characterSelection.py:150
+msgid "Open Character Editor"
+msgstr "打开角色编辑器"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable all available meta buttons"
-msgstr "启用所有可用衍生分类按钮"
+#: gui/builtinContextMenus/fitOpenNewTab.py:37
+msgid "Open Fit in New Tab"
+msgstr "在新标签页打开装配"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
-msgid "Item Market Group Jump"
-msgstr "切换物品分类时"
+#: gui/mainFrame.py:1012
+msgid "Open One Or More Character Files"
+msgstr "打开角色文件"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button"
-msgstr "启用该物品所在衍生分类按钮"
+#: gui/mainFrame.py:836
+msgid "Open One Or More Fitting Files"
+msgstr "打开装配文件"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button, disable others"
-msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
+#: gui/mainMenuBar.py:166
+msgid "Open Wid&gets Inspect tool"
+msgstr "打开控件检查工具(&G)"
+
+#: gui/mainMenuBar.py:166
+msgid "Open Widgets Inspect tool"
+msgstr "打开控件检查工具"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
+msgid "Open fittings in a new page by default"
+msgstr "默认在新标签页打开装配"
+
+#: gui/builtinContextMenus/shipJump.py:35
+msgid "Open in Fitting Browser"
+msgstr "在装配浏览器中打开"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
+msgid "Ore hold"
+msgstr "矿石仓"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:75
+msgid "Passive shield recharge"
+msgstr "被动回充"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:125
+msgid "Password:"
+msgstr "密码："
+
+#: gui/builtinContextMenus/additionsImport.py:40
+msgid "Paste {}"
+msgstr "粘贴{}"
+
+#: gui/patternEditor.py:295
+msgid "Patterns exported to clipboard"
+msgstr "伤害模型已导出到剪贴板"
+
+#: gui/patternEditor.py:276 gui/setEditor.py:210
+msgid "Patterns successfully imported from clipboard"
+msgstr "从剪贴板导入伤害模型成功"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:128
+msgid "Planetary goods hold"
+msgstr "星系物质仓"
+
+#: gui/mainFrame.py:723
+msgid "Please Wait..."
+msgstr "请稍候..."
 
 #: gui/builtinPreferenceViews/pyfaEsiPreferences.py:32
 msgid ""
 "Please see the pyfa wiki on GitHub for information regarding these options."
 msgstr "关于下列选项，详情请参考GitHub上的百科。"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:38
-msgid "Login Authentication Method"
-msgstr "登录鉴权模式"
+#: gui/esiFittings.py:281
+msgid "Please select an active fitting in the main window"
+msgstr "请在主窗口选择一个装配"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
-msgid "Local Server"
-msgstr "本地服务器"
+#: gui/characterEditor.py:758
+msgid "Please select another character or make a new one."
+msgstr "请选择另一角色或创建新角色。"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
-msgid "Manual"
-msgstr "手动"
+#: gui/mainFrame.py:897
+msgid "Please verify path location pyfa's preferences."
+msgstr "请确认Pyfa偏好保存位置。"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
-msgid ""
-"This options starts a local webserver that the web application will call "
-"back to with information about the character login."
-msgstr "本选项将启动一个本地服务器以接收登录页返回的角色信息。"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:42
-msgid ""
-"This option prompts users to copy and paste information from the web "
-"application to allow for character login. Use this if having issues with the "
-"local server."
+#: gui/builtinContextMenus/graphFitAmmoPicker.py:29
+msgid "Plot with Different Ammo..."
 msgstr ""
-"本选项将在角色登录时提示您复制和粘贴登录页相关信息。如果本地服务器出现问题，"
-"可使用该选项。"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:45
-msgid "SSO Mode"
-msgstr "单点登录(SSO)模式"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
-msgid "pyfa.io"
-msgstr "pyfa.io"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
-msgid "Custom application"
-msgstr "自定义应用"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
-msgid ""
-"This options routes SSO Logins through pyfa.io, allowing you to easily login "
-"without any configuration. When in doubt, use this option."
-msgstr ""
-"本选项将通过pyfa.io处理单点登录(SSO)请求，使你无需配置即可登录到EVE。不清除时"
-"可以使用该选项。"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:49
-msgid ""
-"This option goes through EVE SSO directly, but requires more configuration. "
-"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
-"route data throguh pyfa.io."
-msgstr ""
-"本选项将直接发送EvE单点登录请求，但这需要更多配置。如果pyfa.io无法访问，或你"
-"不想让pyfa.io处理登录请求，请使用该选项。"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:63
-msgid "Custom Application"
-msgstr "自定义应用"
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:76
-msgid "Client ID:"
-msgstr "客户ID(Client ID)："
-
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:85
-msgid "Client Secret:"
-msgstr "客户密钥(Client Secret)："
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
-msgid "Fitting Engine"
-msgstr "装配引擎"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
-msgid ""
-"Factor in reload time when calculating capacitor usage, damage, and tank."
-msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
-msgid "Enforce strict skill level requirements"
-msgstr "使用严格的技能等级检查"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
-msgid ""
-"When enabled, skills will check their dependencies' requirements when their "
-"levels change and reset skills that no longer meet the requirement.\n"
-"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
-"skill, as that requires Drones V"
-msgstr ""
-"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
-"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
-msgid ""
-"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
-"behavior)."
-msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
-msgid "Global Default Spoolup Percentage:"
-msgstr "全局默认预热百分比"
-
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
-msgid ""
-"The amount of spoolup to use by default on module which support it. Can be "
-"changed on a per-module basis"
-msgstr "默认模块预热量。可以分模块单独设置。"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
-msgid "General"
-msgstr "通用"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
-msgid "Use global character"
-msgstr "使用全局角色"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
-msgid "Use character implants by default for new fits"
-msgstr "新装配默认使用角色植入体组"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
-msgid "Use global damage pattern"
-msgstr "使用全局伤害分布配置"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
-msgid "Compact skills needed tooltip"
-msgstr "简洁技能需求提示"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
-msgid "Color fitting view by slot"
-msgstr "用背景色区分槽位"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
-msgid "Reopen previous fits on startup"
-msgstr "重新启动时打开之前的装配"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
-msgid "Separate Racks"
-msgstr "分隔不同槽位类型"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
-msgid "Show Rack Labels"
-msgstr "显示槽位类型标签"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
-msgid "Show fitting tab tooltips"
-msgstr "装配标签页显示预览"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
-msgid "Animate gauges"
-msgstr "启用属性进度条动画"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
-msgid "Open fittings in a new page by default"
-msgstr "默认在新标签页打开装配"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
-msgid "Show ship browser tooltip"
-msgstr "船体列表显示预览"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
-msgid "Change charge in all modules of the same type"
-msgstr "同时更换所有同类型模块的弹药"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
-msgid ""
-"When disabled, reloads charges just in selected modules. Action can be "
-"reversed by holding Ctrl or Alt key while changing charge."
-msgstr ""
-"关闭该选项时，更换弹药仅更换选中的模块。按住Ctrl或Alt以更换所有同类型武器弹"
-"药。"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
-msgid "Extra info in Additions panel tab names"
-msgstr "附加装备标签名显示额外信息"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of active items"
-msgstr "激活的物品数量"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of all items"
-msgstr "所有物品数量"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
-msgid "Language (restart required):"
-msgstr "语言（重启后生效）："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
-msgid "Network"
-msgstr "网络"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:33
-msgid "Enable Network"
-msgstr "启用网络功能"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:37
-msgid "EVE Servers (API && CREST import)"
-msgstr "连接到EvE服务器（API 和 CREST 导入）"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:41
-msgid "Pricing updates"
-msgstr "价格更新"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:44
-msgid "Pyfa Update checks"
-msgstr "Pyfa更新检查"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:49
-msgid "Proxy settings"
-msgstr "代理设置"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:83
-msgid "Mode:"
-msgstr "模式"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "No proxy"
-msgstr "无代理"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "Auto-detected proxy settings"
-msgstr "自动检测代理设置"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "Manual proxy settings"
-msgstr "手动配置代理"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:101
-msgid "Addr:"
-msgstr "地址："
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Pod"
+msgstr "逃生舱"
 
 #: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:109
 msgid "Port:"
 msgstr "端口："
 
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:121
-msgid "Username:"
-msgstr "用户名："
+#: gui/builtinStatsViews/resourcesViewFull.py:154
+msgid "PowerGrid"
+msgstr "PG"
 
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:125
-msgid "Password:"
-msgstr "密码："
+#: gui/preferenceDialog.py:31
+msgid "Preferences"
+msgstr "偏好设置"
 
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:136
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:158
-msgid "Auto-detected: "
-msgstr "自动检测结果："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:144
-msgid "Apply Proxy Settings"
-msgstr "应用代理配置"
-
-#: gui/builtinViewColumns/misc.py:50
-msgid "Misc data"
-msgstr "杂项"
-
-#: gui/builtinViewColumns/abilities.py:37
-msgid "Active Abilities"
-msgstr "铁骑技能"
-
-#: gui/builtinViewColumns/sideEffects.py:37
-msgid "Active Side Effects"
-msgstr "副作用"
-
-#: gui/builtinViewColumns/baseName.py:55
-#: gui/builtinItemStatsViews/itemEffects.py:30
-msgid "Name"
-msgstr "名称"
-
-#: gui/esiFittings.py:32
-msgid "Browse EVE Fittings"
-msgstr "浏览游戏内装配"
-
-#: gui/esiFittings.py:44
-msgid "Fetch Fits"
-msgstr "获取装配"
-
-#: gui/esiFittings.py:64
-msgid "Import to pyfa"
-msgstr "导入到Pyfa"
-
-#: gui/esiFittings.py:65
-msgid "Delete from EVE"
-msgstr "删除游戏内装配"
-
-#: gui/esiFittings.py:111
-msgid "Fetching fits, please wait..."
-msgstr "正在获取装配，请稍候..."
-
-#: gui/esiFittings.py:114
-msgid "Need at least one ESI character to fetch"
-msgstr "请为获取至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
-msgid "Connection error, please check your internet connection"
-msgstr "连接错误，请检查您的网络连接"
-
-#: gui/esiFittings.py:156
-msgid "Do you really want to delete {} ({}) from EVE?"
-msgstr "真的要从游戏内删除 {} ({})吗？"
-
-#: gui/esiFittings.py:179
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
 msgid ""
-"There was an issue starting up the localized server, try setting Login "
-"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
-"Authentication Method. If this doesn't fix the problem please file an issue "
-"on Github."
+"Pressing this button will cause all logs in memory to write to the log file:"
+msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+
+#: gui/builtinItemStatsViews/itemCompare.py:155
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinStatsViews/priceViewFull.py:40
+msgid "Price"
+msgstr "价格"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:41
+msgid "Pricing updates"
+msgstr "价格更新"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:265
+#, python-format
+msgid "Probe Size: %.3f"
+msgstr "Probe Size: %.3f"
+
+#: gui/targetProfileEditor.py:372
+msgid "Profiles exported to clipboard"
+msgstr "目标属性已导出到剪贴板"
+
+#: gui/targetProfileEditor.py:352
+msgid "Profiles successfully imported from clipboard"
+msgstr "已成功从剪贴板导入目标属性"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+msgid "Project onto Fit"
 msgstr ""
-"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
-"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
 
-#: gui/esiFittings.py:183
-msgid "Add Character Error"
-msgstr "添加角色错误"
-
-#: gui/esiFittings.py:196
-msgid ""
-"There was an error validating characters' SSO token. Please try logging into "
-"the character again to reset the token."
-msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
-
-#: gui/esiFittings.py:198
-msgid "Invalid Token"
-msgstr "无效登录信息"
-
-#: gui/esiFittings.py:211
-msgid "Export fit to EVE"
-msgstr "导出装配到游戏"
-
-#: gui/esiFittings.py:224
-msgid "Export Fit"
-msgstr "导出装配"
-
-#: gui/esiFittings.py:281
-msgid "Please select an active fitting in the main window"
-msgstr "请在主窗口选择一个装配"
-
-#: gui/esiFittings.py:284
-msgid "Sending request and awaiting response"
-msgstr "正在发送请求和接收响应"
-
-#: gui/esiFittings.py:294
-msgid "Failed to generate export data"
-msgstr "无法生成导出数据"
-
-#: gui/esiFittings.py:300
-msgid "Need at least one ESI character to export"
-msgstr "请为导出至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
-msgid "ERROR"
-msgstr "错误"
-
-#: gui/esiFittings.py:334
-msgid "SSO Character Management"
-msgstr "游戏内人物管理"
-
-#: gui/esiFittings.py:342
-msgid "Character ID"
-msgstr "角色ID"
-
-#: gui/esiFittings.py:350
-msgid "Add Character"
-msgstr "添加角色"
-
-#: gui/esiFittings.py:353
-msgid "Remove Character"
-msgstr "删除角色"
-
-#: gui/aboutData.py:31
-msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
+#: gui/builtinContextMenus/itemProject.py:34
+#, python-brace-format
+msgid "Project {0} onto Fit"
 msgstr ""
-"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/aboutData.py:32
-msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有"
+#: gui/additionsPane.py:81
+msgid "Projected"
+msgstr "环境效果"
 
-#: gui/aboutData.py:33
-msgid ""
-"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
-msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
+#: gui/builtinAdditionPanes/projectedView.py:306
+#: gui/builtinAdditionPanes/projectedView.py:316
+#: gui/builtinAdditionPanes/projectedView.py:321
+#: gui/builtinAdditionPanes/projectedView.py:326
+msgid "Projected Item"
+msgstr ""
 
-#: gui/aboutData.py:34
-msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
-msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
+#: gui/itemStats.py:200
+msgid "Properties"
+msgstr "属性"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:49
+msgid "Proxy settings"
+msgstr "代理设置"
 
 #: gui/aboutData.py:49
 msgid ""
@@ -1107,430 +1762,42 @@ msgstr ""
 "于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
 "wxWidgets支持的所有平台运行。"
 
-#: gui/characterSelection.py:47
-msgid "Character: "
-msgstr "角色："
-
-#: gui/characterSelection.py:68
-msgid "Refresh Skills"
-msgstr "刷新技能"
-
-#: gui/characterSelection.py:102
-msgid "Grant Missing Skills"
-msgstr "习得所需技能"
-
-#: gui/characterSelection.py:105
-msgid "Copy Missing Skills"
-msgstr "复制所需技能"
-
-#: gui/characterSelection.py:150
-msgid "Open Character Editor"
-msgstr "打开角色编辑器"
-
-#: gui/characterSelection.py:230
-msgid "No active fit"
-msgstr "没有选中的装配"
-
-#: gui/characterSelection.py:238
-msgid "All skill prerequisites have been met"
-msgstr "已达到所有技能要求"
-
-#: gui/characterSelection.py:242
-msgid "Skills required:"
-msgstr "所需技能："
-
-#: gui/patternEditor.py:51
-msgid "You must supply a name for your Damage Profile!"
-msgstr "您必须填写一个伤害模型名！"
-
-#: gui/patternEditor.py:53
-msgid "Damage Profile name already in use, please choose another."
-msgstr "伤害模型名已占用，请使用其他名称。"
-
-#: gui/patternEditor.py:65
-msgid "Damage Profile"
-msgstr "伤害模型"
-
-#: gui/patternEditor.py:99
-msgid "Damage Pattern Editor"
-msgstr "伤害模型编辑器"
-
-#: gui/patternEditor.py:171
-msgid "Import patterns from clipboard"
-msgstr "从剪贴板导入伤害模型"
-
-#: gui/patternEditor.py:172
-msgid "Export patterns to clipboard"
-msgstr "导出伤害模型到剪贴板"
-
-#: gui/patternEditor.py:276 gui/setEditor.py:210
-msgid "Patterns successfully imported from clipboard"
-msgstr "从剪贴板导入伤害模型成功"
-
-#: gui/patternEditor.py:283 gui/setEditor.py:218
-msgid "Could not import from clipboard: unknown errors"
-msgstr "无法从剪贴板导入：未知错误"
-
-#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
-msgid "Could not import from clipboard"
-msgstr "无法从剪贴板导入"
-
-#: gui/patternEditor.py:295
-msgid "Patterns exported to clipboard"
-msgstr "伤害模型已导出到剪贴板"
-
-#: gui/additionsPane.py:45
-msgid "Additions"
-msgstr "附加装备"
-
-#: gui/additionsPane.py:69
-msgid "Fighters"
-msgstr "铁骑舰载机"
-
-#: gui/additionsPane.py:78
-msgid "Boosters"
-msgstr "增效剂"
-
-#: gui/additionsPane.py:81
-msgid "Projected"
-msgstr "环境效果"
-
-#: gui/additionsPane.py:84
-msgid "Command"
-msgstr "指令"
-
-#: gui/additionsPane.py:87
-msgid "Notes"
-msgstr "备注"
-
-#: gui/fitBrowserLite.py:17
-msgid "Add Fits"
-msgstr "添加装配"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:43
-msgid "Recharge rates"
-msgstr "回充速度"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:75
-msgid "Passive shield recharge"
-msgstr "被动回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:76
-msgid "Active shield boost"
-msgstr "主动维修"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:77
-msgid "Armor repair amount"
-msgstr "装甲修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:78
-msgid "Hull repair amount"
-msgstr "结构修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:86
-msgid "Reinforced"
-msgstr "加强回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:87
-msgid "Sustained"
-msgstr "持续回充"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:57
-msgid "Capacitor stability"
-msgstr "电容稳定性"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:67
-msgid "Total: "
-msgstr "总计："
-
-#: gui/builtinStatsViews/capacitorViewFull.py:77
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Lasts "
-msgstr "可维持"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:81
-msgid "0s"
-msgstr "0秒"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:90
-msgid "Extra stats"
-msgstr "额外状态"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Stable: "
-msgstr "稳定："
-
-#: gui/builtinStatsViews/firepowerViewFull.py:67
-msgid "Weapon"
-msgstr "武器"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:67
-msgid "Drone"
-msgstr "无人机"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:100
-msgid " Volley: "
-msgstr "齐射"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:107
-msgid " DPS: "
-msgstr " DPS: "
-
-#: gui/builtinStatsViews/firepowerViewFull.py:115
-msgid "Click to toggle to Mining Yield"
-msgstr "点击切换到矿物产出视图"
-
-#: gui/builtinStatsViews/priceViewFull.py:57
-#: gui/builtinStatsViews/priceViewMinimal.py:57
-msgid "Ship"
-msgstr "船体"
-
-#: gui/builtinStatsViews/priceViewFull.py:57
-#: gui/builtinStatsViews/priceViewMinimal.py:57 gui/mainFrame.py:186
-msgid "Fittings"
-msgstr "装配"
-
-#: gui/builtinStatsViews/priceViewFull.py:58
-#: gui/builtinStatsViews/resourcesViewFull.py:158
-msgid "Cargo bay"
-msgstr "货舱"
-
-#: gui/builtinStatsViews/priceViewFull.py:58
-#: gui/builtinStatsViews/priceViewMinimal.py:57
-#: gui/builtinStatsViews/miningyieldViewFull.py:89
-msgid "Total"
-msgstr "总计"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:111
-msgid "Turret hardpoints"
-msgstr "炮台"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:112
-msgid "Launcher hardpoints"
-msgstr "发射器"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:113
-msgid "Drones active"
-msgstr "激活的无人机"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:114
-msgid "Fighter squadrons active"
-msgstr "激活的铁骑舰载机中队"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:115
-msgid "Calibration"
-msgstr "校准"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:153
-msgid "CPU"
-msgstr "CPU"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:154
-msgid "PowerGrid"
-msgstr "PG"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:155
-msgid "Drone bay"
-msgstr "无人机仓库"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:156
-msgid "Fighter bay"
-msgstr "铁骑舰载机仓库"
-
-#: gui/builtinStatsViews/resourcesViewFull.py:157
-msgid "Drone bandwidth"
-msgstr "无人机带宽"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:38
-msgid "Targeting && Misc"
-msgstr "目标和杂项"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:60
-msgid "Targets"
-msgstr "最大锁定数"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:61
-msgid "Range"
-msgstr "锁定范围"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
-msgid "Scan res."
-msgstr "扫描精度"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
-msgid "Sensor str."
-msgstr "传感器强度"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
-msgid "Drone range"
-msgstr "无人机半径"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:84
-msgid "Speed"
-msgstr "亚光速航速"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:85
-msgid "Align time"
-msgstr "起跳时间"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
-msgid "Signature"
-msgstr "信号半径"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
-msgid "Warp Speed"
-msgstr "曲速航速"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:110
-msgid "Fleet hangar"
-msgstr "舰队机库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:111
-msgid "Maintenance bay"
-msgstr "维护舱"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:112
-msgid "Ammo hold"
-msgstr "弹药仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
-msgid "Fuel bay"
-msgstr "燃料仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
-msgid "Ship hold"
-msgstr "舰船仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
-msgid "Small ship hold"
-msgstr "小型舰船仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
-msgid "Medium ship hold"
-msgstr "中型舰船仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
-msgid "Large ship hold"
-msgstr "大型舰船仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
-msgid "Industrial ship hold"
-msgstr "工业舰船仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
-msgid "Ore hold"
-msgstr "矿石仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
-msgid "Mineral hold"
-msgstr "矿物仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
-msgid "Material bay"
-msgstr "物料仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
-msgid "Gas hold"
-msgstr "气体矿物仓库"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
-msgid "Salvage hold"
-msgstr "打捞件仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
-msgid "Command center hold"
-msgstr "指挥中心仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
-msgid "Planetary goods hold"
-msgstr "星系物质仓"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:44
+msgid "Pyfa Update checks"
+msgstr "Pyfa更新检查"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
+msgid ""
+"Pyfa can automatically check and notify you of new releases. This feature is "
+"toggled in the Network settings. Here, you may allow pre-release "
+"notifications and view suppressed release notifications, if any."
+msgstr ""
+"Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
+"布版本更新通知，并查看未提示的版本更新（如果有的话）。"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:129
 msgid "Quafe hold"
 msgstr "酷菲(Quafe)仓"
 
-#: gui/builtinStatsViews/miningyieldViewFull.py:39
-msgid "Mining Yield"
-msgstr "矿物产出"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of active items"
+msgstr "激活的物品数量"
 
-#: gui/builtinStatsViews/miningyieldViewFull.py:102
-msgid "Click to toggle to Firepower View"
-msgstr "点击切换到火力视图"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of all items"
+msgstr "所有物品数量"
 
-#: gui/builtinStatsViews/resistancesViewFull.py:61
-#: gui/builtinStatsViews/resistancesViewFull.py:219
-msgid "Effective HP: "
-msgstr "有效HP："
+#: gui/targetProfileEditor.py:126
+msgid "Radius"
+msgstr "信号半径"
 
-#: gui/builtinStatsViews/resistancesViewFull.py:85
-msgid "Electromagnetic resistance"
-msgstr "电磁抗性"
+#: gui/builtinItemStatsViews/itemMutator.py:54
+msgid "Random stats"
+msgstr "随机化属性"
 
-#: gui/builtinStatsViews/resistancesViewFull.py:86
-#: gui/targetProfileEditor.py:120
-msgid "Thermal resistance"
-msgstr "热能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:87
-#: gui/targetProfileEditor.py:121
-msgid "Kinetic resistance"
-msgstr "动能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:88
-#: gui/targetProfileEditor.py:122
-msgid "Explosive resistance"
-msgstr "爆炸抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:96
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "EHP"
-msgstr "有效HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:97
-#: gui/builtinStatsViews/resistancesViewFull.py:169
-msgid "Click to toggle between effective HP and raw HP"
-msgstr "点击切换有效HP和原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:112
-msgid "Shield resistance"
-msgstr "护盾抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:113
-msgid "Armor resistance"
-msgstr "装甲抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:114
-msgid "Hull resistance"
-msgstr "结构抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:115
-msgid "Incoming damage pattern"
-msgstr "伤害分布"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "HP"
-msgstr "原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Shield: "
-msgstr "护盾："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Armor: "
-msgstr "装甲："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Hull: "
-msgstr "结构："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:213
-msgid "Resist Multiplier: "
-msgstr "抗性倍率："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:220
-#, python-format
-msgid "Effective: %d HP"
-msgstr "有效：%dHP"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
+msgid "Range"
+msgstr "锁定范围"
 
 #: gui/builtinStatsViews/resistancesViewFull.py:222
 msgid "Raw HP: "
@@ -1541,263 +1808,24 @@ msgstr "原始HP："
 msgid "Raw: %d HP"
 msgstr "原始：%dHP"
 
-#: gui/mainMenuBar.py:68
-msgid "&New Tab"
-msgstr "新标签页(&N)"
-
-#: gui/mainMenuBar.py:69
-msgid "&Close Tab"
-msgstr "关闭标签页(&C)"
-
-#: gui/mainMenuBar.py:70
-msgid "&Close All Tabs"
-msgstr "关闭所有标签页(&C)"
-
-#: gui/mainMenuBar.py:73
-msgid "&Backup All Fittings"
-msgstr "备份所有装配(&B)"
-
-#: gui/mainMenuBar.py:73
-msgid "Backup all fittings to a XML file"
-msgstr "备份所有装配到XML文件"
-
-#: gui/mainMenuBar.py:74
-msgid "Export All Fittings to &HTML"
-msgstr "导出所有装配到网页"
-
-#: gui/mainMenuBar.py:74
-msgid "Export fits to HTML file (set in Preferences)"
-msgstr "导出装配到HTML网页文件（通过偏好设置指定）"
-
-#: gui/mainMenuBar.py:81
-msgid "Fi&t"
-msgstr "装配(&T)"
-
-#: gui/mainMenuBar.py:83
-msgid "&Undo"
-msgstr "撤销(&R)"
-
-#: gui/mainMenuBar.py:83
-msgid "Undo the most recent action"
-msgstr "撤销最近一次操作"
-
-#: gui/mainMenuBar.py:84
-msgid "&Redo"
-msgstr "恢复(&R)"
-
-#: gui/mainMenuBar.py:84
-msgid "Redo the most recent undone action"
-msgstr "恢复最近一次撤销的操作"
-
-#: gui/mainMenuBar.py:87
-msgid "&To Clipboard"
-msgstr "导出到剪贴板(&T)"
-
-#: gui/mainMenuBar.py:87
-msgid "Export a fit to the clipboard"
-msgstr "导出装配到剪贴板"
-
-#: gui/mainMenuBar.py:88
-msgid "&From Clipboard"
-msgstr "从剪贴板导入(&F)"
-
-#: gui/mainMenuBar.py:88
-msgid "Import a fit from the clipboard"
-msgstr "从剪贴板导入装配"
-
-#: gui/mainMenuBar.py:91
-msgid "&Import Fittings"
-msgstr "导入装配(&I)"
-
-#: gui/mainMenuBar.py:91
-msgid "Import fittings into pyfa"
-msgstr "从文件导入装配"
-
-#: gui/mainMenuBar.py:92
-msgid "&Export Fitting"
-msgstr "导出装配(&E)"
-
-#: gui/mainMenuBar.py:92
-msgid "Export fitting to another format"
-msgstr "导出装配为其他格式"
-
-#: gui/mainMenuBar.py:95
-msgid "&Optimize Fit Price"
-msgstr "优化装配价格(&O)"
-
-#: gui/mainMenuBar.py:96
-msgid "&Graphs"
-msgstr "图表(&G)"
-
-#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
-msgid "Disable Fitting Re&strictions"
-msgstr "关闭装配资源限制(&S)"
-
-#: gui/mainMenuBar.py:104
-msgid "&Browse ESI Fittings"
-msgstr "浏览游戏内装配(&B)"
-
-#: gui/mainMenuBar.py:105
-msgid "E&xport to ESI"
-msgstr "导出到游戏(&X)"
-
-#: gui/mainMenuBar.py:111
-msgid "&Character"
-msgstr "角色(&C)"
-
-#: gui/mainMenuBar.py:113
-msgid "&Save Character"
-msgstr "保存角色(&S)"
-
-#: gui/mainMenuBar.py:114
-msgid "Save Character &As..."
-msgstr "保存角色为...(&A)"
-
-#: gui/mainMenuBar.py:115
-msgid "&Revert Character"
-msgstr "还原角色(&R)"
-
-#: gui/mainMenuBar.py:118
-msgid "&Import Character File"
-msgstr "导入角色文件(&I)"
-
-#: gui/mainMenuBar.py:118
-msgid "Import characters into pyfa from file"
-msgstr "从文件导入角色信息"
-
-#: gui/mainMenuBar.py:119
-msgid "&Export Skills Needed"
-msgstr "导出所需技能列表(&E)"
-
-#: gui/mainMenuBar.py:119
-msgid "Export skills needed for this fitting"
-msgstr "导出使用本装配所需技能"
-
-#: gui/mainMenuBar.py:122
-msgid "&Manage ESI Characters"
-msgstr "管理游戏内角色(&M)"
-
-#: gui/mainMenuBar.py:128
-msgid "Attribute &Overrides"
-msgstr "自定义属性(&O)"
-
-#: gui/mainMenuBar.py:131 gui/mainFrame.py:690
-msgid "&Turn Overrides On"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainMenuBar.py:135
-msgid "&Global"
-msgstr "全局设置(&G)"
-
-#: gui/mainMenuBar.py:137
-msgid "&Preferences"
-msgstr "偏好设置(&P)"
-
-#: gui/mainMenuBar.py:143
-msgid "&Editors"
-msgstr "编辑器(&E)"
-
-#: gui/mainMenuBar.py:144
-msgid "&Character Editor"
-msgstr "角色编辑器(&C)"
-
-#: gui/mainMenuBar.py:147
-msgid "&Implant Set Editor"
-msgstr "植入体配置编辑器(&I)"
-
-#: gui/mainMenuBar.py:150
-msgid "&Damage Pattern Editor"
-msgstr "伤害模型编辑器(&D)"
-
-#: gui/mainMenuBar.py:153
-msgid "&Target Profile Editor"
-msgstr "目标属性编辑器(&T)"
-
-#: gui/mainMenuBar.py:159
-msgid "&Help"
-msgstr "帮助(&H)"
-
-#: gui/mainMenuBar.py:160
-msgid "&Wiki"
-msgstr "百科(&W)"
-
-#: gui/mainMenuBar.py:160
-msgid "Go to wiki on GitHub"
-msgstr "转到GitHub上的百科页"
-
-#: gui/mainMenuBar.py:161
-msgid "&Forums"
-msgstr "论坛(&F)"
-
-#: gui/mainMenuBar.py:161
-msgid "Go to EVE Online Forum thread"
-msgstr "转到EvE Online论坛讨论贴"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Wid&gets Inspect tool"
-msgstr "打开控件检查工具(&G)"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Widgets Inspect tool"
-msgstr "打开控件检查工具"
-
-#: gui/mainMenuBar.py:167
-msgid "Open &Dev Tools"
-msgstr "打开开发者工具(&D)"
-
-#: gui/mainMenuBar.py:167
-msgid "Dev Tools"
-msgstr "开发者工具"
-
-#: gui/mainMenuBar.py:200
-msgid "Enable Fitting Re&strictions"
-msgstr "开启装配限制(&S)"
-
-#: gui/builtinShipBrowser/navigationPanel.py:48
-msgid "Ship groups"
-msgstr "舰船类型"
-
-#: gui/builtinShipBrowser/navigationPanel.py:50
-msgid "Back"
-msgstr "返回"
-
-#: gui/builtinShipBrowser/navigationPanel.py:51
-msgid "New fitting"
-msgstr "新装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:53
-#: gui/builtinShipBrowser/navigationPanel.py:147
-msgid "Hide empty ship groups"
-msgstr "隐藏空的舰船类型"
+#: gui/mainFrame.py:654
+msgid ""
+"Re-enabling fitting restrictions for this fit will also remove any illegal "
+"items from the fit. Do you want to continue?"
+msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
 
 #: gui/builtinShipBrowser/navigationPanel.py:56
 #: gui/builtinShipBrowser/navigationPanel.py:129
 msgid "Recent Fits"
 msgstr "最近使用的装配"
 
-#: gui/builtinShipBrowser/navigationPanel.py:61
-msgid "Search fittings"
-msgstr "搜索装配"
+#: gui/builtinStatsViews/rechargeViewFull.py:43
+msgid "Recharge rates"
+msgstr "回充速度"
 
-#: gui/builtinShipBrowser/navigationPanel.py:136
-msgid "Hide Recent Fits"
-msgstr "隐藏最近使用的装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:151
-msgid "Show empty ship groups"
-msgstr "显示空的舰船类型"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:67
-msgid "Expand All"
-msgstr "展开所有"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:70
-msgid "Toggle Names"
-msgstr "切换名称"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:73
-msgid "Toggle View"
-msgstr "切换视图"
+#: gui/mainMenuBar.py:84
+msgid "Redo the most recent undone action"
+msgstr "恢复最近一次撤销的操作"
 
 #: gui/builtinItemStatsViews/itemAffectedBy.py:77
 #: gui/builtinItemStatsViews/itemAttributes.py:62
@@ -1805,145 +1833,240 @@ msgstr "切换视图"
 msgid "Refresh"
 msgstr "刷新"
 
-#: gui/builtinItemStatsViews/itemEffects.py:31
-msgid "Active"
-msgstr "激活"
+#: gui/characterSelection.py:68
+msgid "Refresh Skills"
+msgstr "刷新技能"
 
-#: gui/builtinItemStatsViews/itemEffects.py:32
-msgid "Type"
-msgstr "类型"
+#: gui/builtinStatsViews/rechargeViewFull.py:86
+msgid "Reinforced"
+msgstr "加强回充"
 
-#: gui/builtinItemStatsViews/itemEffects.py:34
-msgid "Run Time"
-msgstr "运行时长"
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinStatsViews/outgoingViewFull.py:66
+#: gui/builtinStatsViews/outgoingViewMinimal.py:65
+msgid "Remote Reps"
+msgstr "遥修"
 
-#: gui/builtinItemStatsViews/itemEffects.py:35
-msgid "ID"
-msgstr "ID"
+#: gui/esiFittings.py:353
+msgid "Remove Character"
+msgstr "删除角色"
 
-#: gui/builtinItemStatsViews/itemEffects.py:56
-msgid "Yes"
-msgstr "是"
+#: gui/propertyEditor.py:71
+msgid "Remove Overides for Item"
+msgstr "删除物品的自定义属性"
 
-#: gui/builtinItemStatsViews/itemEffects.py:58
-msgid "No"
-msgstr "否"
+#: gui/builtinContextMenus/itemRemove.py:42
+msgid "Remove {}{}"
+msgstr "移除{}{}"
 
-#: gui/builtinItemStatsViews/itemTraits.py:25
-#: gui/builtinItemStatsViews/itemDescription.py:43
-msgid "Copy"
-msgstr "复制"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
+msgid "Reopen previous fits on startup"
+msgstr "重新启动时打开之前的装配"
 
-#: gui/builtinItemStatsViews/itemProperties.py:56
-#: gui/builtinItemStatsViews/itemAttributes.py:44
-msgid "Attribute"
-msgstr "属性"
+#: gui/itemStats.py:185
+msgid "Requirements"
+msgstr "技能需求"
 
-#: gui/builtinItemStatsViews/itemProperties.py:57
-#: gui/builtinItemStatsViews/itemAttributes.py:45
-msgid "Current Value"
-msgstr "当前值"
+#: gui/builtinContextMenus/moduleSpool.py:98
+msgid "Reset"
+msgstr "重置"
 
-#: gui/builtinItemStatsViews/itemProperties.py:98
-#, python-format
-msgid "%d attribute."
-msgstr "共%d个属性"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:47
-msgid "Base Value"
-msgstr "基础值"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:53
-msgid "View Raw Data"
-msgstr "显示原始数据"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:57
-msgid "Export Item Stats"
-msgstr "导出物品属性"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:117
-msgid "Save CSV file"
-msgstr "保存为逗号分隔符(CSV)文件"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:118
-msgid "CSV files"
-msgstr "逗号分隔符(CSV)文件"
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
+msgid "Reset Suppression"
+msgstr "重置版本更新提示"
 
 #: gui/builtinItemStatsViews/itemMutator.py:51
 msgid "Reset defaults"
 msgstr "重置为默认值"
 
-#: gui/builtinItemStatsViews/itemMutator.py:54
-msgid "Random stats"
-msgstr "随机化属性"
+#: gui/builtinContextMenus/resistMode.py:41
+msgid "Resist Mode"
+msgstr "抗性模式"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:213
+msgid "Resist Multiplier: "
+msgstr "抗性倍率："
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinStatsViews/resistancesViewFull.py:47
+msgid "Resistances"
+msgstr "抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinStatsViews/resourcesViewFull.py:84
+msgid "Resources"
+msgstr "装配资源"
 
 #: gui/builtinItemStatsViews/itemMutator.py:57
 msgid "Revert changes"
 msgstr "还原到初始状态"
 
-#: gui/builtinItemStatsViews/itemCompare.py:75
-msgid "Toggle view mode"
-msgstr "切换显示模式"
+#: gui/builtinContextMenus/moduleMutations.py:33
+msgid "Revert to {}"
+msgstr "还原为{}"
 
-#: gui/builtinItemStatsViews/itemCompare.py:147
-msgid "Item"
-msgstr "物品"
+#: gui/builtinItemStatsViews/itemEffects.py:34
+msgid "Run Time"
+msgstr "运行时长"
 
-#: gui/setEditor.py:48
-msgid "You must supply a name for the Implant Set!"
-msgstr "您必须填写一个植入体配置名！"
+#: gui/esiFittings.py:334
+msgid "SSO Character Management"
+msgstr "游戏内人物管理"
 
-#: gui/setEditor.py:50
-msgid "Implant Set name already in use, please choose another."
-msgstr "植入体配置名已使用，请选择其他名称。"
+#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
+msgid "SSO Login"
+msgstr "通过EVE登录"
 
-#: gui/setEditor.py:62
-msgid "Implant Set"
-msgstr "植入体配置"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:45
+msgid "SSO Mode"
+msgstr "单点登录(SSO)模式"
 
-#: gui/setEditor.py:122
-msgid "Implant Set Editor"
-msgstr "植入体配置编辑器"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
+msgid "Salvage hold"
+msgstr "打捞件仓"
 
-#: gui/setEditor.py:148
-msgid "Import implant sets from clipboard"
-msgstr "从剪贴板导入植入体配置"
+#: gui/mainFrame.py:860
+msgid "Save Backup As..."
+msgstr "保存备份为..."
 
-#: gui/setEditor.py:149
-msgid "Export implant sets to clipboard"
-msgstr "导出植入体配置到剪贴板"
+#: gui/builtinItemStatsViews/itemAttributes.py:117
+msgid "Save CSV file"
+msgstr "保存为逗号分隔符(CSV)文件"
+
+#: gui/mainMenuBar.py:114
+msgid "Save Character &As..."
+msgstr "保存角色为...(&A)"
+
+#: gui/characterEditor.py:282
+msgid "Save Character As..."
+msgstr "保存角色为..."
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
+#: gui/mainFrame.py:467
+msgid "Save Fitting As..."
+msgstr "保存装配为..."
+
+#: gui/propertyEditor.py:130
+msgid "Save Overrides As..."
+msgstr "保存自定义属性为..."
+
+#: gui/builtinContextMenus/implantSetSave.py:27
+msgid "Save as New Implant Set"
+msgstr "保存为新的植入体配置"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
+msgid "Scan res."
+msgstr "扫描精度"
+
+#: gui/builtinShipBrowser/navigationPanel.py:61
+msgid "Search fittings"
+msgstr "搜索装配"
+
+#: gui/characterEditor.py:356
+#, python-brace-format
+msgid "Sec Status: {0:.2f}"
+msgstr "安全等级: {0:.2f}"
+
+#: gui/characterEditor.py:914
+msgid "Security Status is used in some CONCORD hull calculations"
+msgstr "安全等级会用于计算CONCORD警察船体属性"
+
+#: gui/esiFittings.py:284
+msgid "Sending request and awaiting response"
+msgstr "正在发送请求和接收响应"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:65
+msgid "Sensor str."
+msgstr "传感器强度"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
+msgid "Separate Racks"
+msgstr "分隔不同槽位类型"
+
+#: gui/characterEditor.py:907
+msgid "Set Security Status"
+msgstr "设置安全等级"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+msgid "Set as Damage Pattern"
+msgstr "设置为伤害模型"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
+msgid "Set export destination"
+msgstr "设置导出路径"
+
+#: gui/builtinContextMenus/ammoToDmgPattern.py:32
+msgid "Set {} as Damage Pattern"
+msgstr "设置{}为伤害模型"
 
 #: gui/setEditor.py:229
 msgid "Sets exported to clipboard"
 msgstr "植入体配置已导出到剪贴板"
 
-#: gui/targetProfileEditor.py:50
-msgid "Incorrect formatting (decimals only)"
-msgstr "格式无效（仅允许小数）"
+#: gui/characterEditor.py:326
+msgid ""
+"Setting an Alpha clone does not replace the character's skills, but rather "
+"caps them to Alpha levels."
+msgstr ""
+"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
 
-#: gui/targetProfileEditor.py:52
-msgid "Incorrect range (must be 0-100)"
-msgstr "范围无效（必须是 0-100）"
+#: gui/builtinStatsViews/resistancesViewFull.py:112
+msgid "Shield resistance"
+msgstr "护盾抗性"
 
-#: gui/targetProfileEditor.py:71
-msgid "You must supply a name for your Target Profile!"
-msgstr "您必须填写一个目标属性名！"
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+msgid "Shield/Armor Tank"
+msgstr "恢复"
 
-#: gui/targetProfileEditor.py:73
-msgid "Target Profile name already in use, please choose another."
-msgstr "目标属性名已使用，请选择其他名称。"
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Shield: "
+msgstr "护盾："
 
-#: gui/targetProfileEditor.py:86
-msgid "Target Profile"
-msgstr "目标属性"
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+#: gui/builtinViews/fittingView.py:661
+msgid "Ship"
+msgstr "船体"
 
-#: gui/targetProfileEditor.py:119
-msgid "EM resistance"
-msgstr "电磁抗性"
+#: gui/builtinShipBrowser/shipItem.py:111
+msgid "Ship Basic"
+msgstr ""
 
-#: gui/targetProfileEditor.py:124
-msgid "Maximum speed"
-msgstr "亚光速航速"
+#: gui/builtinShipBrowser/navigationPanel.py:48
+msgid "Ship groups"
+msgstr "舰船类型"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
+msgid "Ship hold"
+msgstr "舰船仓"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
+msgid "Show Rack Labels"
+msgstr "显示槽位类型标签"
+
+#: gui/builtinShipBrowser/navigationPanel.py:151
+msgid "Show empty ship groups"
+msgstr "显示空的舰船类型"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
+msgid "Show fitting tab tooltips"
+msgstr "装配标签页显示预览"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
+msgid "Show market shortcuts"
+msgstr "显示市场快捷方式"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
+msgid "Show ship browser tooltip"
+msgstr "船体列表显示预览"
+
+#: gui/builtinContextMenus/boosterSideEffects.py:34
+msgid "Side Effects"
+msgstr "副作用"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:88
+msgid "Signature"
+msgstr "信号半径"
 
 #: gui/targetProfileEditor.py:125
 msgid ""
@@ -1953,45 +2076,384 @@ msgstr ""
 "信号半径\n"
 "保持为空表示信号半径无限大"
 
-#: gui/targetProfileEditor.py:126
-msgid "Radius"
-msgstr "信号半径"
+#: gui/aboutData.py:33
+msgid ""
+"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
+msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
+
+#: gui/characterEditor.py:342 gui/characterEditor.py:608
+msgid "Skill"
+msgstr "技能"
+
+#: gui/characterEditor.py:160
+msgid "Skills"
+msgstr "技能列表"
+
+#: gui/characterSelection.py:242
+msgid "Skills required:"
+msgstr "所需技能："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
+msgid "Small ship hold"
+msgstr "小型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
+msgid "Speed"
+msgstr "亚光速航速"
+
+#: gui/builtinContextMenus/droneSplitStack.py:29
+msgid "Split {} Stack"
+msgstr "分离"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+msgid "Spoolup"
+msgstr "预热"
+
+#: gui/builtinContextMenus/moduleSpool.py:37
+msgid "Spoolup Cycles"
+msgstr "预热周期"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Stable: "
+msgstr "稳定："
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
+msgid "Statistics Panel"
+msgstr "属性面板"
+
+#: gui/characterEditor.py:901
+msgid "Success"
+msgstr "成功"
+
+#: gui/characterEditor.py:901
+msgid "Successfully fetched skills"
+msgstr "成功获取到技能列表"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
+#, python-brace-format
+msgid "Suppressing {0} Notifications"
+msgstr "有{0}个未提示的版本更新"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:87
+msgid "Sustained"
+msgstr "持续回充"
+
+#: gui/builtinContextMenus/shipModeChange.py:32
+#: gui/builtinViews/fittingView.py:657
+msgid "Tactical Mode"
+msgstr "战术模式"
+
+#: graphs/gui/lists.py:358
+msgid "Target"
+msgstr "目标"
+
+#: gui/targetProfileEditor.py:86
+msgid "Target Profile"
+msgstr "目标属性"
 
 #: gui/targetProfileEditor.py:130
 msgid "Target Profile Editor"
 msgstr "目标属性编辑器"
 
-#: gui/targetProfileEditor.py:221
-msgid "Import profiles from clipboard"
-msgstr "从剪贴板导入目标属性"
+#: gui/targetProfileEditor.py:73
+msgid "Target Profile name already in use, please choose another."
+msgstr "目标属性名已使用，请选择其他名称。"
 
-#: gui/targetProfileEditor.py:222
-msgid "Export profiles to clipboard"
-msgstr "导出目标属性到剪贴板"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:40
+msgid "Targeting && Misc"
+msgstr "目标和杂项"
 
-#: gui/targetProfileEditor.py:352
-msgid "Profiles successfully imported from clipboard"
-msgstr "已成功从剪贴板导入目标属性"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:62
+msgid "Targets"
+msgstr "最大锁定数"
 
-#: gui/targetProfileEditor.py:359
-msgid "Could not import from clipboard:"
-msgstr "无法从剪贴板导入："
+#: gui/mainFrame.py:811
+msgid "Text skills training file"
+msgstr "技能列表文本文件"
 
-#: gui/targetProfileEditor.py:372
-msgid "Profiles exported to clipboard"
-msgstr "目标属性已导出到剪贴板"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
+msgid ""
+"The amount of spoolup to use by default on module which support it. Can be "
+"changed on a per-module basis"
+msgstr "默认模块预热量。可以分模块单独设置"
 
-#: gui/multiSwitch.py:41
-msgid "Empty Tab"
-msgstr "空白标签页"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
+msgid ""
+"The delay between a keystroke and the market search. Can help reduce lag "
+"when typing fast in the market search box."
+msgstr ""
+"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
 
-#: gui/preferenceDialog.py:31
-msgid "Preferences"
-msgstr "偏好设置"
+#: gui/mainFrame.py:951
+msgid "The following error was generated"
+msgstr "Pyfa 遇到以下错误"
 
-#: gui/errorDialog.py:68
-msgid "Error!"
-msgstr "错误！"
+#: gui/mainFrame.py:895
+msgid "The following path is invalid or does not exist:"
+msgstr "下述路径无效或不存在："
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
+msgid ""
+"The source you choose will be tried first, but subsequent sources will be "
+"used if the preferred source fails. The system you choose will also be tried "
+"first, and if no data is available, global price will be used."
+msgstr ""
+"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
+"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
+msgid ""
+"There is a release available which you have chosen to suppress. You can "
+"choose to reset notification suppression for this release, or download the "
+"new release from GitHub."
+msgstr ""
+"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
+
+#: gui/characterEditor.py:463
+msgid "There was an error importing skills, please see log file"
+msgstr "导入技能列表出错，详见日志文件"
+
+#: gui/esiFittings.py:196
+msgid ""
+"There was an error validating characters' SSO token. Please try logging into "
+"the character again to reset the token."
+msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
+
+#: gui/esiFittings.py:179
+msgid ""
+"There was an issue starting up the localized server, try setting Login "
+"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
+"Authentication Method. If this doesn't fix the problem please file an issue "
+"on Github."
+msgstr ""
+"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
+"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:86
+#: gui/targetProfileEditor.py:120
+msgid "Thermal resistance"
+msgstr "热能抗性"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+msgid ""
+"This is a destructive action that will delete all cached prices out of the "
+"database.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有价格缓存数据。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
+msgid ""
+"This is a destructive action that will delete all damage pattern profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有伤害模型配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+msgid ""
+"This is a destructive action that will delete all target profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有目标属性配置。\n"
+"您确定要继续吗？"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:49
+msgid ""
+"This option goes through EVE SSO directly, but requires more configuration. "
+"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
+"route data throguh pyfa.io."
+msgstr ""
+"本选项将直接发送EvE单点登录请求，但这需要更多配置。如果pyfa.io无法访问，或你"
+"不想让pyfa.io处理登录请求，请使用该选项。"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:42
+msgid ""
+"This option prompts users to copy and paste information from the web "
+"application to allow for character login. Use this if having issues with the "
+"local server."
+msgstr ""
+"本选项将在角色登录时提示您复制和粘贴登录页相关信息。如果本地服务器出现问题，"
+"可使用该选项。"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
+msgid ""
+"This options routes SSO Logins through pyfa.io, allowing you to easily login "
+"without any configuration. When in doubt, use this option."
+msgstr ""
+"本选项将通过pyfa.io处理单点登录(SSO)请求，使你无需配置即可登录到EVE。不清除时"
+"可以使用该选项。"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
+msgid ""
+"This options starts a local webserver that the web application will call "
+"back to with information about the character login."
+msgstr "本选项将启动一个本地服务器以接收登录页返回的角色信息。"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:70
+msgid "Toggle Names"
+msgstr "切换名称"
+
+#: gui/builtinItemStatsViews/itemAffectedBy.py:73
+msgid "Toggle View"
+msgstr "切换视图"
+
+#: gui/builtinItemStatsViews/itemCompare.py:75
+msgid "Toggle view mode"
+msgstr "切换显示模式"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:89
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+msgid "Total"
+msgstr "总计"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
+msgid "Total Price Includes"
+msgstr "价格总计包括"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:67
+msgid "Total: "
+msgstr "总计："
+
+#: gui/itemStats.py:166
+msgid "Traits"
+msgstr "特征"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:111
+msgid "Turret hardpoints"
+msgstr "炮台"
+
+#: gui/builtinItemStatsViews/itemEffects.py:32
+msgid "Type"
+msgstr "类型"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
+#, python-brace-format
+msgid "Type: {0}\n"
+msgstr "扫描类型：{0}\n"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:222
+msgid "Type: {}"
+msgstr "扫描类型：{}"
+
+#: gui/mainMenuBar.py:83
+msgid "Undo the most recent action"
+msgstr "撤销最近一次操作"
+
+#: gui/characterEditor.py:614
+msgid "Unlearn"
+msgstr "未学习"
+
+#: gui/updateDialog.py:54
+msgid "Update Available"
+msgstr "有更新可用"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
+msgid "Updates"
+msgstr "更新"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
+msgid "Use character implants by default for new fits"
+msgstr "新装配默认使用角色植入体组"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
+msgid "Use global character"
+msgstr "使用全局角色"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
+msgid "Use global damage pattern"
+msgstr "使用全局伤害分布配置"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:121
+msgid "Username:"
+msgstr "用户名："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
+msgid "Using Executable Path for Saved Fit Database and Settings"
+msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
+
+#: gui/builtinContextMenus/itemVariationChange.py:49
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+msgid "Variations"
+msgstr "变种"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:53
+msgid "View Raw Data"
+msgstr "显示原始数据"
+
+#: gui/ssoLogin.py:62
+msgid "Waiting for character login through EVE Single Sign-On."
+msgstr "正在等待角色通过EvE登录。"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:210
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:212
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:243
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:245
+#, python-format
+msgid "Warp Core Strength: %.1f"
+msgstr "跃迁核心强度：%.1f"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:89
+msgid "Warp Speed"
+msgstr "曲速航速"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Weapon"
+msgstr "武器"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
+msgid ""
+"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
+"behavior)."
+msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
+msgid ""
+"When disabled, reloads charges just in selected modules. Action can be "
+"reversed by holding Ctrl or Alt key while changing charge."
+msgstr ""
+"关闭该选项时，更换弹药仅更换选中的模块。按住Ctrl或Alt以更换所有同类型武器弹"
+"药。"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
+msgid ""
+"When enabled, skills will check their dependencies' requirements when their "
+"levels change and reset skills that no longer meet the requirement.\n"
+"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
+"skill, as that requires Drones V"
+msgstr ""
+"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
+"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
+
+#: gui/builtinItemStatsViews/itemEffects.py:56
+msgid "Yes"
+msgstr "是"
+
+#: gui/characterEditor.py:757
+msgid "You cannot link All 0 or All 5 characters to an EVE character."
+msgstr "你不能关联全0级或全5级到一个EvE角色。"
+
+#: gui/characterEditor.py:76
+msgid "You must supply a name for the Character!"
+msgstr "您必须填写一个角色名！"
+
+#: gui/setEditor.py:48
+msgid "You must supply a name for the Implant Set!"
+msgstr "您必须填写一个植入体配置名！"
+
+#: gui/patternEditor.py:51
+msgid "You must supply a name for your Damage Profile!"
+msgstr "您必须填写一个伤害模型名！"
+
+#: gui/targetProfileEditor.py:71
+msgid "You must supply a name for your Target Profile!"
+msgstr "您必须填写一个目标属性名！"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
+msgid "pyfa User Path:"
+msgstr "pyfa用户数据路径："
 
 #: gui/errorDialog.py:69
 msgid "pyfa error"
@@ -2008,146 +2470,41 @@ msgstr ""
 "Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
 "请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
 
-#: gui/mainFrame.py:182
-msgid "Market"
-msgstr "市场"
+#: gui/aboutData.py:31
+msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
+msgstr ""
+"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/mainFrame.py:273
-msgid "Loading previous fits..."
-msgstr "正在打开之前的装配..."
+#: gui/propertyEditor.py:108
+msgid "pyfa override file"
+msgstr "Pyfa属性自定义文件"
 
-#: gui/mainFrame.py:468 gui/mainFrame.py:838
-msgid "EVE XML fitting files"
-msgstr "EvE装配XML文件"
+#: gui/propertyEditor.py:131
+msgid "pyfa overrides"
+msgstr "Pyfa属性自定义文件"
 
-#: gui/mainFrame.py:647
-msgid ""
-"Are you sure you wish to ignore fitting restrictions for the current fit? "
-"This could lead to wildly inaccurate results and possible errors."
-msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "pyfa.io"
+msgstr "pyfa.io"
 
-#: gui/mainFrame.py:654
-msgid ""
-"Re-enabling fitting restrictions for this fit will also remove any illegal "
-"items from the fit. Do you want to continue?"
-msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
+#: gui/builtinContextMenus/itemMarketJump.py:44
+#, python-brace-format
+msgid "{0} Market Group"
+msgstr "{0}市场分类"
 
-#: gui/mainFrame.py:673
-msgid "Manage Characters"
-msgstr "管理角色"
+#: gui/itemStats.py:87
+#, python-brace-format
+msgid "{context}Stats: {name}{debug_info}"
+msgstr "{context}属性：{name}{debug_info}"
 
-#: gui/mainFrame.py:690
-msgid "&Turn Overrides Off"
-msgstr "启用自定义属性(&T)"
+#: gui/builtinContextMenus/moduleSpool.py:83
+msgid "{} (default)"
+msgstr "{}（默认值）"
 
-#: gui/mainFrame.py:723
-msgid "Please Wait..."
-msgstr "请稍候..."
+#: gui/characterEditor.py:284
+msgid "{} Copy"
+msgstr "复制{}"
 
-#: gui/mainFrame.py:807
-msgid "Export Skills Needed As..."
-msgstr "导出所需技能列表到..."
-
-#: gui/mainFrame.py:809
-msgid "EVEMon skills training file"
-msgstr "EvEMon技能训练文件"
-
-#: gui/mainFrame.py:810
-msgid "EVEMon skills training XML file"
-msgstr "EvEMon技能训练XML文件"
-
-#: gui/mainFrame.py:811
-msgid "Text skills training file"
-msgstr "技能列表文本文件"
-
-#: gui/mainFrame.py:829
-msgid "Exporting skills needed..."
-msgstr "正在导出所需技能..."
-
-#: gui/mainFrame.py:836
-msgid "Open One Or More Fitting Files"
-msgstr "打开装配文件"
-
-#: gui/mainFrame.py:839
-msgid "EFT text fitting files"
-msgstr "EFT装配文本文件"
-
-#: gui/mainFrame.py:840 gui/mainFrame.py:1015
-msgid "All Files"
-msgstr "所有文件"
-
-#: gui/mainFrame.py:846
-msgid "Importing fits"
-msgstr "正在导入装配"
-
-#: gui/mainFrame.py:860
-msgid "Save Backup As..."
-msgstr "保存备份为..."
-
-#: gui/mainFrame.py:861
-msgid "EVE XML fitting file"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:874 gui/mainFrame.py:905
-msgid "Backup fits"
-msgstr "备份装配"
-
-#: gui/mainFrame.py:875
-msgid "Backing up {} fits to: {}"
-msgstr "正在备份{}个装配到：{}"
-
-#: gui/mainFrame.py:894
-msgid "Invalid Path"
-msgstr "无效路径"
-
-#: gui/mainFrame.py:895
-msgid "The following path is invalid or does not exist:"
-msgstr "下述路径无效或不存在："
-
-#: gui/mainFrame.py:897
-msgid "Please verify path location pyfa's preferences."
-msgstr "请确认Pyfa偏好保存位置。"
-
-#: gui/mainFrame.py:906
-msgid "Generating HTML file at: {}"
-msgstr "正在生成HTML网页到：{}"
-
-#: gui/mainFrame.py:948
-msgid "Import Error"
-msgstr "导入错误"
-
-#: gui/mainFrame.py:948
-msgid "Export Error"
-msgstr "导出错误"
-
-#: gui/mainFrame.py:951
-msgid "The following error was generated"
-msgstr "Pyfa 遇到以下错误"
-
-#: gui/mainFrame.py:953
-msgid "Be aware that already processed fits were not saved"
-msgstr "请注意已处理的装配未作保存"
-
-#: gui/mainFrame.py:1012
-msgid "Open One Or More Character Files"
-msgstr "打开角色文件"
-
-#: gui/mainFrame.py:1014
-msgid "EVE API XML character files"
-msgstr "EvE API 角色XML文件"
-
-#: gui/mainFrame.py:1021
-msgid "Importing Character..."
-msgstr "正在导入角色..."
-
-#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
-msgid "SSO Login"
-msgstr "通过EVE登录"
-
-#: gui/ssoLogin.py:20
-msgid "Copy and paste the block of text provided by pyfa.io"
-msgstr "请复制和粘贴pyfa.io提供的字符串"
-
-#: gui/ssoLogin.py:62
-msgid "Waiting for character login through EVE Single Sign-On."
-msgstr "正在等待角色通过EvE登录。"
+#: gui/builtinContextMenus/itemStats.py:38
+msgid "{} Stats"
+msgstr "{}属性"


### PR DESCRIPTION
This time the major changes are about Preference. The zh_CN translation now have ~~454/455 (99%)~~ 556/565 (98%) strings translated.

Components that still not translated:

- graph window
- context menus
- some stat view tool tips
- column names
- Fit table high/med/low/rig slot names

Edit: update stat with context menus (mostly) translated.