### PR TITLE
i18n_db: fix ValueError exception when name should be groupName

### DIFF
--- a/gui/builtinAdditionPanes/fighterView.py
+++ b/gui/builtinAdditionPanes/fighterView.py
@@ -255,7 +255,7 @@ class FighterDisplay(d.Display):
 
     @staticmethod
     def fighterKey(fighter):
-        groupName = Market.getInstance().getGroupByItem(fighter.item).name
+        groupName = Market.getInstance().getGroupByItem(fighter.item).groupName
         orderPos = FIGHTER_ORDER.index(groupName)
         # Sort support fighters by name, ignore their abilities
         if groupName == 'Support Fighter':


### PR DESCRIPTION
a fit with fighters can trigger this exception. e.g. this Chimera [fit](https://wiki.eveuniversity.org/Chimera/Fittings) from EvE University Wiki