### PR TITLE
i18n: update locale/README.md to include sort detail; sort zh_CN lang.po

### DIFF
--- a/locale/README.md
+++ b/locale/README.md
@@ -12,7 +12,7 @@ For Linux and macOS users these tools might be available out-of-box.
 ### To generate new template for translation:
 
 ```console
-$ find gui/ *.py -name "*.py" | xgettext --from-code=UTF-8 -o locale/lang.pot -d lang -k_t -f -
+$ find gui/ *.py -name "*.py" | xgettext --from-code=UTF-8 -o locale/lang.pot -d lang -k_t -f - -s
 ```
 
 explanation:
@@ -24,13 +24,14 @@ explanation:
     * `-d lang`: default language domain is `lang`
     * `-k_t`: besides default keyword (including `_`, see `info xgettext` for detail), also look for `_t`
     * `-f -`: let `xgettext` to read from stdin, which is connected to `find` stdout
+    * `-s`: sort output according to `msgid`
 
 this `locale/lang.pot` is called PO template, which is throwed away once actual `ll_CC/LC_MESSAGES/lang.po` is ready for use.
 
 ### To initialize PO file for new language
 
 ```console
-$ msginit -i locale/lang.pot -l ll_CC -o locale/ll_CC/LC_MESSAGES/lang.po
+$ msginit -i locale/lang.pot -l ll_CC -o locale/ll_CC/LC_MESSAGES/lang.po -s
 ```
 
 explanation:
@@ -47,7 +48,7 @@ this `locale/ll_CC/LC_MESSAGES/lang.po` should be checked into VCS, later it wil
 ### To update PO file for existing translation
 
 ```console
-$ msgmerge locale/ll_CC/LC_MESSAGES/lang.po locale/lang.pot
+$ msgmerge -s locale/ll_CC/LC_MESSAGES/lang.po locale/lang.pot
 ```
 
 ### To do actual translation
@@ -68,6 +69,15 @@ for f in locale/*/; do
     msgfmt $f/LC_MESSAGES/lang.po -o $f/LC_MESSAGES/lang.mo
 done
 ```
+
+### To merge 2 or more PO file
+
+```console
+$ msgcat -s path/to/old.po [path/to/another.po] -o path/to/new.po
+```
+
+Note that `msgcat` cannot perform a 3-way merge, it will simply stack translations with same `msgid` on top of each other.
+If you use `msgcat` to merge multiple PO file, please check and fix the output before commit to Git. 
 
 ## i18n with Poedit
 

--- a/locale/zh_CN/LC_MESSAGES/lang.po
+++ b/locale/zh_CN/LC_MESSAGES/lang.po
@@ -18,68 +18,383 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gui/aboutData.py:31
-msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
-msgstr ""
-"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
+#: gui/builtinStatsViews/firepowerViewFull.py:107
+msgid " DPS: "
+msgstr " DPS: "
 
-#: gui/aboutData.py:32
-msgid "All EVE-Online related materials are property of CCP hf."
-msgstr "所有 EvE Online 相关材料版权归CCP所有"
+#: gui/builtinContextMenus/itemRemove.py:44
+msgid " Stack"
+msgstr "小队"
 
-#: gui/aboutData.py:33
+#: gui/builtinStatsViews/firepowerViewFull.py:100
+msgid " Volley: "
+msgstr "齐射"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
+msgid " chance to be jammed"
+msgstr "概率丢失目标"
+
+#: gui/builtinItemStatsViews/itemProperties.py:98
+#, python-format
+msgid "%d attribute."
+msgstr "共%d个属性。"
+
+#: gui/mainMenuBar.py:73
+msgid "&Backup All Fittings"
+msgstr "备份所有装配(&B)"
+
+#: gui/mainMenuBar.py:104
+msgid "&Browse ESI Fittings"
+msgstr "浏览游戏内装配(&B)"
+
+#: gui/mainMenuBar.py:111
+msgid "&Character"
+msgstr "角色(&C)"
+
+#: gui/mainMenuBar.py:144
+msgid "&Character Editor"
+msgstr "角色编辑器(&C)"
+
+#: gui/mainMenuBar.py:70
+msgid "&Close All Tabs"
+msgstr "关闭所有标签页(&C)"
+
+#: gui/mainMenuBar.py:69
+msgid "&Close Tab"
+msgstr "关闭标签页(&C)"
+
+#: gui/mainMenuBar.py:150
+msgid "&Damage Pattern Editor"
+msgstr "伤害模型编辑器(&D)"
+
+#: gui/mainMenuBar.py:143
+msgid "&Editors"
+msgstr "编辑器(&E)"
+
+#: gui/mainMenuBar.py:92
+msgid "&Export Fitting"
+msgstr "导出装配(&E)"
+
+#: gui/mainMenuBar.py:119
+msgid "&Export Skills Needed"
+msgstr "导出所需技能列表(&E)"
+
+#: gui/mainMenuBar.py:66 gui/propertyEditor.py:42
+msgid "&File"
+msgstr "文件(&F)"
+
+#: gui/mainMenuBar.py:161
+msgid "&Forums"
+msgstr "论坛(&F)"
+
+#: gui/mainMenuBar.py:88
+msgid "&From Clipboard"
+msgstr "从剪贴板导入(&F)"
+
+#: gui/mainMenuBar.py:135
+msgid "&Global"
+msgstr "全局设置(&G)"
+
+#: gui/mainMenuBar.py:96
+msgid "&Graphs"
+msgstr "图表(&G)"
+
+#: gui/mainMenuBar.py:159
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: gui/mainMenuBar.py:147
+msgid "&Implant Set Editor"
+msgstr "植入体配置编辑器(&I)"
+
+#: gui/mainMenuBar.py:118
+msgid "&Import Character File"
+msgstr "导入角色文件(&I)"
+
+#: gui/mainMenuBar.py:91
+msgid "&Import Fittings"
+msgstr "导入装配(&I)"
+
+#: gui/mainMenuBar.py:122
+msgid "&Manage ESI Characters"
+msgstr "管理游戏内角色(&M)"
+
+#: gui/mainMenuBar.py:68
+msgid "&New Tab"
+msgstr "新标签页(&N)"
+
+#: gui/mainMenuBar.py:95
+msgid "&Optimize Fit Price"
+msgstr "优化装配价格(&O)"
+
+#: gui/mainMenuBar.py:137
+msgid "&Preferences"
+msgstr "偏好设置(&P)"
+
+#: gui/mainMenuBar.py:84
+msgid "&Redo"
+msgstr "恢复(&R)"
+
+#: gui/mainMenuBar.py:115
+msgid "&Revert Character"
+msgstr "还原角色(&R)"
+
+#: gui/mainMenuBar.py:113
+msgid "&Save Character"
+msgstr "保存角色(&S)"
+
+#: gui/mainMenuBar.py:153
+msgid "&Target Profile Editor"
+msgstr "目标属性编辑器(&T)"
+
+#: gui/mainMenuBar.py:87
+msgid "&To Clipboard"
+msgstr "导出到剪贴板(&T)"
+
+#: gui/mainFrame.py:690
+msgid "&Turn Overrides Off"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainFrame.py:690 gui/mainMenuBar.py:131
+msgid "&Turn Overrides On"
+msgstr "启用自定义属性(&T)"
+
+#: gui/mainMenuBar.py:83
+msgid "&Undo"
+msgstr "撤销(&R)"
+
+#: gui/mainMenuBar.py:160
+msgid "&Wiki"
+msgstr "百科(&W)"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
 msgid ""
-"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
-msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
+"(Cannot be changed while pyfa is running. Set via command line switches.)"
+msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
 
-#: gui/aboutData.py:34
-msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
-msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
+#: gui/builtinStatsViews/capacitorViewFull.py:81
+msgid "0s"
+msgstr "0秒"
 
-#: gui/aboutData.py:49
-msgid ""
-"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
-"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
-"high degree of accuracy. Pyfa can run on all platforms where Python and "
-"wxWidgets are supported."
+#: gui/builtinContextMenus/fighterAbilities.py:33
+msgid "Abilities"
+msgstr "铁骑技能"
+
+#: gui/builtinContextMenus/envEffectAdd.py:119
+msgid "Abyssal Weather"
 msgstr ""
-"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
-"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
-"wxWidgets支持的所有平台运行。"
+
+#: gui/builtinItemStatsViews/itemEffects.py:31
+msgid "Active"
+msgstr "激活"
+
+#: gui/builtinViewColumns/abilities.py:37
+msgid "Active Abilities"
+msgstr "铁骑技能"
+
+#: gui/builtinViewColumns/sideEffects.py:37
+msgid "Active Side Effects"
+msgstr "副作用"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:76
+msgid "Active shield boost"
+msgstr "主动维修"
+
+#: gui/esiFittings.py:350
+msgid "Add Character"
+msgstr "添加角色"
+
+#: gui/esiFittings.py:183
+msgid "Add Character Error"
+msgstr "添加角色错误"
+
+#: gui/builtinContextMenus/fitAddCurrentlyOpen.py:29
+msgid "Add Currently Open Fit"
+msgstr "添加当前装配"
+
+#: gui/builtinContextMenus/envEffectAdd.py:56
+msgid "Add Environmental Effect"
+msgstr "添加环境效果"
+
+#: gui/builtinContextMenus/fitAddBrowse.py:22
+msgid "Add Fit..."
+msgstr "添加装配..."
+
+#: gui/fitBrowserLite.py:17
+msgid "Add Fits"
+msgstr "添加装配"
+
+#: gui/builtinContextMenus/cargoAddAmmo.py:28
+#, python-brace-format
+msgid "Add {0} to Cargo (x1000)"
+msgstr "添加 {0} 到货舱(x1000)"
+
+#: gui/builtinContextMenus/cargoAdd.py:33
+msgid "Add {} to Cargo"
+msgstr "添加{}到货舱"
+
+#: gui/builtinContextMenus/droneAddStack.py:40
+msgid "Add {} to Drone Bay{}"
+msgstr "添加{}到无人机机库{}"
 
 #: gui/additionsPane.py:45
 msgid "Additions"
 msgstr "附加装备"
 
-#: gui/additionsPane.py:66 gui/builtinContextMenus/additionsExportAll.py:18
-#: gui/builtinContextMenus/additionsExportSelection.py:18
-#: gui/builtinContextMenus/additionsImport.py:19
-#: gui/builtinContextMenus/priceOptions.py:40
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
-#: gui/builtinStatsViews/priceViewFull.py:58
-msgid "Drones"
-msgstr "无人机"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
+msgid "Additions Panel Copy/Paste"
+msgstr "附加装备栏复制/粘贴"
 
-#: gui/additionsPane.py:69 gui/builtinContextMenus/additionsExportAll.py:19
-#: gui/builtinContextMenus/additionsExportSelection.py:19
-#: gui/builtinContextMenus/additionsImport.py:20
-msgid "Fighters"
-msgstr "铁骑舰载机"
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:101
+msgid "Addr:"
+msgstr "地址："
 
-#: gui/additionsPane.py:72 gui/builtinContextMenus/priceOptions.py:47
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:90
-msgid "Cargo"
-msgstr "货舱"
+#: gui/itemStats.py:196
+msgid "Affected by"
+msgstr "影响因素"
 
-#: gui/additionsPane.py:75 gui/builtinContextMenus/additionsExportAll.py:21
-#: gui/builtinContextMenus/additionsExportAll.py:22
-#: gui/builtinContextMenus/additionsExportSelection.py:21
-#: gui/builtinContextMenus/additionsExportSelection.py:22
-#: gui/builtinContextMenus/additionsImport.py:22
-#: gui/builtinContextMenus/additionsImport.py:23 gui/characterEditor.py:161
-msgid "Implants"
-msgstr "植入体"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:226
+#, python-format
+msgid "Agility:\t%.3fx"
+msgstr "灵活性：%.3fx"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
+msgid "Align time"
+msgstr "起跳时间"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:224
+#, python-format
+msgid "Align:\t%.3fs"
+msgstr "起跳时间：%.3fs"
+
+#: gui/aboutData.py:32
+msgid "All EVE-Online related materials are property of CCP hf."
+msgstr "所有 EvE Online 相关材料版权归CCP所有"
+
+#: gui/mainFrame.py:840 gui/mainFrame.py:1015
+msgid "All Files"
+msgstr "所有文件"
+
+#: gui/characterSelection.py:238
+msgid "All skill prerequisites have been met"
+msgstr "已达到所有技能要求"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
+msgid "Allow pre-release notifications"
+msgstr "允许预发布版本更新通知"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
+msgid "Ammo hold"
+msgstr "弹药仓"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
+msgid "Animate gauges"
+msgstr "启用属性进度条动画"
+
+#: gui/builtinContextMenus/implantSetApply.py:25
+msgid "Apply Implant Set"
+msgstr "应用植入体配置"
+
+#: gui/builtinContextMenus/moduleMutations.py:33
+msgid "Apply Mutaplasmid"
+msgstr "使用突变质体"
+
+#: gui/builtinContextMenus/graphDmgApplyProjected.py:23
+msgid "Apply Projected Items"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:144
+msgid "Apply Proxy Settings"
+msgstr "应用代理配置"
+
+#: gui/propertyEditor.py:146
+msgid "Are you sure you want to delete all overrides?"
+msgstr "您确定要删除所有自定义属性吗？"
+
+#: gui/mainFrame.py:647
+msgid ""
+"Are you sure you wish to ignore fitting restrictions for the current fit? "
+"This could lead to wildly inaccurate results and possible errors."
+msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:77
+msgid "Armor repair amount"
+msgstr "装甲修量"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:113
+msgid "Armor resistance"
+msgstr "装甲抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Armor: "
+msgstr "装甲："
+
+#: gui/builtinItemStatsViews/itemAttributes.py:44
+#: gui/builtinItemStatsViews/itemProperties.py:56
+msgid "Attribute"
+msgstr "属性"
+
+#: gui/mainMenuBar.py:128
+msgid "Attribute &Overrides"
+msgstr "自定义属性(&O)"
+
+#: gui/propertyEditor.py:28
+msgid "Attribute Editor"
+msgstr "属性编辑器"
+
+#: gui/itemStats.py:177
+msgid "Attributes"
+msgstr "属性"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Auto-detected proxy settings"
+msgstr "自动检测代理设置"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:136
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:158
+msgid "Auto-detected: "
+msgstr "自动检测结果："
+
+#: gui/builtinShipBrowser/navigationPanel.py:50
+msgid "Back"
+msgstr "返回"
+
+#: gui/mainFrame.py:875
+msgid "Backing up {} fits to: {}"
+msgstr "正在备份{}个装配到：{}"
+
+#: gui/mainMenuBar.py:73
+msgid "Backup all fittings to a XML file"
+msgstr "备份所有装配到XML文件"
+
+#: gui/mainFrame.py:874 gui/mainFrame.py:905
+msgid "Backup fits"
+msgstr "备份装配"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:47
+msgid "Base Value"
+msgstr "基础值"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
+msgid "Battlecruiser"
+msgstr "战巡"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
+msgid "Battleship"
+msgstr "战列"
+
+#: gui/mainFrame.py:953
+msgid "Be aware that already processed fits were not saved"
+msgstr "请注意已处理的装配未作保存"
+
+#: gui/builtinContextMenus/envEffectAdd.py:197
+msgid "Bioluminescence"
+msgstr "生物荧光"
+
+#: gui/builtinAdditionPanes/boosterView.py:215
+msgid "Booster"
+msgstr "增效剂"
 
 #: gui/additionsPane.py:78 gui/builtinContextMenus/additionsExportAll.py:23
 #: gui/builtinContextMenus/additionsExportSelection.py:23
@@ -87,32 +402,36 @@ msgstr "植入体"
 msgid "Boosters"
 msgstr "增效剂"
 
-#: gui/additionsPane.py:81
-msgid "Projected"
-msgstr "环境效果"
+#: gui/esiFittings.py:32
+msgid "Browse EVE Fittings"
+msgstr "浏览游戏内装配"
 
-#: gui/additionsPane.py:84
-msgid "Command"
-msgstr "指令"
+#: gui/builtinStatsViews/resourcesViewFull.py:153
+msgid "CPU"
+msgstr "CPU"
 
-#: gui/additionsPane.py:87
-msgid "Notes"
-msgstr "备注"
+#: gui/builtinItemStatsViews/itemAttributes.py:118
+msgid "CSV files"
+msgstr "逗号分隔符(CSV)文件"
 
-#: gui/builtinAdditionPanes/boosterView.py:215
-msgid "Booster"
-msgstr "增效剂"
+#: gui/builtinStatsViews/resourcesViewFull.py:115
+msgid "Calibration"
+msgstr "校准"
 
-#: gui/builtinAdditionPanes/commandView.py:201
-msgid "Command Fit"
-msgstr ""
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
+#: gui/builtinStatsViews/capacitorViewFull.py:37
+msgid "Capacitor"
+msgstr "电容"
 
-#: gui/builtinAdditionPanes/projectedView.py:306
-#: gui/builtinAdditionPanes/projectedView.py:316
-#: gui/builtinAdditionPanes/projectedView.py:321
-#: gui/builtinAdditionPanes/projectedView.py:326
-msgid "Projected Item"
-msgstr ""
+#: gui/builtinStatsViews/capacitorViewFull.py:57
+msgid "Capacitor stability"
+msgstr "电容稳定性"
+
+#: gui/additionsPane.py:72 gui/builtinContextMenus/priceOptions.py:47
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:81
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:90
+msgid "Cargo"
+msgstr "货舱"
 
 #: gui/builtinContextMenus/additionsExportAll.py:20
 #: gui/builtinContextMenus/additionsExportSelection.py:20
@@ -120,62 +439,170 @@ msgstr ""
 msgid "Cargo Items"
 msgstr "货舱物品"
 
-#: gui/builtinContextMenus/additionsExportAll.py:39
-msgid "Copy All {}"
-msgstr "复制所有{}"
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/resourcesViewFull.py:158
+msgid "Cargo bay"
+msgstr "货舱"
 
-#: gui/builtinContextMenus/additionsExportSelection.py:39
-msgid "Copy Selected {}"
-msgstr "拷贝选中的{}"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:229
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:254
+msgid "Cargohold: "
+msgstr "货舱："
 
-#: gui/builtinContextMenus/additionsImport.py:40
-msgid "Paste {}"
-msgstr "粘贴{}"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:167
+msgid "Carrier"
+msgstr "航母"
 
-#: gui/builtinContextMenus/ammoToDmgPattern.py:32
-msgid "Set {} as Damage Pattern"
-msgstr "设置{}为伤害模型"
+#: gui/builtinContextMenus/envEffectAdd.py:197
+msgid "Caustic"
+msgstr "腐蚀"
 
-#: gui/builtinContextMenus/ammoToDmgPattern.py:32
-#: gui/builtinContextMenus/itemMarketJump.py:44
-#: gui/builtinContextMenus/itemRemove.py:43
-#: gui/builtinContextMenus/itemStats.py:38
-#: gui/builtinItemStatsViews/itemCompare.py:147
-msgid "Item"
-msgstr "物品"
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
+msgid "Cert Path:"
+msgstr "证书路径："
 
-#: gui/builtinContextMenus/boosterSideEffects.py:34
-msgid "Side Effects"
-msgstr "副作用"
+#: gui/builtinContextMenus/skillAffectors.py:73
+#, python-format
+msgid "Change %s Skills"
+msgstr "修改%s技能等级"
 
-#: gui/builtinContextMenus/cargoAdd.py:33
-msgid "Add {} to Cargo"
-msgstr "添加{}到货舱"
+#: gui/builtinContextMenus/itemAmountChange.py:92
+msgid "Change Amount"
+msgstr "更改数量"
 
-#: gui/builtinContextMenus/cargoAddAmmo.py:28
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
+msgid "Change Skills"
+msgstr "修改技能等级"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
+msgid "Change charge in all modules of the same type"
+msgstr "同时更换所有同类型模块的弹药"
+
+#: gui/builtinContextMenus/itemAmountChange.py:34
 #, python-brace-format
-msgid "Add {0} to Cargo (x1000)"
-msgstr "添加 {0} 到货舱(x1000)"
+msgid "Change {0} Quantity"
+msgstr "更改{0}数量"
+
+#: gui/builtinContextMenus/itemProjectionRange.py:34
+msgid "Change {} Range"
+msgstr "变更{}半径"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
+msgid "Changes require restart of pyfa to take effect."
+msgstr "变更将在重启Pyfa之后生效。"
+
+#: gui/builtinStatsViews/priceViewFull.py:57 gui/characterEditor.py:90
+#: gui/esiFittings.py:341
+msgid "Character"
+msgstr "角色"
+
+#: gui/characterEditor.py:137
+msgid "Character Editor"
+msgstr "角色编辑器"
+
+#: gui/esiFittings.py:342
+msgid "Character ID"
+msgstr "角色ID"
+
+#: gui/characterEditor.py:78
+msgid "Character name already in use, please choose another."
+msgstr "角色名已占用，请使用其他名称。"
+
+#: gui/characterEditor.py:771
+msgid "Character:"
+msgstr "角色："
+
+#: gui/characterSelection.py:47
+msgid "Character: "
+msgstr "角色："
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:48
+msgid "Charge"
+msgstr "弹药"
+
+#: gui/builtinViews/fittingView.py:661
+msgid "Citadel"
+msgstr "堡垒"
+
+#: gui/builtinContextMenus/fitSystemSecurity.py:38
+msgid "Citadel System Security"
+msgstr ""
+
+#: gui/propertyEditor.py:40
+msgid "Clear All"
+msgstr "清除所有"
+
+#: gui/propertyEditor.py:40
+msgid "Clear all overrides"
+msgstr "清除所有自定义属性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:97
+#: gui/builtinStatsViews/resistancesViewFull.py:169
+msgid "Click to toggle between effective HP and raw HP"
+msgstr "点击切换有效HP和原始HP"
+
+#: gui/builtinStatsViews/miningyieldViewFull.py:102
+msgid "Click to toggle to Firepower View"
+msgstr "点击切换到火力视图"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:115
+msgid "Click to toggle to Mining Yield"
+msgstr "点击切换到矿物产出视图"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:76
+msgid "Client ID:"
+msgstr "客户ID(Client ID)："
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:85
+msgid "Client Secret:"
+msgstr "客户密钥(Client Secret)："
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
+msgid "Color fitting view by slot"
+msgstr "用背景色区分槽位"
+
+#: gui/additionsPane.py:84
+msgid "Command"
+msgstr "指令"
+
+#: gui/builtinAdditionPanes/commandView.py:201
+msgid "Command Fit"
+msgstr ""
 
 #: gui/builtinContextMenus/commandFitAdd.py:51
 msgid "Command Fits"
 msgstr ""
 
-#: gui/builtinContextMenus/droneAddStack.py:40
-msgid "Add {} to Drone Bay{}"
-msgstr "添加{}到无人机机库{}"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:127
+msgid "Command center hold"
+msgstr "指挥中心仓"
 
-#: gui/builtinContextMenus/droneSplitStack.py:29
-msgid "Split {} Stack"
-msgstr "分离"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
+msgid "Compact skills needed tooltip"
+msgstr "简洁技能需求提示"
 
-#: gui/builtinContextMenus/envEffectAdd.py:56
-msgid "Add Environmental Effect"
-msgstr "添加环境效果"
+#: gui/itemStats.py:182
+msgid "Compare"
+msgstr "对比"
 
-#: gui/builtinContextMenus/envEffectAdd.py:105
-msgid "Wormhole"
-msgstr ""
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:108
+#: gui/mainFrame.py:649 gui/mainFrame.py:655
+msgid "Confirm"
+msgstr "确认"
+
+#: gui/esiFittings.py:157 gui/propertyEditor.py:147
+msgid "Confirm Delete"
+msgstr "删除确认"
+
+#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
+msgid "Connection error, please check your internet connection"
+msgstr "连接错误，请检查您的网络连接"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
+msgid "Context Menus"
+msgstr "右键菜单"
 
 #: gui/builtinContextMenus/envEffectAdd.py:106
 msgid "ContextMenu|ProjectedEffectManipulation|Black Hole"
@@ -184,6 +611,10 @@ msgstr "黑洞"
 #: gui/builtinContextMenus/envEffectAdd.py:107
 msgid "ContextMenu|ProjectedEffectManipulation|Cataclysmic Variable"
 msgstr "激变变星"
+
+#: gui/builtinContextMenus/envEffectAdd.py:133
+msgid "ContextMenu|ProjectedEffectManipulation|Effects"
+msgstr "效果"
 
 #: gui/builtinContextMenus/envEffectAdd.py:108
 msgid "ContextMenu|ProjectedEffectManipulation|Magnetar"
@@ -197,415 +628,145 @@ msgstr "脉冲星"
 msgid "ContextMenu|ProjectedEffectManipulation|Red Giant"
 msgstr "红巨星"
 
-#: gui/builtinContextMenus/envEffectAdd.py:111
-msgid "ContextMenu|ProjectedEffectManipulation|Wolf Rayet"
-msgstr "沃尔夫-拉叶星"
-
-#: gui/builtinContextMenus/envEffectAdd.py:112
-msgid "Sansha Incursion"
-msgstr "萨沙入侵"
-
 #: gui/builtinContextMenus/envEffectAdd.py:113
 msgid "ContextMenu|ProjectedEffectManipulation|Sansha Incursion"
 msgstr "萨沙入侵"
-
-#: gui/builtinContextMenus/envEffectAdd.py:115
-#: gui/builtinContextMenus/envEffectAdd.py:118
-msgid "Triglavian Invasion"
-msgstr "三神裔入侵"
-
-#: gui/builtinContextMenus/envEffectAdd.py:116
-msgid "ContextMenu|ProjectedEffectManipulation|Triglavian Invasion"
-msgstr "三神裔入侵"
-
-#: gui/builtinContextMenus/envEffectAdd.py:118
-msgid "Destructible Beacons"
-msgstr ""
-
-#: gui/builtinContextMenus/envEffectAdd.py:119
-msgid "Abyssal Weather"
-msgstr ""
 
 #: gui/builtinContextMenus/envEffectAdd.py:133
 msgid "ContextMenu|ProjectedEffectManipulation|System Effects"
 msgstr "星系效果"
 
-#: gui/builtinContextMenus/envEffectAdd.py:133
-msgid "ContextMenu|ProjectedEffectManipulation|Effects"
-msgstr "效果"
-
-#: gui/builtinContextMenus/envEffectAdd.py:193
-msgid "Localized"
-msgstr ""
-
-#: gui/builtinContextMenus/envEffectAdd.py:197
-msgid "Bioluminescence"
-msgstr "生物荧光"
-
-#: gui/builtinContextMenus/envEffectAdd.py:197
-msgid "Caustic"
-msgstr "腐蚀"
-
-#: gui/builtinContextMenus/envEffectAdd.py:197
-msgid "Filament"
-msgstr "纤维"
-
-#: gui/builtinContextMenus/envEffectAdd.py:210
-msgid "PvP Weather"
-msgstr ""
-
-#: gui/builtinContextMenus/factorReload.py:26
-msgid "Factor in Reload Time"
-msgstr "考虑换弹时间"
-
-#: gui/builtinContextMenus/fighterAbilities.py:33
-msgid "Abilities"
-msgstr "铁骑技能"
-
-#: gui/builtinContextMenus/fitAddBrowse.py:22
-msgid "Add Fit..."
-msgstr "添加装配..."
-
-#: gui/builtinContextMenus/fitAddCurrentlyOpen.py:29
-msgid "Add Currently Open Fit"
-msgstr "添加当前装配"
-
-#: gui/builtinContextMenus/fitOpenNewTab.py:37
-msgid "Open Fit in New Tab"
-msgstr "在新标签页打开装配"
-
-#: gui/builtinContextMenus/fitSystemSecurity.py:38
-msgid "Citadel System Security"
-msgstr ""
-
-#: gui/builtinContextMenus/graphDmgApplyProjected.py:23
-msgid "Apply Projected Items"
-msgstr ""
-
-#: gui/builtinContextMenus/graphDmgDroneMode.py:26
-msgid "Drone Mode"
-msgstr "无人机模式"
-
-#: gui/builtinContextMenus/graphDmgIgnoreResists.py:23
-msgid "Ignore Target Resists"
-msgstr "忽略目标抗性"
-
-#: gui/builtinContextMenus/graphDroneControlRange.py:23
-msgid "Ignore Drone Control Range"
-msgstr "忽略无人机控制半径"
-
-#: gui/builtinContextMenus/graphFitAmmoPicker.py:29
-msgid "Plot with Different Ammo..."
-msgstr ""
-
-#: gui/builtinContextMenus/graphLockRange.py:23
-msgid "Ignore Lock Range"
-msgstr "忽略锁定半径"
-
-#: gui/builtinContextMenus/implantSetApply.py:25
-msgid "Apply Implant Set"
-msgstr "应用植入体配置"
-
-#: gui/builtinContextMenus/implantSetSave.py:27
-msgid "Save as New Implant Set"
-msgstr "保存为新的植入体配置"
-
-#: gui/builtinContextMenus/implantSetSave.py:45
-msgid "New Implant Set"
-msgstr "新建植入体配置"
-
-#: gui/builtinContextMenus/implantSetSave.py:51
-msgid "Enter a name for your new Implant Set:"
-msgstr "请为新植入体配置输入一个名称："
-
-#: gui/builtinContextMenus/itemAmountChange.py:34
-#, python-brace-format
-msgid "Change {0} Quantity"
-msgstr "更改{0}数量"
-
-#: gui/builtinContextMenus/itemAmountChange.py:92
-msgid "Change Amount"
-msgstr "更改数量"
-
-#: gui/builtinContextMenus/itemAmountChange.py:98
-msgid "New Amount:"
-msgstr "新数量："
-
-#: gui/builtinContextMenus/itemAmountChange.py:98
-msgid "New Amount ({}-{})"
-msgstr "新数量 ({}-{})"
-
-#: gui/builtinContextMenus/itemFill.py:32
-msgid "Fill With Module"
-msgstr "用该模块填满空白槽位"
-
-#: gui/builtinContextMenus/itemMarketJump.py:44
-#, python-brace-format
-msgid "{0} Market Group"
-msgstr "{0}市场分类"
-
-#: gui/builtinContextMenus/itemProject.py:34
-#, python-brace-format
-msgid "Project {0} onto Fit"
-msgstr ""
-
-#: gui/builtinContextMenus/itemProjectionRange.py:34
-msgid "Change {} Range"
-msgstr "变更{}半径"
-
-#: gui/builtinContextMenus/itemRemove.py:42
-msgid "Remove {}{}"
-msgstr "移除{}{}"
-
-#: gui/builtinContextMenus/itemRemove.py:44
-msgid " Stack"
-msgstr "小队"
-
-#: gui/builtinContextMenus/itemStats.py:38
-msgid "{} Stats"
-msgstr "{}属性"
-
-#: gui/builtinContextMenus/itemVariationChange.py:49
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
-msgid "Variations"
-msgstr "变种"
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:24
-msgid "EM"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:25
-msgid "Thermal"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:26
-#, fuzzy
-msgid "Explosive"
-msgstr "爆炸抗性"
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:27
-msgid "Kinetic"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:28
-msgid "Mixed"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:48
-msgid "Charge"
-msgstr "弹药"
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:59
-#, fuzzy
-msgid "Empty"
-msgstr "空白标签页"
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:82
-#, fuzzy
-msgid "Long Range"
-msgstr "锁定范围"
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:94
-#: gui/builtinContextMenus/moduleAmmoChange.py:109
-msgid "Less Damage"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:97
-#: gui/builtinContextMenus/moduleAmmoChange.py:112
-msgid "More Damage"
-msgstr ""
-
-#: gui/builtinContextMenus/moduleAmmoChange.py:100
-#, fuzzy
-msgid "Short Range"
-msgstr "锁定范围"
-
-#: gui/builtinContextMenus/moduleFill.py:24
-#, python-brace-format
-msgid "Fill With {0}"
-msgstr "用{0}填满"
-
-#: gui/builtinContextMenus/moduleFill.py:24
-msgid "Module"
-msgstr "模块"
-
-#: gui/builtinContextMenus/moduleMutatedExport.py:28
-msgid "Copy Module to Clipboard"
-msgstr "复制模块到剪贴板"
-
-#: gui/builtinContextMenus/moduleMutations.py:33
-msgid "Apply Mutaplasmid"
-msgstr "使用突变质体"
-
-#: gui/builtinContextMenus/moduleMutations.py:33
-msgid "Revert to {}"
-msgstr "还原为{}"
-
-#: gui/builtinContextMenus/moduleSpool.py:37
-msgid "Spoolup Cycles"
-msgstr "预热周期"
-
-#: gui/builtinContextMenus/moduleSpool.py:83
-msgid "{} (default)"
-msgstr "{}（默认值）"
-
-#: gui/builtinContextMenus/moduleSpool.py:98
-msgid "Reset"
-msgstr "重置"
-
-#: gui/builtinContextMenus/priceOptions.py:54
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
-msgid "Implants && Boosters"
-msgstr "植入体和增效剂"
-
-#: gui/builtinContextMenus/resistMode.py:41
-msgid "Resist Mode"
-msgstr "抗性模式"
-
-#: gui/builtinContextMenus/shipJump.py:35
-msgid "Open in Fitting Browser"
-msgstr "在装配浏览器中打开"
-
-#: gui/builtinContextMenus/shipModeChange.py:32
-#: gui/builtinViewColumns/baseName.py:101 gui/builtinViews/fittingView.py:657
-msgid "Tactical Mode"
-msgstr "战术模式"
-
-#: gui/builtinContextMenus/skillAffectors.py:73
-#, python-format
-msgid "Change %s Skills"
-msgstr "修改%s技能等级"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:67
-msgid "Expand All"
-msgstr "展开所有"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:70
-msgid "Toggle Names"
-msgstr "切换名称"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:73
-msgid "Toggle View"
-msgstr "切换视图"
-
-#: gui/builtinItemStatsViews/itemAffectedBy.py:77
-#: gui/builtinItemStatsViews/itemAttributes.py:62
-#: gui/builtinItemStatsViews/itemCompare.py:79
-msgid "Refresh"
-msgstr "刷新"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:44
-#: gui/builtinItemStatsViews/itemProperties.py:56
-msgid "Attribute"
-msgstr "属性"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:45
-#: gui/builtinItemStatsViews/itemProperties.py:57
-msgid "Current Value"
-msgstr "当前值"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:47
-msgid "Base Value"
-msgstr "基础值"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:53
-msgid "View Raw Data"
-msgstr "显示原始数据"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:57
-msgid "Export Item Stats"
-msgstr "导出物品属性"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:117
-msgid "Save CSV file"
-msgstr "保存为逗号分隔符(CSV)文件"
-
-#: gui/builtinItemStatsViews/itemAttributes.py:118
-msgid "CSV files"
-msgstr "逗号分隔符(CSV)文件"
-
-#: gui/builtinItemStatsViews/itemCompare.py:75
-msgid "Toggle view mode"
-msgstr "切换显示模式"
-
-#: gui/builtinItemStatsViews/itemCompare.py:155
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
-#: gui/builtinStatsViews/priceViewFull.py:40
-msgid "Price"
-msgstr "价格"
-
-#: gui/builtinItemStatsViews/itemDependants.py:46 gui/characterEditor.py:591
-#: gui/characterEditor.py:616 gui/characterEditor.py:649
-msgid "Level {}"
-msgstr "等级{}"
+#: gui/builtinContextMenus/envEffectAdd.py:116
+msgid "ContextMenu|ProjectedEffectManipulation|Triglavian Invasion"
+msgstr "三神裔入侵"
+
+#: gui/builtinContextMenus/envEffectAdd.py:111
+msgid "ContextMenu|ProjectedEffectManipulation|Wolf Rayet"
+msgstr "沃尔夫-拉叶星"
 
 #: gui/builtinItemStatsViews/itemDescription.py:43
 #: gui/builtinItemStatsViews/itemTraits.py:25
 msgid "Copy"
 msgstr "复制"
 
-#: gui/builtinItemStatsViews/itemEffects.py:30
-#: gui/builtinViewColumns/baseName.py:55
-msgid "Name"
-msgstr "名称"
+#: gui/builtinContextMenus/additionsExportAll.py:39
+msgid "Copy All {}"
+msgstr "复制所有{}"
 
-#: gui/builtinItemStatsViews/itemEffects.py:31
-msgid "Active"
-msgstr "激活"
+#: gui/characterSelection.py:105
+msgid "Copy Missing Skills"
+msgstr "复制所需技能"
 
-#: gui/builtinItemStatsViews/itemEffects.py:32
-msgid "Type"
-msgstr "类型"
+#: gui/builtinContextMenus/moduleMutatedExport.py:28
+msgid "Copy Module to Clipboard"
+msgstr "复制模块到剪贴板"
 
-#: gui/builtinItemStatsViews/itemEffects.py:34
-msgid "Run Time"
-msgstr "运行时长"
+#: gui/builtinContextMenus/additionsExportSelection.py:39
+msgid "Copy Selected {}"
+msgstr "拷贝选中的{}"
 
-#: gui/builtinItemStatsViews/itemEffects.py:35
-msgid "ID"
-msgstr "ID"
+#: gui/ssoLogin.py:20
+msgid "Copy and paste the block of text provided by pyfa.io"
+msgstr "请复制和粘贴pyfa.io提供的字符串"
 
-#: gui/builtinItemStatsViews/itemEffects.py:56
-msgid "Yes"
-msgstr "是"
+#: gui/patternEditor.py:290 gui/setEditor.py:222
+#: gui/targetProfileEditor.py:366
+msgid "Could not import from clipboard"
+msgstr "无法从剪贴板导入"
 
-#: gui/builtinItemStatsViews/itemEffects.py:58
-msgid "No"
-msgstr "否"
+#: gui/targetProfileEditor.py:359
+msgid "Could not import from clipboard:"
+msgstr "无法从剪贴板导入："
 
-#: gui/builtinItemStatsViews/itemMutator.py:51
-msgid "Reset defaults"
-msgstr "重置为默认值"
+#: gui/patternEditor.py:283 gui/setEditor.py:218
+msgid "Could not import from clipboard: unknown errors"
+msgstr "无法从剪贴板导入：未知错误"
 
-#: gui/builtinItemStatsViews/itemMutator.py:54
-msgid "Random stats"
-msgstr "随机化属性"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
+msgid "Cruiser"
+msgstr "巡洋"
 
-#: gui/builtinItemStatsViews/itemMutator.py:57
-msgid "Revert changes"
-msgstr "还原到初始状态"
+#: gui/builtinItemStatsViews/itemAttributes.py:45
+#: gui/builtinItemStatsViews/itemProperties.py:57
+msgid "Current Value"
+msgstr "当前值"
 
-#: gui/builtinItemStatsViews/itemProperties.py:98
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:63
+msgid "Custom Application"
+msgstr "自定义应用"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "Custom application"
+msgstr "自定义应用"
+
+#: gui/patternEditor.py:99
+msgid "Damage Pattern Editor"
+msgstr "伤害模型编辑器"
+
+#: gui/patternEditor.py:65
+msgid "Damage Profile"
+msgstr "伤害模型"
+
+#: gui/patternEditor.py:53
+msgid "Damage Profile name already in use, please choose another."
+msgstr "伤害模型名已占用，请使用其他名称。"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
+msgid "Database"
+msgstr "数据库"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
+msgid "Debug Logging Enabled"
+msgstr "调试日子已开启"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
+msgid "Default Market Prices:"
+msgstr "默认价格源："
+
+#: gui/propertyEditor.py:271
 #, python-format
-msgid "%d attribute."
-msgstr "共%d个属性。"
+msgid "Default Value: %0.3f"
+msgstr "默认值：%0.3f"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:14
-msgid "Context Menus"
-msgstr "右键菜单"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
+msgid "Delete All Damage Pattern Profiles"
+msgstr "删除所有伤害模型配置"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
-msgid ""
-"Disabling context menus can improve responsiveness.\n"
-"You can hold {} key + right-click to show all menu items regardless of these "
-"settings."
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
+msgid "Delete All Prices"
+msgstr "删除所有价格缓存数据"
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
+msgid "Delete All Target Profiles"
+msgstr "删除所有目标属性配置"
+
+#: gui/esiFittings.py:65
+msgid "Delete from EVE"
+msgstr "删除游戏内装配"
+
+#: gui/itemStats.py:189
+msgid "Dependents"
+msgstr "依赖"
+
+#: gui/itemStats.py:174
+msgid "Description"
+msgstr "简介"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
+msgid "Destroyer"
+msgstr "驱逐"
+
+#: gui/builtinContextMenus/envEffectAdd.py:118
+msgid "Destructible Beacons"
 msgstr ""
-"关闭右键菜单可提升响应速度。\n"
-"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
-msgid "Set as Damage Pattern"
-msgstr "设置为伤害模型"
+#: gui/mainMenuBar.py:167
+msgid "Dev Tools"
+msgstr "开发者工具"
+
+#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
+msgid "Disable Fitting Re&strictions"
+msgstr "关闭装配资源限制(&S)"
 
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
@@ -617,6 +778,196 @@ msgstr "设置为伤害模型"
 msgid "Disabled"
 msgstr "关闭"
 
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:28
+msgid ""
+"Disabling context menus can improve responsiveness.\n"
+"You can hold {} key + right-click to show all menu items regardless of these "
+"settings."
+msgstr ""
+"关闭右键菜单可提升响应速度。\n"
+"如果按住{}键+右键单击，可以无视这些设置显示完整的右键菜单。"
+
+#: gui/esiFittings.py:156
+msgid "Do you really want to delete {} ({}) from EVE?"
+msgstr "真的要从游戏内删除 {} ({})吗？"
+
+#: gui/updateDialog.py:102
+msgid "Don't remind me again for this release"
+msgstr "不再提示此更新"
+
+#: gui/characterEditor.py:789
+msgid "Don't see your EVE character in the list?"
+msgstr "列表中没有你的EvE角色？"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
+#: gui/updateDialog.py:113
+msgid "Download"
+msgstr "下载"
+
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Drone"
+msgstr "无人机"
+
+#: gui/builtinContextMenus/graphDmgDroneMode.py:26
+msgid "Drone Mode"
+msgstr "无人机模式"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:157
+msgid "Drone bandwidth"
+msgstr "无人机带宽"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:155
+msgid "Drone bay"
+msgstr "无人机仓库"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:66
+msgid "Drone range"
+msgstr "无人机半径"
+
+#: gui/additionsPane.py:66 gui/builtinContextMenus/additionsExportAll.py:18
+#: gui/builtinContextMenus/additionsExportSelection.py:18
+#: gui/builtinContextMenus/additionsImport.py:19
+#: gui/builtinContextMenus/priceOptions.py:40
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:77
+#: gui/builtinStatsViews/priceViewFull.py:58
+msgid "Drones"
+msgstr "无人机"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:113
+msgid "Drones active"
+msgstr "激活的无人机"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
+msgid "Dump All Logs"
+msgstr "将所有日志写入文件"
+
+#: gui/mainMenuBar.py:105
+msgid "E&xport to ESI"
+msgstr "导出到游戏(&X)"
+
+#: gui/mainFrame.py:839
+msgid "EFT text fitting files"
+msgstr "EFT装配文本文件"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:96
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "EHP"
+msgstr "EHP"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:24
+msgid "EM"
+msgstr ""
+
+#: gui/targetProfileEditor.py:119
+msgid "EM resistance"
+msgstr "电磁抗性"
+
+#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
+msgid "ERROR"
+msgstr "错误"
+
+#: gui/mainFrame.py:1014
+msgid "EVE API XML character files"
+msgstr "EvE API XML角色文件"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
+msgid "EVE IGB HTML fitting file"
+msgstr "EvE IGB 装配HTML网页文件"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
+#: gui/characterEditor.py:162
+msgid "EVE SSO"
+msgstr "EvE单点登录(SSO)"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:37
+msgid "EVE Servers (API && CREST import)"
+msgstr "连接到EvE服务器（API 和 CREST 导入）"
+
+#: gui/mainFrame.py:861
+msgid "EVE XML fitting file"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:468 gui/mainFrame.py:838
+msgid "EVE XML fitting files"
+msgstr "EvE装配XML文件"
+
+#: gui/mainFrame.py:810
+msgid "EVEMon skills training XML file"
+msgstr "EvEMon技能训练XML文件"
+
+#: gui/mainFrame.py:809
+msgid "EVEMon skills training file"
+msgstr "EvEMon技能训练文件"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:61
+#: gui/builtinStatsViews/resistancesViewFull.py:219
+msgid "Effective HP: "
+msgstr "有效HP："
+
+#: gui/builtinStatsViews/resistancesViewFull.py:220
+#, python-format
+msgid "Effective: %d HP"
+msgstr "有效：%dHP"
+
+#: gui/itemStats.py:192
+msgid "Effects"
+msgstr "效果"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:85
+msgid "Electromagnetic resistance"
+msgstr "电磁抗性"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:59
+#, fuzzy
+msgid "Empty"
+msgstr "空白标签页"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
+msgid "Empty Market View"
+msgstr "空白搜索结果时"
+
+#: gui/multiSwitch.py:41
+msgid "Empty Tab"
+msgstr "空白标签页"
+
+#: gui/mainMenuBar.py:200
+msgid "Enable Fitting Re&strictions"
+msgstr "开启装配限制(&S)"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:33
+msgid "Enable Network"
+msgstr "启用网络功能"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable all available meta buttons"
+msgstr "启用所有可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
+msgid "Enable all meta buttons"
+msgstr "启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+msgid "Enable all meta buttons for a duration of search / recents"
+msgstr "一段时间内启用所有衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button"
+msgstr "启用该物品所在衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "Enable item's meta button, disable others"
+msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+msgid "Enable leftmost available meta button"
+msgstr "启用最左侧可用衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
+msgid "Enable minimal format"
+msgstr "使用极简风格"
+
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
 #: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
@@ -627,282 +978,215 @@ msgstr "关闭"
 msgid "Enabled"
 msgstr "打开"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:46
-msgid "Change Skills"
-msgstr "修改技能等级"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
+msgid "Enforce strict skill level requirements"
+msgstr "使用严格的技能等级检查"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
-msgid "Project onto Fit"
-msgstr ""
+#: gui/characterEditor.py:281
+msgid "Enter a name for your new Character:"
+msgstr "请为新角色输入一个名称："
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
-msgid "Fill with module"
-msgstr "用该模块填满空白槽位"
+#: gui/builtinContextMenus/implantSetSave.py:51
+msgid "Enter a name for your new Implant Set:"
+msgstr "请为新植入体配置输入一个名称："
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
-msgid "Spoolup"
-msgstr "预热"
+#: gui/characterEditor.py:83 gui/characterEditor.py:463
+#: gui/characterEditor.py:898 gui/characterSelection.py:174
+#: gui/mainFrame.py:898 gui/patternEditor.py:58 gui/setEditor.py:55
+#: gui/targetProfileEditor.py:78
+msgid "Error"
+msgstr "错误"
 
-#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:81
-msgid "Additions Panel Copy/Paste"
-msgstr "附加装备栏复制/粘贴"
+#: gui/characterEditor.py:897 gui/characterSelection.py:173
+msgid "Error fetching skill information"
+msgstr "无法获取技能信息"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:15
-msgid "Database"
-msgstr "数据库"
+#: gui/errorDialog.py:68
+msgid "Error!"
+msgstr "错误！"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:25
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:29
+#: gui/builtinItemStatsViews/itemAffectedBy.py:67
+msgid "Expand All"
+msgstr "展开所有"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:26
+#, fuzzy
+msgid "Explosive"
+msgstr "爆炸抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:88
+#: gui/targetProfileEditor.py:122
+msgid "Explosive resistance"
+msgstr "爆炸抗性"
+
+#: gui/propertyEditor.py:39
+msgid "Export"
+msgstr "导出"
+
+#: gui/mainMenuBar.py:74
+msgid "Export All Fittings to &HTML"
+msgstr "导出所有装配到网页"
+
+#: gui/mainFrame.py:948
+msgid "Export Error"
+msgstr "导出错误"
+
+#: gui/esiFittings.py:224
+msgid "Export Fit"
+msgstr "导出装配"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
 msgid ""
-"(Cannot be changed while pyfa is running. Set via command line switches.)"
-msgstr "（无法在Pyfa运行时更改。请通过命令行开关设置。）"
+"Export Fittings in a minimal HTML Version, just containing the fittings "
+"links without any visual styling"
+msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
-msgid "Using Executable Path for Saved Fit Database and Settings"
-msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
+#: gui/builtinItemStatsViews/itemAttributes.py:57
+msgid "Export Item Stats"
+msgstr "导出物品属性"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
-msgid "pyfa User Path:"
-msgstr "pyfa用户数据路径："
+#: gui/mainFrame.py:807
+msgid "Export Skills Needed As..."
+msgstr "导出所需技能列表到..."
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
-msgid "Fitting Database:"
-msgstr "装配数据库："
+#: gui/mainMenuBar.py:87
+msgid "Export a fit to the clipboard"
+msgstr "导出装配到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
-msgid "Game Database:"
-msgstr "游戏数据库："
+#: gui/esiFittings.py:211
+msgid "Export fit to EVE"
+msgstr "导出装配到游戏"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:79
-msgid "Delete All Damage Pattern Profiles"
-msgstr "删除所有伤害模型配置"
+#: gui/mainMenuBar.py:74
+msgid "Export fits to HTML file (set in Preferences)"
+msgstr "导出装配到HTML网页文件（通过偏好设置指定）"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:83
-msgid "Delete All Target Profiles"
-msgstr "删除所有目标属性配置"
+#: gui/mainMenuBar.py:92
+msgid "Export fitting to another format"
+msgstr "导出装配为其他格式"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:87
-msgid "Delete All Prices"
-msgstr "删除所有价格缓存数据"
+#: gui/setEditor.py:149
+msgid "Export implant sets to clipboard"
+msgstr "导出植入体配置到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
-msgid ""
-"This is a destructive action that will delete all damage pattern profiles.\n"
-"Are you sure you want to do this?"
-msgstr ""
-"本操作将永久删除所有伤害模型配置。\n"
-"您确定要继续吗？"
+#: gui/patternEditor.py:172
+msgid "Export patterns to clipboard"
+msgstr "导出伤害模型到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:98
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:103
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:108
-#: gui/mainFrame.py:649 gui/mainFrame.py:655
-msgid "Confirm"
-msgstr "确认"
+#: gui/targetProfileEditor.py:222
+msgid "Export profiles to clipboard"
+msgstr "导出目标属性到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
-msgid ""
-"This is a destructive action that will delete all target profiles.\n"
-"Are you sure you want to do this?"
-msgstr ""
-"本操作将永久删除所有目标属性配置。\n"
-"您确定要继续吗？"
+#: gui/characterEditor.py:373
+msgid "Export skills from clipboard"
+msgstr "导出技能列表到剪贴板"
 
-#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
-msgid ""
-"This is a destructive action that will delete all cached prices out of the "
-"database.\n"
-"Are you sure you want to do this?"
-msgstr ""
-"本操作将永久删除所有价格缓存数据。\n"
-"您确定要继续吗？"
+#: gui/mainMenuBar.py:119
+msgid "Export skills needed for this fitting"
+msgstr "导出使用本装配所需技能"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
-msgid "Fitting Engine"
-msgstr "装配引擎"
+#: gui/mainFrame.py:829
+msgid "Exporting skills needed..."
+msgstr "正在导出所需技能..."
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
+msgid "Extra info in Additions panel tab names"
+msgstr "附加装备标签名显示额外信息"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:90
+msgid "Extra stats"
+msgstr "额外状态"
+
+#: gui/builtinContextMenus/factorReload.py:26
+msgid "Factor in Reload Time"
+msgstr "考虑换弹时间"
 
 #: gui/builtinPreferenceViews/pyfaEnginePreferences.py:44
 msgid ""
 "Factor in reload time when calculating capacitor usage, damage, and tank."
 msgstr "计算电容用量、伤害、防御时考虑换弹时间。"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:50
-msgid "Enforce strict skill level requirements"
-msgstr "使用严格的技能等级检查"
+#: gui/esiFittings.py:294
+msgid "Failed to generate export data"
+msgstr "无法生成导出数据"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
-msgid ""
-"When enabled, skills will check their dependencies' requirements when their "
-"levels change and reset skills that no longer meet the requirement.\n"
-"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
-"skill, as that requires Drones V"
-msgstr ""
-"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
-"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
+#: gui/aboutData.py:34
+msgid "Fat Cow Icons by fatcow.com - Creative Commons Attribution 3.0 License"
+msgstr "胖奶牛系列图标来自 fatcow.com - 基于知识共享署名3.0许可使用"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
-msgid ""
-"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
-"behavior)."
-msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
+#: gui/esiFittings.py:44
+msgid "Fetch Fits"
+msgstr "获取装配"
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
-msgid "Global Default Spoolup Percentage:"
-msgstr "全局默认预热百分比："
+#: gui/esiFittings.py:111
+msgid "Fetching fits, please wait..."
+msgstr "正在获取装配，请稍候..."
 
-#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
-msgid ""
-"The amount of spoolup to use by default on module which support it. Can be "
-"changed on a per-module basis"
-msgstr "默认模块预热量。可以分模块单独设置"
+#: gui/mainMenuBar.py:81
+msgid "Fi&t"
+msgstr "装配(&T)"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:16
-#: gui/characterEditor.py:162
-msgid "EVE SSO"
-msgstr "EvE单点登录(SSO)"
+#: gui/builtinStatsViews/resourcesViewFull.py:156
+msgid "Fighter bay"
+msgstr "铁骑舰载机仓库"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:32
-msgid ""
-"Please see the pyfa wiki on GitHub for information regarding these options."
-msgstr "关于下列选项，详情请参考GitHub上的百科。"
+#: gui/builtinStatsViews/resourcesViewFull.py:114
+msgid "Fighter squadrons active"
+msgstr "激活的铁骑舰载机中队"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:38
-msgid "Login Authentication Method"
-msgstr "登录鉴权模式"
+#: gui/additionsPane.py:69 gui/builtinContextMenus/additionsExportAll.py:19
+#: gui/builtinContextMenus/additionsExportSelection.py:19
+#: gui/builtinContextMenus/additionsImport.py:20
+msgid "Fighters"
+msgstr "铁骑舰载机"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
-msgid "Local Server"
-msgstr "本地服务器"
+#: gui/builtinContextMenus/envEffectAdd.py:197
+msgid "Filament"
+msgstr "纤维"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
-msgid "Manual"
-msgstr "手动"
+#: gui/builtinContextMenus/itemFill.py:32
+msgid "Fill With Module"
+msgstr "用该模块填满空白槽位"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
-msgid ""
-"This options starts a local webserver that the web application will call "
-"back to with information about the character login."
-msgstr "本选项将启动一个本地服务器以接收登录页返回的角色信息。"
+#: gui/builtinContextMenus/moduleFill.py:24
+#, python-brace-format
+msgid "Fill With {0}"
+msgstr "用{0}填满"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:42
-msgid ""
-"This option prompts users to copy and paste information from the web "
-"application to allow for character login. Use this if having issues with the "
-"local server."
-msgstr ""
-"本选项将在角色登录时提示您复制和粘贴登录页相关信息。如果本地服务器出现问题，"
-"可使用该选项。"
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:66
+msgid "Fill with module"
+msgstr "用该模块填满空白槽位"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:45
-msgid "SSO Mode"
-msgstr "单点登录(SSO)模式"
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
+#: gui/builtinStatsViews/firepowerViewFull.py:43
+msgid "Firepower"
+msgstr "火力"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
-msgid "pyfa.io"
-msgstr "pyfa.io"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:47
+msgid "Fitting Database:"
+msgstr "装配数据库："
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
-msgid "Custom application"
-msgstr "自定义应用"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:27
+msgid "Fitting Engine"
+msgstr "装配引擎"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
-msgid ""
-"This options routes SSO Logins through pyfa.io, allowing you to easily login "
-"without any configuration. When in doubt, use this option."
-msgstr ""
-"本选项将通过pyfa.io处理单点登录(SSO)请求，使你无需配置即可登录到EVE。不清除时"
-"可以使用该选项。"
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57 gui/mainFrame.py:186
+msgid "Fittings"
+msgstr "装配"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:49
-msgid ""
-"This option goes through EVE SSO directly, but requires more configuration. "
-"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
-"route data throguh pyfa.io."
-msgstr ""
-"本选项将直接发送EvE单点登录请求，但这需要更多配置。如果pyfa.io无法访问，或你"
-"不想让pyfa.io处理登录请求，请使用该选项。"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
+msgid "Fleet hangar"
+msgstr "舰队机库"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:63
-msgid "Custom Application"
-msgstr "自定义应用"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Frigate"
+msgstr "护卫"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:76
-msgid "Client ID:"
-msgstr "客户ID(Client ID)："
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
+msgid "Fuel bay"
+msgstr "燃料仓"
 
-#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:85
-msgid "Client Secret:"
-msgstr "客户密钥(Client Secret)："
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
-msgid "General"
-msgstr "通用"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
-msgid "Use global character"
-msgstr "使用全局角色"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
-msgid "Use character implants by default for new fits"
-msgstr "新装配默认使用角色植入体组"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
-msgid "Use global damage pattern"
-msgstr "使用全局伤害分布配置"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:47
-msgid "Compact skills needed tooltip"
-msgstr "简洁技能需求提示"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:51
-msgid "Color fitting view by slot"
-msgstr "用背景色区分槽位"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
-msgid "Reopen previous fits on startup"
-msgstr "重新启动时打开之前的装配"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
-msgid "Separate Racks"
-msgstr "分隔不同槽位类型"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
-msgid "Show Rack Labels"
-msgstr "显示槽位类型标签"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
-msgid "Show fitting tab tooltips"
-msgstr "装配标签页显示预览"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:70
-msgid "Animate gauges"
-msgstr "启用属性进度条动画"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
-msgid "Open fittings in a new page by default"
-msgstr "默认在新标签页打开装配"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
-msgid "Show ship browser tooltip"
-msgstr "船体列表显示预览"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:81
-msgid "Change charge in all modules of the same type"
-msgstr "同时更换所有同类型模块的弹药"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
-msgid ""
-"When disabled, reloads charges just in selected modules. Action can be "
-"reversed by holding Ctrl or Alt key while changing charge."
-msgstr ""
-"关闭该选项时，更换弹药仅更换选中的模块。按住Ctrl或Alt以更换所有同类型武器弹"
-"药。"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:89
-msgid "Extra info in Additions panel tab names"
-msgstr "附加装备标签名显示额外信息"
-
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
@@ -911,21 +1195,49 @@ msgstr "附加装备标签名显示额外信息"
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/characterEditor.py:855
-msgid "None"
-msgstr "无"
+msgid "Full"
+msgstr "完整"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of active items"
-msgstr "激活的物品数量"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:57
+msgid "Game Database:"
+msgstr "游戏数据库："
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
-msgid "Quantity of all items"
-msgstr "所有物品数量"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
+msgid "Gas hold"
+msgstr "气体矿物仓库"
 
-#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
-msgid "Language (restart required):"
-msgstr "语言（重启后生效）："
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:17
+msgid "General"
+msgstr "通用"
+
+#: gui/mainFrame.py:906
+msgid "Generating HTML file at: {}"
+msgstr "正在生成HTML网页到：{}"
+
+#: gui/characterEditor.py:778
+msgid "Get Skills"
+msgstr "获取技能列表"
+
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:68
+msgid "Global Default Spoolup Percentage:"
+msgstr "全局默认预热百分比："
+
+#: gui/mainMenuBar.py:161
+msgid "Go to EVE Online Forum thread"
+msgstr "转到EvE Online论坛讨论贴"
+
+#: gui/mainMenuBar.py:160
+msgid "Go to wiki on GitHub"
+msgstr "转到GitHub上的百科页"
+
+#: gui/characterSelection.py:102
+msgid "Grant Missing Skills"
+msgstr "习得所需技能"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:172
+#: gui/builtinStatsViews/resistancesViewFull.py:187
+msgid "HP"
+msgstr "HP"
 
 #: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:19
 msgid "HTML Export"
@@ -940,53 +1252,290 @@ msgstr ""
 "HTML导出（文件>导出到所有装配到网页）可以导出你的所有装配为HTML网页，放在指定"
 "路径下。网页版装配应用可以很容易的打开该HTML网页"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:23
+#: gui/builtinShipBrowser/navigationPanel.py:136
+msgid "Hide Recent Fits"
+msgstr "隐藏最近使用的装配"
+
+#: gui/builtinShipBrowser/navigationPanel.py:53
+#: gui/builtinShipBrowser/navigationPanel.py:147
+msgid "Hide empty ship groups"
+msgstr "隐藏空的舰船类型"
+
+#: gui/builtinViewColumns/baseName.py:59
+msgid "High"
+msgstr ""
+
+#: gui/builtinStatsViews/rechargeViewFull.py:78
+msgid "Hull repair amount"
+msgstr "结构修量"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:114
+msgid "Hull resistance"
+msgstr "结构抗性"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Hull: "
+msgstr "结构："
+
+#: gui/builtinItemStatsViews/itemEffects.py:35
+msgid "ID"
+msgstr "ID"
+
+#: gui/builtinContextMenus/graphDroneControlRange.py:23
+msgid "Ignore Drone Control Range"
+msgstr "忽略无人机控制半径"
+
+#: gui/builtinContextMenus/graphLockRange.py:23
+msgid "Ignore Lock Range"
+msgstr "忽略锁定半径"
+
+#: gui/builtinContextMenus/graphDmgIgnoreResists.py:23
+msgid "Ignore Target Resists"
+msgstr "忽略目标抗性"
+
+#: gui/setEditor.py:62
+msgid "Implant Set"
+msgstr "植入体配置"
+
+#: gui/setEditor.py:122
+msgid "Implant Set Editor"
+msgstr "植入体配置编辑器"
+
+#: gui/setEditor.py:50
+msgid "Implant Set name already in use, please choose another."
+msgstr "植入体配置名已使用，请选择其他名称。"
+
+#: gui/additionsPane.py:75 gui/builtinContextMenus/additionsExportAll.py:21
+#: gui/builtinContextMenus/additionsExportAll.py:22
+#: gui/builtinContextMenus/additionsExportSelection.py:21
+#: gui/builtinContextMenus/additionsExportSelection.py:22
+#: gui/builtinContextMenus/additionsImport.py:22
+#: gui/builtinContextMenus/additionsImport.py:23 gui/characterEditor.py:161
+msgid "Implants"
+msgstr "植入体"
+
+#: gui/builtinContextMenus/priceOptions.py:54
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:85
+msgid "Implants && Boosters"
+msgstr "植入体和增效剂"
+
+#: gui/propertyEditor.py:38
+msgid "Import"
+msgstr "导入"
+
+#: gui/mainFrame.py:948
+msgid "Import Error"
+msgstr "导入错误"
+
+#: gui/characterEditor.py:442
+msgid "Import Skills"
+msgstr "导入技能"
+
+#: gui/mainMenuBar.py:88
+msgid "Import a fit from the clipboard"
+msgstr "从剪贴板导入装配"
+
+#: gui/mainMenuBar.py:118
+msgid "Import characters into pyfa from file"
+msgstr "从文件导入角色信息"
+
+#: gui/mainMenuBar.py:91
+msgid "Import fittings into pyfa"
+msgstr "从文件导入装配"
+
+#: gui/setEditor.py:148
+msgid "Import implant sets from clipboard"
+msgstr "从剪贴板导入植入体配置"
+
+#: gui/propertyEditor.py:38 gui/propertyEditor.py:39
+msgid "Import overrides"
+msgstr "导入自定义属性"
+
+#: gui/patternEditor.py:171
+msgid "Import patterns from clipboard"
+msgstr "从剪贴板导入伤害模型"
+
+#: gui/targetProfileEditor.py:221
+msgid "Import profiles from clipboard"
+msgstr "从剪贴板导入目标属性"
+
+#: gui/propertyEditor.py:107
+msgid "Import pyfa override file"
+msgstr "导入Pyfa属性自定义文件"
+
+#: gui/characterEditor.py:372
+msgid "Import skills from clipboard"
+msgstr "从剪贴板导入技能列表"
+
+#: gui/esiFittings.py:64
+msgid "Import to pyfa"
+msgstr "导入到Pyfa"
+
+#: gui/mainFrame.py:1021
+msgid "Importing Character..."
+msgstr "正在导入角色..."
+
+#: gui/mainFrame.py:846
+msgid "Importing fits"
+msgstr "正在导入装配"
+
+#: gui/characterEditor.py:440
 msgid ""
-"Export Fittings in a minimal HTML Version, just containing the fittings "
-"links without any visual styling"
-msgstr "导出装配为极简版网页，仅保留装配链接，不包含样式设计"
+"Importing skills into this character will set the skill levels as pending. "
+"To save the skills permanently, please click the Save button at the bottom "
+"of the window after importing"
+msgstr ""
+"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
+"窗口底部的保存按钮"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
-#: gui/mainFrame.py:467
-msgid "Save Fitting As..."
-msgstr "保存装配为..."
+#: gui/builtinStatsViews/resistancesViewFull.py:115
+msgid "Incoming damage pattern"
+msgstr "伤害分布"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:49
-msgid "EVE IGB HTML fitting file"
-msgstr "EvE IGB 装配HTML网页文件"
+#: gui/targetProfileEditor.py:50
+msgid "Incorrect formatting (decimals only)"
+msgstr "格式无效（仅允许小数）"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
-msgid "Set export destination"
-msgstr "设置导出路径"
+#: gui/targetProfileEditor.py:52
+msgid "Incorrect range (must be 0-100)"
+msgstr "范围无效（必须是 0-100）"
 
-#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:61
-msgid "Enable minimal format"
-msgstr "使用极简风格"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
+msgid "Industrial ship hold"
+msgstr "工业舰船仓"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
-msgid "Logging"
-msgstr "日志"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Interceptor"
+msgstr "截击"
+
+#: gui/mainFrame.py:894
+msgid "Invalid Path"
+msgstr "无效路径"
+
+#: gui/esiFittings.py:198
+msgid "Invalid Token"
+msgstr "无效登录信息"
+
+#: gui/builtinContextMenus/ammoToDmgPattern.py:32
+#: gui/builtinContextMenus/itemMarketJump.py:44
+#: gui/builtinContextMenus/itemRemove.py:43
+#: gui/builtinContextMenus/itemStats.py:38
+#: gui/builtinItemStatsViews/itemCompare.py:147
+msgid "Item"
+msgstr "物品"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
+msgid "Item Market Group Jump"
+msgstr "切换物品分类时"
+
+#: gui/itemStats.py:58
+msgid "Item stats"
+msgstr "物品属性"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:27
+msgid "Kinetic"
+msgstr ""
+
+#: gui/builtinStatsViews/resistancesViewFull.py:87
+#: gui/targetProfileEditor.py:121
+msgid "Kinetic resistance"
+msgstr "动能抗性"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:96
+msgid "Language (restart required):"
+msgstr "语言（重启后生效）："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
+msgid "Large ship hold"
+msgstr "大型舰船仓"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:77
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Lasts "
+msgstr "可维持"
+
+#: gui/builtinStatsViews/resourcesViewFull.py:112
+msgid "Launcher hardpoints"
+msgstr "发射器"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:94
+#: gui/builtinContextMenus/moduleAmmoChange.py:109
+msgid "Less Damage"
+msgstr ""
+
+#: gui/characterEditor.py:343
+msgid "Level"
+msgstr "技能等级"
+
+#: gui/builtinItemStatsViews/itemDependants.py:46 gui/characterEditor.py:591
+#: gui/characterEditor.py:616 gui/characterEditor.py:649
+msgid "Level {}"
+msgstr "等级{}"
+
+#: gui/characterEditor.py:532
+msgid "Level {}d"
+msgstr "等级{}d"
+
+#: gui/mainFrame.py:273
+msgid "Loading previous fits..."
+msgstr "正在打开之前的装配..."
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Local Server"
+msgstr "本地服务器"
+
+#: gui/builtinContextMenus/envEffectAdd.py:193
+msgid "Localized"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:201
+msgid "Lock Times"
+msgstr "锁定时间"
+
+#: gui/characterEditor.py:794
+msgid "Log In with EVE SSO"
+msgstr "通过EVE登录"
 
 #: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:38
 msgid "Log file location:"
 msgstr "日志文件路径："
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:47
-msgid "Cert Path:"
-msgstr "证书路径："
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:19
+msgid "Logging"
+msgstr "日志"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:56
-msgid "Debug Logging Enabled"
-msgstr "调试日子已开启"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:38
+msgid "Login Authentication Method"
+msgstr "登录鉴权模式"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
-msgid ""
-"Pressing this button will cause all logs in memory to write to the log file:"
-msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+#: gui/builtinContextMenus/moduleAmmoChange.py:82
+#, fuzzy
+msgid "Long Range"
+msgstr "锁定范围"
 
-#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:62
-msgid "Dump All Logs"
-msgstr "将所有日志写入文件"
+#: gui/builtinViewColumns/baseName.py:61
+msgid "Low"
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
+msgid "Maintenance bay"
+msgstr "维护舱"
+
+#: gui/mainFrame.py:673
+msgid "Manage Characters"
+msgstr "管理角色"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:39
+msgid "Manual"
+msgstr "手动"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "Manual proxy settings"
+msgstr "手动配置代理"
+
+#: gui/mainFrame.py:182
+msgid "Market"
+msgstr "市场"
 
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:23
 msgid "Market & Prices"
@@ -996,164 +1545,47 @@ msgstr "市场和价格"
 msgid "Market && Prices"
 msgstr "市场和价格"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
-msgid "Market Search Delay (ms):"
-msgstr "市场搜索延迟（毫秒）："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
-msgid ""
-"The delay between a keystroke and the market search. Can help reduce lag "
-"when typing fast in the market search box."
-msgstr ""
-"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
-msgid "Show market shortcuts"
-msgstr "显示市场快捷方式"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:58
-msgid "Default Market Prices:"
-msgstr "默认价格源："
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
-msgid ""
-"The source you choose will be tried first, but subsequent sources will be "
-"used if the preferred source fails. The system you choose will also be tried "
-"first, and if no data is available, global price will be used."
-msgstr ""
-"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
-"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
-msgid "Total Price Includes"
-msgstr "价格总计包括"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
+msgid "Market Group Selection"
+msgstr "选择物品类别时"
 
 #: gui/builtinPreferenceViews/pyfaMarketPreferences.py:91
 msgid "Market Search && Recent Items"
 msgstr "搜索和显示最近使用列表时"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "No changes to meta buttons"
-msgstr "不改变衍生分类按钮"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:39
+msgid "Market Search Delay (ms):"
+msgstr "市场搜索延迟（毫秒）："
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
-msgid "Enable all meta buttons for a duration of search / recents"
-msgstr "一段时间内启用所有衍生分类按钮"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:225
+msgid "Mass:\t{:,.0f}kg"
+msgstr "质量：{:,.0f}kg"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:93
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:114
-msgid "Enable all meta buttons"
-msgstr "启用所有衍生分类按钮"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
+msgid "Material bay"
+msgstr "物料仓"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:99
-msgid "Market Group Selection"
-msgstr "选择物品类别时"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:208
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:241
+#, python-format
+msgid "Max Warp Distance: %.1f AU"
+msgstr "最大跃迁距离：%.1f AU"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:105
-msgid "Empty Market View"
-msgstr "空白搜索结果时"
+#: gui/targetProfileEditor.py:124
+msgid "Maximum speed"
+msgstr "亚光速航速"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable leftmost available meta button"
-msgstr "启用最左侧可用衍生分类按钮"
+#: gui/builtinViewColumns/baseName.py:60
+msgid "Med"
+msgstr ""
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
-msgid "Enable all available meta buttons"
-msgstr "启用所有可用衍生分类按钮"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
+msgid "Medium ship hold"
+msgstr "中型舰船仓"
 
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:112
-msgid "Item Market Group Jump"
-msgstr "切换物品分类时"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button"
-msgstr "启用该物品所在衍生分类按钮"
-
-#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
-msgid "Enable item's meta button, disable others"
-msgstr "启用该物品所在衍生分类按钮，禁用其他按钮"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
-msgid "Network"
-msgstr "网络"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:33
-msgid "Enable Network"
-msgstr "启用网络功能"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:37
-msgid "EVE Servers (API && CREST import)"
-msgstr "连接到EvE服务器（API 和 CREST 导入）"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:41
-msgid "Pricing updates"
-msgstr "价格更新"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:44
-msgid "Pyfa Update checks"
-msgstr "Pyfa更新检查"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:49
-msgid "Proxy settings"
-msgstr "代理设置"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:83
-msgid "Mode:"
-msgstr "模式"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "No proxy"
-msgstr "无代理"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "Auto-detected proxy settings"
-msgstr "自动检测代理设置"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
-msgid "Manual proxy settings"
-msgstr "手动配置代理"
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:101
-msgid "Addr:"
-msgstr "地址："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:109
-msgid "Port:"
-msgstr "端口："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:121
-msgid "Username:"
-msgstr "用户名："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:125
-msgid "Password:"
-msgstr "密码："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:136
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:158
-msgid "Auto-detected: "
-msgstr "自动检测结果："
-
-#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:144
-msgid "Apply Proxy Settings"
-msgstr "应用代理配置"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
-msgid "Statistics Panel"
-msgstr "属性面板"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:31
-msgid "Changes require restart of pyfa to take effect."
-msgstr "变更将在重启Pyfa之后生效。"
-
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
-#: gui/builtinStatsViews/resourcesViewFull.py:84
-msgid "Resources"
-msgstr "装配资源"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
+msgid "Mineral hold"
+msgstr "矿物仓"
 
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
@@ -1166,6 +1598,92 @@ msgstr "装配资源"
 msgid "Minimal"
 msgstr "简洁"
 
+#: gui/builtinStatsViews/miningyieldViewFull.py:39
+msgid "Mining Yield"
+msgstr "矿物产出"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
+msgid "Misc"
+msgstr "杂项"
+
+#: gui/builtinViewColumns/misc.py:50
+msgid "Misc data"
+msgstr "杂项"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:28
+msgid "Mixed"
+msgstr ""
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:83
+msgid "Mode:"
+msgstr "模式"
+
+#: gui/builtinContextMenus/moduleFill.py:24
+msgid "Module"
+msgstr "模块"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:97
+#: gui/builtinContextMenus/moduleAmmoChange.py:112
+msgid "More Damage"
+msgstr ""
+
+#: gui/itemStats.py:170
+msgid "Mutations"
+msgstr "变质"
+
+#: gui/builtinItemStatsViews/itemEffects.py:30
+#: gui/builtinViewColumns/baseName.py:55
+msgid "Name"
+msgstr "名称"
+
+#: gui/esiFittings.py:300
+msgid "Need at least one ESI character to export"
+msgstr "请为导出至少选择一个游戏内角色"
+
+#: gui/esiFittings.py:114
+msgid "Need at least one ESI character to fetch"
+msgstr "请为获取至少选择一个游戏内角色"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:17
+msgid "Network"
+msgstr "网络"
+
+#: gui/builtinContextMenus/itemAmountChange.py:98
+msgid "New Amount ({}-{})"
+msgstr "新数量 ({}-{})"
+
+#: gui/builtinContextMenus/itemAmountChange.py:98
+msgid "New Amount:"
+msgstr "新数量："
+
+#: gui/builtinContextMenus/implantSetSave.py:45
+msgid "New Implant Set"
+msgstr "新建植入体配置"
+
+#: gui/builtinShipBrowser/navigationPanel.py:51
+msgid "New fitting"
+msgstr "新装配"
+
+#: gui/builtinItemStatsViews/itemEffects.py:58
+msgid "No"
+msgstr "否"
+
+#: gui/characterSelection.py:230
+msgid "No active fit"
+msgstr "没有选中的装配"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:92
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:100
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:106
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:113
+msgid "No changes to meta buttons"
+msgstr "不改变衍生分类按钮"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:87
+msgid "No proxy"
+msgstr "无代理"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
@@ -1174,41 +1692,193 @@ msgstr "简洁"
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
 #: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-msgid "Full"
-msgstr "完整"
+#: gui/characterEditor.py:855
+msgid "None"
+msgstr "无"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
-#: gui/builtinStatsViews/resistancesViewFull.py:47
-msgid "Resistances"
-msgstr "抗性"
+#: gui/additionsPane.py:87
+msgid "Notes"
+msgstr "备注"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
-msgid "Shield/Armor Tank"
-msgstr "恢复"
+#: gui/mainMenuBar.py:167
+msgid "Open &Dev Tools"
+msgstr "打开开发者工具(&D)"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:71
-#: gui/builtinStatsViews/firepowerViewFull.py:43
-msgid "Firepower"
-msgstr "火力"
+#: gui/characterSelection.py:150
+msgid "Open Character Editor"
+msgstr "打开角色编辑器"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:79
-#: gui/builtinStatsViews/capacitorViewFull.py:37
-msgid "Capacitor"
-msgstr "电容"
+#: gui/builtinContextMenus/fitOpenNewTab.py:37
+msgid "Open Fit in New Tab"
+msgstr "在新标签页打开装配"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:87
-msgid "Misc"
-msgstr "杂项"
+#: gui/mainFrame.py:1012
+msgid "Open One Or More Character Files"
+msgstr "打开角色文件"
 
-#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
-#: gui/builtinStatsViews/outgoingViewFull.py:66
-#: gui/builtinStatsViews/outgoingViewMinimal.py:65
-msgid "Remote Reps"
-msgstr "遥修"
+#: gui/mainFrame.py:836
+msgid "Open One Or More Fitting Files"
+msgstr "打开装配文件"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
-msgid "Updates"
-msgstr "更新"
+#: gui/mainMenuBar.py:166
+msgid "Open Wid&gets Inspect tool"
+msgstr "打开控件检查工具(&G)"
+
+#: gui/mainMenuBar.py:166
+msgid "Open Widgets Inspect tool"
+msgstr "打开控件检查工具"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:73
+msgid "Open fittings in a new page by default"
+msgstr "默认在新标签页打开装配"
+
+#: gui/builtinContextMenus/shipJump.py:35
+msgid "Open in Fitting Browser"
+msgstr "在装配浏览器中打开"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
+msgid "Ore hold"
+msgstr "矿石仓"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:75
+msgid "Passive shield recharge"
+msgstr "被动回充"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:125
+msgid "Password:"
+msgstr "密码："
+
+#: gui/builtinContextMenus/additionsImport.py:40
+msgid "Paste {}"
+msgstr "粘贴{}"
+
+#: gui/patternEditor.py:295
+msgid "Patterns exported to clipboard"
+msgstr "伤害模型已导出到剪贴板"
+
+#: gui/patternEditor.py:276 gui/setEditor.py:210
+msgid "Patterns successfully imported from clipboard"
+msgstr "从剪贴板导入伤害模型成功"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:128
+msgid "Planetary goods hold"
+msgstr "星系物质仓"
+
+#: gui/mainFrame.py:723
+msgid "Please Wait..."
+msgstr "请稍候..."
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:32
+msgid ""
+"Please see the pyfa wiki on GitHub for information regarding these options."
+msgstr "关于下列选项，详情请参考GitHub上的百科。"
+
+#: gui/esiFittings.py:281
+msgid "Please select an active fitting in the main window"
+msgstr "请在主窗口选择一个装配"
+
+#: gui/characterEditor.py:758
+msgid "Please select another character or make a new one."
+msgstr "请选择另一角色或创建新角色。"
+
+#: gui/mainFrame.py:897
+msgid "Please verify path location pyfa's preferences."
+msgstr "请确认Pyfa偏好保存位置。"
+
+#: gui/builtinContextMenus/graphFitAmmoPicker.py:29
+msgid "Plot with Different Ammo..."
+msgstr ""
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
+msgid "Pod"
+msgstr "逃生舱"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:109
+msgid "Port:"
+msgstr "端口："
+
+#: gui/builtinStatsViews/resourcesViewFull.py:154
+msgid "PowerGrid"
+msgstr "PG"
+
+#: gui/preferenceDialog.py:31
+msgid "Preferences"
+msgstr "偏好设置"
+
+#: gui/builtinPreferenceViews/pyfaLoggingPreferences.py:59
+msgid ""
+"Pressing this button will cause all logs in memory to write to the log file:"
+msgstr "点击此按钮以将所有缓存的日志写入到日志文件："
+
+#: gui/builtinItemStatsViews/itemCompare.py:155
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:99
+#: gui/builtinStatsViews/priceViewFull.py:40
+msgid "Price"
+msgstr "价格"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:41
+msgid "Pricing updates"
+msgstr "价格更新"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:265
+#, python-format
+msgid "Probe Size: %.3f"
+msgstr "Probe Size: %.3f"
+
+#: gui/targetProfileEditor.py:372
+msgid "Profiles exported to clipboard"
+msgstr "目标属性已导出到剪贴板"
+
+#: gui/targetProfileEditor.py:352
+msgid "Profiles successfully imported from clipboard"
+msgstr "已成功从剪贴板导入目标属性"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:61
+msgid "Project onto Fit"
+msgstr ""
+
+#: gui/builtinContextMenus/itemProject.py:34
+#, python-brace-format
+msgid "Project {0} onto Fit"
+msgstr ""
+
+#: gui/additionsPane.py:81
+msgid "Projected"
+msgstr "环境效果"
+
+#: gui/builtinAdditionPanes/projectedView.py:306
+#: gui/builtinAdditionPanes/projectedView.py:316
+#: gui/builtinAdditionPanes/projectedView.py:321
+#: gui/builtinAdditionPanes/projectedView.py:326
+msgid "Projected Item"
+msgstr ""
+
+#: gui/itemStats.py:200
+msgid "Properties"
+msgstr "属性"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:49
+msgid "Proxy settings"
+msgstr "代理设置"
+
+#: gui/builtinContextMenus/envEffectAdd.py:210
+msgid "PvP Weather"
+msgstr ""
+
+#: gui/aboutData.py:49
+msgid ""
+"Pyfa (the Python Fitting Assistant) is an open-source standalone application "
+"able to create and simulate fittings for EVE-Online SciFi MMORPG with a very "
+"high degree of accuracy. Pyfa can run on all platforms where Python and "
+"wxWidgets are supported."
+msgstr ""
+"Python装配助手（the Python Fitting Assistant, Pyfa）是一个开源独立应用，可用"
+"于为星战前线（EvE Online）创建和模拟非常准确的装配方案。Pyfa可在python和"
+"wxWidgets支持的所有平台运行。"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:44
+msgid "Pyfa Update checks"
+msgstr "Pyfa更新检查"
 
 #: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:15
 msgid ""
@@ -1219,253 +1889,29 @@ msgstr ""
 "Pyfa可以自动检查更新并提示。这个功能可在网络设置中开启。在这里你可以开启预发"
 "布版本更新通知，并查看未提示的版本更新（如果有的话）。"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:38
-msgid "Allow pre-release notifications"
-msgstr "允许预发布版本更新通知"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:129
+msgid "Quafe hold"
+msgstr "酷菲(Quafe)仓"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
-#, python-brace-format
-msgid "Suppressing {0} Notifications"
-msgstr "有{0}个未提示的版本更新"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of active items"
+msgstr "激活的物品数量"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
-msgid ""
-"There is a release available which you have chosen to suppress. You can "
-"choose to reset notification suppression for this release, or download the "
-"new release from GitHub."
-msgstr ""
-"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:90
+msgid "Quantity of all items"
+msgstr "所有物品数量"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:71
-#: gui/updateDialog.py:113
-msgid "Download"
-msgstr "下载"
+#: gui/targetProfileEditor.py:126
+msgid "Radius"
+msgstr "信号半径"
 
-#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
-msgid "Reset Suppression"
-msgstr "重置版本更新提示"
+#: gui/builtinItemStatsViews/itemMutator.py:54
+msgid "Random stats"
+msgstr "随机化属性"
 
-#: gui/builtinShipBrowser/navigationPanel.py:48
-msgid "Ship groups"
-msgstr "舰船类型"
-
-#: gui/builtinShipBrowser/navigationPanel.py:50
-msgid "Back"
-msgstr "返回"
-
-#: gui/builtinShipBrowser/navigationPanel.py:51
-msgid "New fitting"
-msgstr "新装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:53
-#: gui/builtinShipBrowser/navigationPanel.py:147
-msgid "Hide empty ship groups"
-msgstr "隐藏空的舰船类型"
-
-#: gui/builtinShipBrowser/navigationPanel.py:56
-#: gui/builtinShipBrowser/navigationPanel.py:129
-msgid "Recent Fits"
-msgstr "最近使用的装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:61
-msgid "Search fittings"
-msgstr "搜索装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:136
-msgid "Hide Recent Fits"
-msgstr "隐藏最近使用的装配"
-
-#: gui/builtinShipBrowser/navigationPanel.py:151
-msgid "Show empty ship groups"
-msgstr "显示空的舰船类型"
-
-#: gui/builtinShipBrowser/shipItem.py:111
-msgid "Ship Basic"
-msgstr ""
-
-#: gui/builtinStatsViews/capacitorViewFull.py:57
-msgid "Capacitor stability"
-msgstr "电容稳定性"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:67
-msgid "Total: "
-msgstr "总计："
-
-#: gui/builtinStatsViews/capacitorViewFull.py:77
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Lasts "
-msgstr "可维持"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:81
-msgid "0s"
-msgstr "0秒"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:90
-msgid "Extra stats"
-msgstr "额外状态"
-
-#: gui/builtinStatsViews/capacitorViewFull.py:171
-msgid "Stable: "
-msgstr "稳定："
-
-#: gui/builtinStatsViews/firepowerViewFull.py:67
-msgid "Weapon"
-msgstr "武器"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:67
-msgid "Drone"
-msgstr "无人机"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:100
-msgid " Volley: "
-msgstr "齐射"
-
-#: gui/builtinStatsViews/firepowerViewFull.py:107
-msgid " DPS: "
-msgstr " DPS: "
-
-#: gui/builtinStatsViews/firepowerViewFull.py:115
-msgid "Click to toggle to Mining Yield"
-msgstr "点击切换到矿物产出视图"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:39
-msgid "Mining Yield"
-msgstr "矿物产出"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:89
-#: gui/builtinStatsViews/priceViewFull.py:58
-#: gui/builtinStatsViews/priceViewMinimal.py:57
-msgid "Total"
-msgstr "总计"
-
-#: gui/builtinStatsViews/miningyieldViewFull.py:102
-msgid "Click to toggle to Firepower View"
-msgstr "点击切换到火力视图"
-
-#: gui/builtinStatsViews/priceViewFull.py:57
-#: gui/builtinStatsViews/priceViewMinimal.py:57
-#: gui/builtinViews/fittingView.py:661
-msgid "Ship"
-msgstr "船体"
-
-#: gui/builtinStatsViews/priceViewFull.py:57
-#: gui/builtinStatsViews/priceViewMinimal.py:57 gui/mainFrame.py:186
-msgid "Fittings"
-msgstr "装配"
-
-#: gui/builtinStatsViews/priceViewFull.py:57 gui/characterEditor.py:90
-#: gui/esiFittings.py:341
-msgid "Character"
-msgstr "角色"
-
-#: gui/builtinStatsViews/priceViewFull.py:58
-#: gui/builtinStatsViews/resourcesViewFull.py:158
-msgid "Cargo bay"
-msgstr "货舱"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:43
-msgid "Recharge rates"
-msgstr "回充速度"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:75
-msgid "Passive shield recharge"
-msgstr "被动回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:76
-msgid "Active shield boost"
-msgstr "主动维修"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:77
-msgid "Armor repair amount"
-msgstr "装甲修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:78
-msgid "Hull repair amount"
-msgstr "结构修量"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:86
-msgid "Reinforced"
-msgstr "加强回充"
-
-#: gui/builtinStatsViews/rechargeViewFull.py:87
-msgid "Sustained"
-msgstr "持续回充"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:61
-#: gui/builtinStatsViews/resistancesViewFull.py:219
-msgid "Effective HP: "
-msgstr "有效HP："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:85
-msgid "Electromagnetic resistance"
-msgstr "电磁抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:86
-#: gui/targetProfileEditor.py:120
-msgid "Thermal resistance"
-msgstr "热能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:87
-#: gui/targetProfileEditor.py:121
-msgid "Kinetic resistance"
-msgstr "动能抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:88
-#: gui/targetProfileEditor.py:122
-msgid "Explosive resistance"
-msgstr "爆炸抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:96
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "EHP"
-msgstr "EHP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:97
-#: gui/builtinStatsViews/resistancesViewFull.py:169
-msgid "Click to toggle between effective HP and raw HP"
-msgstr "点击切换有效HP和原始HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:112
-msgid "Shield resistance"
-msgstr "护盾抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:113
-msgid "Armor resistance"
-msgstr "装甲抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:114
-msgid "Hull resistance"
-msgstr "结构抗性"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:115
-msgid "Incoming damage pattern"
-msgstr "伤害分布"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:172
-#: gui/builtinStatsViews/resistancesViewFull.py:187
-msgid "HP"
-msgstr "HP"
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Shield: "
-msgstr "护盾："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Armor: "
-msgstr "装甲："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:206
-msgid "Hull: "
-msgstr "结构："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:213
-msgid "Resist Multiplier: "
-msgstr "抗性倍率："
-
-#: gui/builtinStatsViews/resistancesViewFull.py:220
-#, python-format
-msgid "Effective: %d HP"
-msgstr "有效：%dHP"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
+msgid "Range"
+msgstr "锁定范围"
 
 #: gui/builtinStatsViews/resistancesViewFull.py:222
 msgid "Raw HP: "
@@ -1476,45 +1922,369 @@ msgstr "原始HP："
 msgid "Raw: %d HP"
 msgstr "原始：%dHP"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:111
-msgid "Turret hardpoints"
-msgstr "炮台"
+#: gui/mainFrame.py:654
+msgid ""
+"Re-enabling fitting restrictions for this fit will also remove any illegal "
+"items from the fit. Do you want to continue?"
+msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:112
-msgid "Launcher hardpoints"
-msgstr "发射器"
+#: gui/builtinShipBrowser/navigationPanel.py:56
+#: gui/builtinShipBrowser/navigationPanel.py:129
+msgid "Recent Fits"
+msgstr "最近使用的装配"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:113
-msgid "Drones active"
-msgstr "激活的无人机"
+#: gui/builtinStatsViews/rechargeViewFull.py:43
+msgid "Recharge rates"
+msgstr "回充速度"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:114
-msgid "Fighter squadrons active"
-msgstr "激活的铁骑舰载机中队"
+#: gui/mainMenuBar.py:84
+msgid "Redo the most recent undone action"
+msgstr "恢复最近一次撤销的操作"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:115
-msgid "Calibration"
-msgstr "校准"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:77
+#: gui/builtinItemStatsViews/itemAttributes.py:62
+#: gui/builtinItemStatsViews/itemCompare.py:79
+msgid "Refresh"
+msgstr "刷新"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:153
-msgid "CPU"
-msgstr "CPU"
+#: gui/characterSelection.py:68
+msgid "Refresh Skills"
+msgstr "刷新技能"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:154
-msgid "PowerGrid"
-msgstr "PG"
+#: gui/builtinStatsViews/rechargeViewFull.py:86
+msgid "Reinforced"
+msgstr "加强回充"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:155
-msgid "Drone bay"
-msgstr "无人机仓库"
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:104
+#: gui/builtinStatsViews/outgoingViewFull.py:66
+#: gui/builtinStatsViews/outgoingViewMinimal.py:65
+msgid "Remote Reps"
+msgstr "遥修"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:156
-msgid "Fighter bay"
-msgstr "铁骑舰载机仓库"
+#: gui/esiFittings.py:353
+msgid "Remove Character"
+msgstr "删除角色"
 
-#: gui/builtinStatsViews/resourcesViewFull.py:157
-msgid "Drone bandwidth"
-msgstr "无人机带宽"
+#: gui/propertyEditor.py:71
+msgid "Remove Overides for Item"
+msgstr "删除物品的自定义属性"
+
+#: gui/builtinContextMenus/itemRemove.py:42
+msgid "Remove {}{}"
+msgstr "移除{}{}"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:55
+msgid "Reopen previous fits on startup"
+msgstr "重新启动时打开之前的装配"
+
+#: gui/itemStats.py:185
+msgid "Requirements"
+msgstr "技能需求"
+
+#: gui/builtinContextMenus/moduleSpool.py:98
+msgid "Reset"
+msgstr "重置"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:76
+msgid "Reset Suppression"
+msgstr "重置版本更新提示"
+
+#: gui/builtinItemStatsViews/itemMutator.py:51
+msgid "Reset defaults"
+msgstr "重置为默认值"
+
+#: gui/builtinContextMenus/resistMode.py:41
+msgid "Resist Mode"
+msgstr "抗性模式"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:213
+msgid "Resist Multiplier: "
+msgstr "抗性倍率："
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:50
+#: gui/builtinStatsViews/resistancesViewFull.py:47
+msgid "Resistances"
+msgstr "抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:42
+#: gui/builtinStatsViews/resourcesViewFull.py:84
+msgid "Resources"
+msgstr "装配资源"
+
+#: gui/builtinItemStatsViews/itemMutator.py:57
+msgid "Revert changes"
+msgstr "还原到初始状态"
+
+#: gui/builtinContextMenus/moduleMutations.py:33
+msgid "Revert to {}"
+msgstr "还原为{}"
+
+#: gui/builtinViewColumns/baseName.py:63
+msgid "Rig"
+msgstr ""
+
+#: gui/builtinItemStatsViews/itemEffects.py:34
+msgid "Run Time"
+msgstr "运行时长"
+
+#: gui/esiFittings.py:334
+msgid "SSO Character Management"
+msgstr "游戏内人物管理"
+
+#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
+msgid "SSO Login"
+msgstr "通过EVE登录"
+
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:45
+msgid "SSO Mode"
+msgstr "单点登录(SSO)模式"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
+msgid "Salvage hold"
+msgstr "打捞件仓"
+
+#: gui/builtinContextMenus/envEffectAdd.py:112
+msgid "Sansha Incursion"
+msgstr "萨沙入侵"
+
+#: gui/mainFrame.py:860
+msgid "Save Backup As..."
+msgstr "保存备份为..."
+
+#: gui/builtinItemStatsViews/itemAttributes.py:117
+msgid "Save CSV file"
+msgstr "保存为逗号分隔符(CSV)文件"
+
+#: gui/mainMenuBar.py:114
+msgid "Save Character &As..."
+msgstr "保存角色为...(&A)"
+
+#: gui/characterEditor.py:282
+msgid "Save Character As..."
+msgstr "保存角色为..."
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:48
+#: gui/mainFrame.py:467
+msgid "Save Fitting As..."
+msgstr "保存装配为..."
+
+#: gui/propertyEditor.py:130
+msgid "Save Overrides As..."
+msgstr "保存自定义属性为..."
+
+#: gui/builtinContextMenus/implantSetSave.py:27
+msgid "Save as New Implant Set"
+msgstr "保存为新的植入体配置"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
+msgid "Scan res."
+msgstr "扫描精度"
+
+#: gui/builtinShipBrowser/navigationPanel.py:61
+msgid "Search fittings"
+msgstr "搜索装配"
+
+#: gui/characterEditor.py:356
+#, python-brace-format
+msgid "Sec Status: {0:.2f}"
+msgstr "安全等级: {0:.2f}"
+
+#: gui/characterEditor.py:914
+msgid "Security Status is used in some CONCORD hull calculations"
+msgstr "安全等级会用于计算CONCORD警察船体属性"
+
+#: gui/esiFittings.py:284
+msgid "Sending request and awaiting response"
+msgstr "正在发送请求和接收响应"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:65
+msgid "Sensor str."
+msgstr "传感器强度"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:59
+msgid "Separate Racks"
+msgstr "分隔不同槽位类型"
+
+#: gui/characterEditor.py:907
+msgid "Set Security Status"
+msgstr "设置安全等级"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:41
+msgid "Set as Damage Pattern"
+msgstr "设置为伤害模型"
+
+#: gui/builtinPreferenceViews/pyfaHTMLExportPreferences.py:53
+msgid "Set export destination"
+msgstr "设置导出路径"
+
+#: gui/builtinContextMenus/ammoToDmgPattern.py:32
+msgid "Set {} as Damage Pattern"
+msgstr "设置{}为伤害模型"
+
+#: gui/setEditor.py:229
+msgid "Sets exported to clipboard"
+msgstr "植入体配置已导出到剪贴板"
+
+#: gui/characterEditor.py:326
+msgid ""
+"Setting an Alpha clone does not replace the character's skills, but rather "
+"caps them to Alpha levels."
+msgstr ""
+"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:112
+msgid "Shield resistance"
+msgstr "护盾抗性"
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:58
+msgid "Shield/Armor Tank"
+msgstr "恢复"
+
+#: gui/builtinStatsViews/resistancesViewFull.py:206
+msgid "Shield: "
+msgstr "护盾："
+
+#: gui/builtinStatsViews/priceViewFull.py:57
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+#: gui/builtinViews/fittingView.py:661
+msgid "Ship"
+msgstr "船体"
+
+#: gui/builtinShipBrowser/shipItem.py:111
+msgid "Ship Basic"
+msgstr ""
+
+#: gui/builtinShipBrowser/navigationPanel.py:48
+msgid "Ship groups"
+msgstr "舰船类型"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
+msgid "Ship hold"
+msgstr "舰船仓"
+
+#: gui/builtinContextMenus/moduleAmmoChange.py:100
+#, fuzzy
+msgid "Short Range"
+msgstr "锁定范围"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:63
+msgid "Show Rack Labels"
+msgstr "显示槽位类型标签"
+
+#: gui/builtinShipBrowser/navigationPanel.py:151
+msgid "Show empty ship groups"
+msgstr "显示空的舰船类型"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:67
+msgid "Show fitting tab tooltips"
+msgstr "装配标签页显示预览"
+
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:52
+msgid "Show market shortcuts"
+msgstr "显示市场快捷方式"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:77
+msgid "Show ship browser tooltip"
+msgstr "船体列表显示预览"
+
+#: gui/builtinContextMenus/boosterSideEffects.py:34
+msgid "Side Effects"
+msgstr "副作用"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:88
+msgid "Signature"
+msgstr "信号半径"
+
+#: gui/targetProfileEditor.py:125
+msgid ""
+"Signature radius\n"
+"Leave blank for infinitely big value"
+msgstr ""
+"信号半径\n"
+"保持为空表示信号半径无限大"
+
+#: gui/aboutData.py:33
+msgid ""
+"Silk Icons Set by famfamfam.com - Creative Commons Attribution 2.5 License"
+msgstr "技能系列图标来自 famfamfam.com - 基于知识共享署名2.5许可使用"
+
+#: gui/characterEditor.py:342 gui/characterEditor.py:608
+msgid "Skill"
+msgstr "技能"
+
+#: gui/characterEditor.py:160
+msgid "Skills"
+msgstr "技能列表"
+
+#: gui/characterSelection.py:242
+msgid "Skills required:"
+msgstr "所需技能："
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
+msgid "Small ship hold"
+msgstr "小型舰船仓"
+
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
+msgid "Speed"
+msgstr "亚光速航速"
+
+#: gui/builtinContextMenus/droneSplitStack.py:29
+msgid "Split {} Stack"
+msgstr "分离"
+
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:76
+msgid "Spoolup"
+msgstr "预热"
+
+#: gui/builtinContextMenus/moduleSpool.py:37
+msgid "Spoolup Cycles"
+msgstr "预热周期"
+
+#: gui/builtinStatsViews/capacitorViewFull.py:171
+msgid "Stable: "
+msgstr "稳定："
+
+#: gui/builtinPreferenceViews/pyfaStatViewPreferences.py:22
+msgid "Statistics Panel"
+msgstr "属性面板"
+
+#: gui/builtinViewColumns/baseName.py:62
+msgid "Subsystem"
+msgstr ""
+
+#: gui/characterEditor.py:901
+msgid "Success"
+msgstr "成功"
+
+#: gui/characterEditor.py:901
+msgid "Successfully fetched skills"
+msgstr "成功获取到技能列表"
+
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:48
+#, python-brace-format
+msgid "Suppressing {0} Notifications"
+msgstr "有{0}个未提示的版本更新"
+
+#: gui/builtinStatsViews/rechargeViewFull.py:87
+msgid "Sustained"
+msgstr "持续回充"
+
+#: gui/builtinContextMenus/shipModeChange.py:32
+#: gui/builtinViewColumns/baseName.py:101 gui/builtinViews/fittingView.py:657
+msgid "Tactical Mode"
+msgstr "战术模式"
+
+#: gui/targetProfileEditor.py:86
+msgid "Target Profile"
+msgstr "目标属性"
+
+#: gui/targetProfileEditor.py:130
+msgid "Target Profile Editor"
+msgstr "目标属性编辑器"
+
+#: gui/targetProfileEditor.py:73
+msgid "Target Profile name already in use, please choose another."
+msgstr "目标属性名已使用，请选择其他名称。"
 
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:40
 msgid "Targeting && Misc"
@@ -1524,147 +2294,234 @@ msgstr "目标和杂项"
 msgid "Targets"
 msgstr "最大锁定数"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:63
-msgid "Range"
-msgstr "锁定范围"
+#: gui/mainFrame.py:811
+msgid "Text skills training file"
+msgstr "技能列表文本文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:64
-msgid "Scan res."
-msgstr "扫描精度"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:72
+msgid ""
+"The amount of spoolup to use by default on module which support it. Can be "
+"changed on a per-module basis"
+msgstr "默认模块预热量。可以分模块单独设置"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:65
-msgid "Sensor str."
-msgstr "传感器强度"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:44
+msgid ""
+"The delay between a keystroke and the market search. Can help reduce lag "
+"when typing fast in the market search box."
+msgstr ""
+"按键与触发市场搜索的延迟。较大的值可以缓解在市场搜索框快速打字造成的卡顿。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:66
-msgid "Drone range"
-msgstr "无人机半径"
+#: gui/mainFrame.py:951
+msgid "The following error was generated"
+msgstr "Pyfa 遇到以下错误"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:86
-msgid "Speed"
-msgstr "亚光速航速"
+#: gui/mainFrame.py:895
+msgid "The following path is invalid or does not exist:"
+msgstr "下述路径无效或不存在："
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:87
-msgid "Align time"
-msgstr "起跳时间"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:64
+msgid ""
+"The source you choose will be tried first, but subsequent sources will be "
+"used if the preferred source fails. The system you choose will also be tried "
+"first, and if no data is available, global price will be used."
+msgstr ""
+"Pyfa将优先使用指定的价格源，但指定价格源不可用时将使用其他价格源。同理，Pyfa"
+"将优先使用指定的星系，但星系价格不可用时将使用全局价格。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:88
-msgid "Signature"
-msgstr "信号半径"
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:53
+msgid ""
+"There is a release available which you have chosen to suppress. You can "
+"choose to reset notification suppression for this release, or download the "
+"new release from GitHub."
+msgstr ""
+"当前有不提示的版本更新。你可以选择重置版本更新提示，或从GitHub下载版本更新。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:89
-msgid "Warp Speed"
-msgstr "曲速航速"
+#: gui/characterEditor.py:463
+msgid "There was an error importing skills, please see log file"
+msgstr "导入技能列表出错，详见日志文件"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:113
-msgid "Fleet hangar"
-msgstr "舰队机库"
+#: gui/esiFittings.py:196
+msgid ""
+"There was an error validating characters' SSO token. Please try logging into "
+"the character again to reset the token."
+msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:114
-msgid "Maintenance bay"
-msgstr "维护舱"
+#: gui/esiFittings.py:179
+msgid ""
+"There was an issue starting up the localized server, try setting Login "
+"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
+"Authentication Method. If this doesn't fix the problem please file an issue "
+"on Github."
+msgstr ""
+"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
+"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:115
-msgid "Ammo hold"
-msgstr "弹药仓"
+#: gui/builtinContextMenus/moduleAmmoChange.py:25
+msgid "Thermal"
+msgstr ""
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:116
-msgid "Fuel bay"
-msgstr "燃料仓"
+#: gui/builtinStatsViews/resistancesViewFull.py:86
+#: gui/targetProfileEditor.py:120
+msgid "Thermal resistance"
+msgstr "热能抗性"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:117
-msgid "Ship hold"
-msgstr "舰船仓"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:107
+msgid ""
+"This is a destructive action that will delete all cached prices out of the "
+"database.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有价格缓存数据。\n"
+"您确定要继续吗？"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:118
-msgid "Small ship hold"
-msgstr "小型舰船仓"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:97
+msgid ""
+"This is a destructive action that will delete all damage pattern profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有伤害模型配置。\n"
+"您确定要继续吗？"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:119
-msgid "Medium ship hold"
-msgstr "中型舰船仓"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:102
+msgid ""
+"This is a destructive action that will delete all target profiles.\n"
+"Are you sure you want to do this?"
+msgstr ""
+"本操作将永久删除所有目标属性配置。\n"
+"您确定要继续吗？"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:120
-msgid "Large ship hold"
-msgstr "大型舰船仓"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:49
+msgid ""
+"This option goes through EVE SSO directly, but requires more configuration. "
+"Use this is pyfa.io is blocked for some reason, or if you do not wish to "
+"route data throguh pyfa.io."
+msgstr ""
+"本选项将直接发送EvE单点登录请求，但这需要更多配置。如果pyfa.io无法访问，或你"
+"不想让pyfa.io处理登录请求，请使用该选项。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:121
-msgid "Industrial ship hold"
-msgstr "工业舰船仓"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:42
+msgid ""
+"This option prompts users to copy and paste information from the web "
+"application to allow for character login. Use this if having issues with the "
+"local server."
+msgstr ""
+"本选项将在角色登录时提示您复制和粘贴登录页相关信息。如果本地服务器出现问题，"
+"可使用该选项。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:122
-msgid "Ore hold"
-msgstr "矿石仓"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:47
+msgid ""
+"This options routes SSO Logins through pyfa.io, allowing you to easily login "
+"without any configuration. When in doubt, use this option."
+msgstr ""
+"本选项将通过pyfa.io处理单点登录(SSO)请求，使你无需配置即可登录到EVE。不清除时"
+"可以使用该选项。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:123
-msgid "Mineral hold"
-msgstr "矿物仓"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:40
+msgid ""
+"This options starts a local webserver that the web application will call "
+"back to with information about the character login."
+msgstr "本选项将启动一个本地服务器以接收登录页返回的角色信息。"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:124
-msgid "Material bay"
-msgstr "物料仓"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:70
+msgid "Toggle Names"
+msgstr "切换名称"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:125
-msgid "Gas hold"
-msgstr "气体矿物仓库"
+#: gui/builtinItemStatsViews/itemAffectedBy.py:73
+msgid "Toggle View"
+msgstr "切换视图"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:126
-msgid "Salvage hold"
-msgstr "打捞件仓"
+#: gui/builtinItemStatsViews/itemCompare.py:75
+msgid "Toggle view mode"
+msgstr "切换显示模式"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:127
-msgid "Command center hold"
-msgstr "指挥中心仓"
+#: gui/builtinStatsViews/miningyieldViewFull.py:89
+#: gui/builtinStatsViews/priceViewFull.py:58
+#: gui/builtinStatsViews/priceViewMinimal.py:57
+msgid "Total"
+msgstr "总计"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:128
-msgid "Planetary goods hold"
-msgstr "星系物质仓"
+#: gui/builtinPreferenceViews/pyfaMarketPreferences.py:76
+msgid "Total Price Includes"
+msgstr "价格总计包括"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:129
-msgid "Quafe hold"
-msgstr "酷菲(Quafe)仓"
+#: gui/builtinStatsViews/capacitorViewFull.py:67
+msgid "Total: "
+msgstr "总计："
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
-msgid "Pod"
-msgstr "逃生舱"
+#: gui/itemStats.py:166
+msgid "Traits"
+msgstr "特征"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
-msgid "Interceptor"
-msgstr "截击"
+#: gui/builtinContextMenus/envEffectAdd.py:115
+#: gui/builtinContextMenus/envEffectAdd.py:118
+msgid "Triglavian Invasion"
+msgstr "三神裔入侵"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:164
-msgid "Frigate"
-msgstr "护卫"
+#: gui/builtinStatsViews/resourcesViewFull.py:111
+msgid "Turret hardpoints"
+msgstr "炮台"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
-msgid "Destroyer"
-msgstr "驱逐"
+#: gui/builtinItemStatsViews/itemEffects.py:32
+msgid "Type"
+msgstr "类型"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:165
-msgid "Cruiser"
-msgstr "巡洋"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
+#, python-brace-format
+msgid "Type: {0}\n"
+msgstr "扫描类型：{0}\n"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
-msgid "Battlecruiser"
-msgstr "战巡"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:222
+msgid "Type: {}"
+msgstr "扫描类型：{}"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:166
-msgid "Battleship"
-msgstr "战列"
+#: gui/mainMenuBar.py:83
+msgid "Undo the most recent action"
+msgstr "撤销最近一次操作"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:167
-msgid "Carrier"
-msgstr "航母"
+#: gui/characterEditor.py:614
+msgid "Unlearn"
+msgstr "未学习"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:201
-msgid "Lock Times"
-msgstr "锁定时间"
+#: gui/updateDialog.py:54
+msgid "Update Available"
+msgstr "有更新可用"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:208
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:241
-#, python-format
-msgid "Max Warp Distance: %.1f AU"
-msgstr "最大跃迁距离：%.1f AU"
+#: gui/builtinPreferenceViews/pyfaUpdatePreferences.py:14
+msgid "Updates"
+msgstr "更新"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:39
+msgid "Use character implants by default for new fits"
+msgstr "新装配默认使用角色植入体组"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:35
+msgid "Use global character"
+msgstr "使用全局角色"
+
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:43
+msgid "Use global damage pattern"
+msgstr "使用全局伤害分布配置"
+
+#: gui/builtinPreferenceViews/pyfaNetworkPreferences.py:121
+msgid "Username:"
+msgstr "用户名："
+
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:34
+msgid "Using Executable Path for Saved Fit Database and Settings"
+msgstr "使用Pyfa可执行文件路径来保存装配数据库和偏好设置"
+
+#: gui/builtinContextMenus/itemVariationChange.py:49
+#: gui/builtinPreferenceViews/pyfaContextMenuPreferences.py:51
+msgid "Variations"
+msgstr "变种"
+
+#: gui/builtinItemStatsViews/itemAttributes.py:53
+msgid "View Raw Data"
+msgstr "显示原始数据"
+
+#: gui/ssoLogin.py:62
+msgid "Waiting for character login through EVE Single Sign-On."
+msgstr "正在等待角色通过EvE登录。"
 
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:210
 #: gui/builtinStatsViews/targetingMiscViewMinimal.py:212
@@ -1674,250 +2531,69 @@ msgstr "最大跃迁距离：%.1f AU"
 msgid "Warp Core Strength: %.1f"
 msgstr "跃迁核心强度：%.1f"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
-#, python-brace-format
-msgid "Type: {0}\n"
-msgstr "扫描类型：{0}\n"
+#: gui/builtinStatsViews/targetingMiscViewMinimal.py:89
+msgid "Warp Speed"
+msgstr "曲速航速"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:219
-msgid " chance to be jammed"
-msgstr "概率丢失目标"
+#: gui/builtinStatsViews/firepowerViewFull.py:67
+msgid "Weapon"
+msgstr "武器"
 
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:222
-msgid "Type: {}"
-msgstr "扫描类型：{}"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:224
-#, python-format
-msgid "Align:\t%.3fs"
-msgstr "起跳时间：%.3fs"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:225
-msgid "Mass:\t{:,.0f}kg"
-msgstr "质量：{:,.0f}kg"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:226
-#, python-format
-msgid "Agility:\t%.3fx"
-msgstr "灵活性：%.3fx"
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:229
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:254
-msgid "Cargohold: "
-msgstr "货舱："
-
-#: gui/builtinStatsViews/targetingMiscViewMinimal.py:265
-#, python-format
-msgid "Probe Size: %.3f"
-msgstr "Probe Size: %.3f"
-
-#: gui/builtinViewColumns/abilities.py:37
-msgid "Active Abilities"
-msgstr "铁骑技能"
-
-#: gui/builtinViewColumns/baseName.py:59
-msgid "High"
-msgstr ""
-
-#: gui/builtinViewColumns/baseName.py:60
-msgid "Med"
-msgstr ""
-
-#: gui/builtinViewColumns/baseName.py:61
-msgid "Low"
-msgstr ""
-
-#: gui/builtinViewColumns/baseName.py:62
-msgid "Subsystem"
-msgstr ""
-
-#: gui/builtinViewColumns/baseName.py:63
-msgid "Rig"
-msgstr ""
-
-#: gui/builtinViewColumns/baseName.py:103
-msgid "{} {} Slot"
-msgstr ""
-
-#: gui/builtinViewColumns/misc.py:50
-msgid "Misc data"
-msgstr "杂项"
-
-#: gui/builtinViewColumns/sideEffects.py:37
-msgid "Active Side Effects"
-msgstr "副作用"
-
-#: gui/builtinViews/fittingView.py:661
-msgid "Citadel"
-msgstr "堡垒"
-
-#: gui/characterEditor.py:76
-msgid "You must supply a name for the Character!"
-msgstr "您必须填写一个角色名！"
-
-#: gui/characterEditor.py:78
-msgid "Character name already in use, please choose another."
-msgstr "角色名已占用，请使用其他名称。"
-
-#: gui/characterEditor.py:83 gui/characterEditor.py:463
-#: gui/characterEditor.py:898 gui/characterSelection.py:174
-#: gui/mainFrame.py:898 gui/patternEditor.py:58 gui/setEditor.py:55
-#: gui/targetProfileEditor.py:78
-msgid "Error"
-msgstr "错误"
-
-#: gui/characterEditor.py:137
-msgid "Character Editor"
-msgstr "角色编辑器"
-
-#: gui/characterEditor.py:160
-msgid "Skills"
-msgstr "技能列表"
-
-#: gui/characterEditor.py:281
-msgid "Enter a name for your new Character:"
-msgstr "请为新角色输入一个名称："
-
-#: gui/characterEditor.py:282
-msgid "Save Character As..."
-msgstr "保存角色为..."
-
-#: gui/characterEditor.py:284
-msgid "{} Copy"
-msgstr "复制{}"
-
-#: gui/characterEditor.py:326
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:61
 msgid ""
-"Setting an Alpha clone does not replace the character's skills, but rather "
-"caps them to Alpha levels."
-msgstr ""
-"设置为阿尔法克隆不会替换角色技能等级，但会设置技能等级上限为阿尔法状态。"
+"When damage profile is Uniform, set Reactive Armor Hardener to match (old "
+"behavior)."
+msgstr "当伤害分布为均匀模式时，重置反应式装甲增强器（兼容模式）。"
 
-#: gui/characterEditor.py:342 gui/characterEditor.py:608
-msgid "Skill"
-msgstr "技能"
-
-#: gui/characterEditor.py:343
-msgid "Level"
-msgstr "技能等级"
-
-#: gui/characterEditor.py:356
-#, python-brace-format
-msgid "Sec Status: {0:.2f}"
-msgstr "安全等级: {0:.2f}"
-
-#: gui/characterEditor.py:372
-msgid "Import skills from clipboard"
-msgstr "从剪贴板导入技能列表"
-
-#: gui/characterEditor.py:373
-msgid "Export skills from clipboard"
-msgstr "导出技能列表到剪贴板"
-
-#: gui/characterEditor.py:440
+#: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:86
 msgid ""
-"Importing skills into this character will set the skill levels as pending. "
-"To save the skills permanently, please click the Save button at the bottom "
-"of the window after importing"
+"When disabled, reloads charges just in selected modules. Action can be "
+"reversed by holding Ctrl or Alt key while changing charge."
 msgstr ""
-"导入技能到该角色将设置技能等级为等待状态。若需要永久保存技能，请在导入后点击"
-"窗口底部的保存按钮"
+"关闭该选项时，更换弹药仅更换选中的模块。按住Ctrl或Alt以更换所有同类型武器弹"
+"药。"
 
-#: gui/characterEditor.py:442
-msgid "Import Skills"
-msgstr "导入技能"
+#: gui/builtinPreferenceViews/pyfaEnginePreferences.py:54
+msgid ""
+"When enabled, skills will check their dependencies' requirements when their "
+"levels change and reset skills that no longer meet the requirement.\n"
+"eg: Setting Drones from level V to IV will reset the Heavy Drone Operation "
+"skill, as that requires Drones V"
+msgstr ""
+"启用时，技能级别变化时将检查并移除未达等级要求的相关技能。\n"
+"例如：将无人机从5级设置为4级将移除重型无人机操作技能，因为该技能要求无人机5级"
 
-#: gui/characterEditor.py:463
-msgid "There was an error importing skills, please see log file"
-msgstr "导入技能列表出错，详见日志文件"
+#: gui/builtinContextMenus/envEffectAdd.py:105
+msgid "Wormhole"
+msgstr ""
 
-#: gui/characterEditor.py:532
-msgid "Level {}d"
-msgstr "等级{}d"
-
-#: gui/characterEditor.py:614
-msgid "Unlearn"
-msgstr "未学习"
+#: gui/builtinItemStatsViews/itemEffects.py:56
+msgid "Yes"
+msgstr "是"
 
 #: gui/characterEditor.py:757
 msgid "You cannot link All 0 or All 5 characters to an EVE character."
 msgstr "你不能关联全0级或全5级到一个EvE角色。"
 
-#: gui/characterEditor.py:758
-msgid "Please select another character or make a new one."
-msgstr "请选择另一角色或创建新角色。"
+#: gui/characterEditor.py:76
+msgid "You must supply a name for the Character!"
+msgstr "您必须填写一个角色名！"
 
-#: gui/characterEditor.py:771
-msgid "Character:"
-msgstr "角色："
+#: gui/setEditor.py:48
+msgid "You must supply a name for the Implant Set!"
+msgstr "您必须填写一个植入体配置名！"
 
-#: gui/characterEditor.py:778
-msgid "Get Skills"
-msgstr "获取技能列表"
+#: gui/patternEditor.py:51
+msgid "You must supply a name for your Damage Profile!"
+msgstr "您必须填写一个伤害模型名！"
 
-#: gui/characterEditor.py:789
-msgid "Don't see your EVE character in the list?"
-msgstr "列表中没有你的EvE角色？"
+#: gui/targetProfileEditor.py:71
+msgid "You must supply a name for your Target Profile!"
+msgstr "您必须填写一个目标属性名！"
 
-#: gui/characterEditor.py:794
-msgid "Log In with EVE SSO"
-msgstr "通过EVE登录"
-
-#: gui/characterEditor.py:897 gui/characterSelection.py:173
-msgid "Error fetching skill information"
-msgstr "无法获取技能信息"
-
-#: gui/characterEditor.py:901
-msgid "Successfully fetched skills"
-msgstr "成功获取到技能列表"
-
-#: gui/characterEditor.py:901
-msgid "Success"
-msgstr "成功"
-
-#: gui/characterEditor.py:907
-msgid "Set Security Status"
-msgstr "设置安全等级"
-
-#: gui/characterEditor.py:914
-msgid "Security Status is used in some CONCORD hull calculations"
-msgstr "安全等级会用于计算CONCORD警察船体属性"
-
-#: gui/characterSelection.py:47
-msgid "Character: "
-msgstr "角色："
-
-#: gui/characterSelection.py:68
-msgid "Refresh Skills"
-msgstr "刷新技能"
-
-#: gui/characterSelection.py:102
-msgid "Grant Missing Skills"
-msgstr "习得所需技能"
-
-#: gui/characterSelection.py:105
-msgid "Copy Missing Skills"
-msgstr "复制所需技能"
-
-#: gui/characterSelection.py:150
-msgid "Open Character Editor"
-msgstr "打开角色编辑器"
-
-#: gui/characterSelection.py:230
-msgid "No active fit"
-msgstr "没有选中的装配"
-
-#: gui/characterSelection.py:238
-msgid "All skill prerequisites have been met"
-msgstr "已达到所有技能要求"
-
-#: gui/characterSelection.py:242
-msgid "Skills required:"
-msgstr "所需技能："
-
-#: gui/errorDialog.py:68
-msgid "Error!"
-msgstr "错误！"
+#: gui/builtinPreferenceViews/pyfaDatabasePreferences.py:38
+msgid "pyfa User Path:"
+msgstr "pyfa用户数据路径："
 
 #: gui/errorDialog.py:69
 msgid "pyfa error"
@@ -1934,721 +2610,45 @@ msgstr ""
 "Pyfa遇到了未知问题。下方文本框显示了该问题如何发生的关键信息。\n"
 "请通过EvE论坛或GitHub issue联系开发者，并提供下方文本框中的信息。"
 
-#: gui/esiFittings.py:32
-msgid "Browse EVE Fittings"
-msgstr "浏览游戏内装配"
-
-#: gui/esiFittings.py:44
-msgid "Fetch Fits"
-msgstr "获取装配"
-
-#: gui/esiFittings.py:64
-msgid "Import to pyfa"
-msgstr "导入到Pyfa"
-
-#: gui/esiFittings.py:65
-msgid "Delete from EVE"
-msgstr "删除游戏内装配"
-
-#: gui/esiFittings.py:111
-msgid "Fetching fits, please wait..."
-msgstr "正在获取装配，请稍候..."
-
-#: gui/esiFittings.py:114
-msgid "Need at least one ESI character to fetch"
-msgstr "请为获取至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:126 gui/esiFittings.py:169 gui/esiFittings.py:311
-msgid "Connection error, please check your internet connection"
-msgstr "连接错误，请检查您的网络连接"
-
-#: gui/esiFittings.py:156
-msgid "Do you really want to delete {} ({}) from EVE?"
-msgstr "真的要从游戏内删除 {} ({})吗？"
-
-#: gui/esiFittings.py:157 gui/propertyEditor.py:147
-msgid "Confirm Delete"
-msgstr "删除确认"
-
-#: gui/esiFittings.py:179
-msgid ""
-"There was an issue starting up the localized server, try setting Login "
-"Authentication Method to Manual by going to Preferences -> EVE SS0 -> Login "
-"Authentication Method. If this doesn't fix the problem please file an issue "
-"on Github."
+#: gui/aboutData.py:31
+msgid "pyfa is released under GNU GPLv3 - see included LICENSE file"
 msgstr ""
-"无法启动本地服务器，请尝试转到偏好设置->EVE SSO->登录验证方法并设置为手动模"
-"式。如果仍然遇到问题，请在Github填写issue以报告该问题。"
+"pyfa基于GNU通用公共许可证第三版(GPLv3)发布 - 详见应用目录下的LICENSE文件"
 
-#: gui/esiFittings.py:183
-msgid "Add Character Error"
-msgstr "添加角色错误"
+#: gui/propertyEditor.py:108
+msgid "pyfa override file"
+msgstr "Pyfa属性自定义文件"
 
-#: gui/esiFittings.py:196
-msgid ""
-"There was an error validating characters' SSO token. Please try logging into "
-"the character again to reset the token."
-msgstr "验证EvE角色登录信息出错，请重试登录以刷新信息。"
+#: gui/propertyEditor.py:131
+msgid "pyfa overrides"
+msgstr "Pyfa属性自定义文件"
 
-#: gui/esiFittings.py:198
-msgid "Invalid Token"
-msgstr "无效登录信息"
+#: gui/builtinPreferenceViews/pyfaEsiPreferences.py:46
+msgid "pyfa.io"
+msgstr "pyfa.io"
 
-#: gui/esiFittings.py:211
-msgid "Export fit to EVE"
-msgstr "导出装配到游戏"
-
-#: gui/esiFittings.py:224
-msgid "Export Fit"
-msgstr "导出装配"
-
-#: gui/esiFittings.py:281
-msgid "Please select an active fitting in the main window"
-msgstr "请在主窗口选择一个装配"
-
-#: gui/esiFittings.py:284
-msgid "Sending request and awaiting response"
-msgstr "正在发送请求和接收响应"
-
-#: gui/esiFittings.py:294
-msgid "Failed to generate export data"
-msgstr "无法生成导出数据"
-
-#: gui/esiFittings.py:300
-msgid "Need at least one ESI character to export"
-msgstr "请为导出至少选择一个游戏内角色"
-
-#: gui/esiFittings.py:313 gui/esiFittings.py:317 gui/esiFittings.py:325
-msgid "ERROR"
-msgstr "错误"
-
-#: gui/esiFittings.py:334
-msgid "SSO Character Management"
-msgstr "游戏内人物管理"
-
-#: gui/esiFittings.py:342
-msgid "Character ID"
-msgstr "角色ID"
-
-#: gui/esiFittings.py:350
-msgid "Add Character"
-msgstr "添加角色"
-
-#: gui/esiFittings.py:353
-msgid "Remove Character"
-msgstr "删除角色"
-
-#: gui/fitBrowserLite.py:17
-msgid "Add Fits"
-msgstr "添加装配"
-
-#: gui/itemStats.py:58
-msgid "Item stats"
-msgstr "物品属性"
+#: gui/builtinContextMenus/itemMarketJump.py:44
+#, python-brace-format
+msgid "{0} Market Group"
+msgstr "{0}市场分类"
 
 #: gui/itemStats.py:87
 #, python-brace-format
 msgid "{context}Stats: {name}{debug_info}"
 msgstr "{context}属性：{name}{debug_info}"
 
-#: gui/itemStats.py:166
-msgid "Traits"
-msgstr "特征"
-
-#: gui/itemStats.py:170
-msgid "Mutations"
-msgstr "变质"
-
-#: gui/itemStats.py:174
-msgid "Description"
-msgstr "简介"
-
-#: gui/itemStats.py:177
-msgid "Attributes"
-msgstr "属性"
-
-#: gui/itemStats.py:182
-msgid "Compare"
-msgstr "对比"
-
-#: gui/itemStats.py:185
-msgid "Requirements"
-msgstr "技能需求"
-
-#: gui/itemStats.py:189
-msgid "Dependents"
-msgstr "依赖"
-
-#: gui/itemStats.py:192
-msgid "Effects"
-msgstr "效果"
-
-#: gui/itemStats.py:196
-msgid "Affected by"
-msgstr "影响因素"
-
-#: gui/itemStats.py:200
-msgid "Properties"
-msgstr "属性"
-
-#: gui/mainFrame.py:182
-msgid "Market"
-msgstr "市场"
-
-#: gui/mainFrame.py:273
-msgid "Loading previous fits..."
-msgstr "正在打开之前的装配..."
-
-#: gui/mainFrame.py:468 gui/mainFrame.py:838
-msgid "EVE XML fitting files"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:647
-msgid ""
-"Are you sure you wish to ignore fitting restrictions for the current fit? "
-"This could lead to wildly inaccurate results and possible errors."
-msgstr "您确定要忽略当前装配资源限制吗？这可能导致不准确或错误的结果。"
-
-#: gui/mainFrame.py:654
-msgid ""
-"Re-enabling fitting restrictions for this fit will also remove any illegal "
-"items from the fit. Do you want to continue?"
-msgstr "重新启用装配限制将删除所有无效物品。您要继续吗？"
-
-#: gui/mainFrame.py:673
-msgid "Manage Characters"
-msgstr "管理角色"
-
-#: gui/mainFrame.py:690
-msgid "&Turn Overrides Off"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:690 gui/mainMenuBar.py:131
-msgid "&Turn Overrides On"
-msgstr "启用自定义属性(&T)"
-
-#: gui/mainFrame.py:723
-msgid "Please Wait..."
-msgstr "请稍候..."
-
-#: gui/mainFrame.py:807
-msgid "Export Skills Needed As..."
-msgstr "导出所需技能列表到..."
-
-#: gui/mainFrame.py:809
-msgid "EVEMon skills training file"
-msgstr "EvEMon技能训练文件"
-
-#: gui/mainFrame.py:810
-msgid "EVEMon skills training XML file"
-msgstr "EvEMon技能训练XML文件"
-
-#: gui/mainFrame.py:811
-msgid "Text skills training file"
-msgstr "技能列表文本文件"
-
-#: gui/mainFrame.py:829
-msgid "Exporting skills needed..."
-msgstr "正在导出所需技能..."
-
-#: gui/mainFrame.py:836
-msgid "Open One Or More Fitting Files"
-msgstr "打开装配文件"
-
-#: gui/mainFrame.py:839
-msgid "EFT text fitting files"
-msgstr "EFT装配文本文件"
-
-#: gui/mainFrame.py:840 gui/mainFrame.py:1015
-msgid "All Files"
-msgstr "所有文件"
-
-#: gui/mainFrame.py:846
-msgid "Importing fits"
-msgstr "正在导入装配"
-
-#: gui/mainFrame.py:860
-msgid "Save Backup As..."
-msgstr "保存备份为..."
-
-#: gui/mainFrame.py:861
-msgid "EVE XML fitting file"
-msgstr "EvE装配XML文件"
-
-#: gui/mainFrame.py:874 gui/mainFrame.py:905
-msgid "Backup fits"
-msgstr "备份装配"
-
-#: gui/mainFrame.py:875
-msgid "Backing up {} fits to: {}"
-msgstr "正在备份{}个装配到：{}"
-
-#: gui/mainFrame.py:894
-msgid "Invalid Path"
-msgstr "无效路径"
-
-#: gui/mainFrame.py:895
-msgid "The following path is invalid or does not exist:"
-msgstr "下述路径无效或不存在："
-
-#: gui/mainFrame.py:897
-msgid "Please verify path location pyfa's preferences."
-msgstr "请确认Pyfa偏好保存位置。"
-
-#: gui/mainFrame.py:906
-msgid "Generating HTML file at: {}"
-msgstr "正在生成HTML网页到：{}"
-
-#: gui/mainFrame.py:948
-msgid "Import Error"
-msgstr "导入错误"
-
-#: gui/mainFrame.py:948
-msgid "Export Error"
-msgstr "导出错误"
-
-#: gui/mainFrame.py:951
-msgid "The following error was generated"
-msgstr "Pyfa 遇到以下错误"
-
-#: gui/mainFrame.py:953
-msgid "Be aware that already processed fits were not saved"
-msgstr "请注意已处理的装配未作保存"
-
-#: gui/mainFrame.py:1012
-msgid "Open One Or More Character Files"
-msgstr "打开角色文件"
-
-#: gui/mainFrame.py:1014
-msgid "EVE API XML character files"
-msgstr "EvE API XML角色文件"
-
-#: gui/mainFrame.py:1021
-msgid "Importing Character..."
-msgstr "正在导入角色..."
-
-#: gui/mainMenuBar.py:66 gui/propertyEditor.py:42
-msgid "&File"
-msgstr "文件(&F)"
-
-#: gui/mainMenuBar.py:68
-msgid "&New Tab"
-msgstr "新标签页(&N)"
-
-#: gui/mainMenuBar.py:69
-msgid "&Close Tab"
-msgstr "关闭标签页(&C)"
-
-#: gui/mainMenuBar.py:70
-msgid "&Close All Tabs"
-msgstr "关闭所有标签页(&C)"
-
-#: gui/mainMenuBar.py:73
-msgid "&Backup All Fittings"
-msgstr "备份所有装配(&B)"
-
-#: gui/mainMenuBar.py:73
-msgid "Backup all fittings to a XML file"
-msgstr "备份所有装配到XML文件"
-
-#: gui/mainMenuBar.py:74
-msgid "Export All Fittings to &HTML"
-msgstr "导出所有装配到网页"
-
-#: gui/mainMenuBar.py:74
-msgid "Export fits to HTML file (set in Preferences)"
-msgstr "导出装配到HTML网页文件（通过偏好设置指定）"
-
-#: gui/mainMenuBar.py:81
-msgid "Fi&t"
-msgstr "装配(&T)"
-
-#: gui/mainMenuBar.py:83
-msgid "&Undo"
-msgstr "撤销(&R)"
-
-#: gui/mainMenuBar.py:83
-msgid "Undo the most recent action"
-msgstr "撤销最近一次操作"
-
-#: gui/mainMenuBar.py:84
-msgid "&Redo"
-msgstr "恢复(&R)"
-
-#: gui/mainMenuBar.py:84
-msgid "Redo the most recent undone action"
-msgstr "恢复最近一次撤销的操作"
-
-#: gui/mainMenuBar.py:87
-msgid "&To Clipboard"
-msgstr "导出到剪贴板(&T)"
-
-#: gui/mainMenuBar.py:87
-msgid "Export a fit to the clipboard"
-msgstr "导出装配到剪贴板"
-
-#: gui/mainMenuBar.py:88
-msgid "&From Clipboard"
-msgstr "从剪贴板导入(&F)"
-
-#: gui/mainMenuBar.py:88
-msgid "Import a fit from the clipboard"
-msgstr "从剪贴板导入装配"
-
-#: gui/mainMenuBar.py:91
-msgid "&Import Fittings"
-msgstr "导入装配(&I)"
-
-#: gui/mainMenuBar.py:91
-msgid "Import fittings into pyfa"
-msgstr "从文件导入装配"
-
-#: gui/mainMenuBar.py:92
-msgid "&Export Fitting"
-msgstr "导出装配(&E)"
-
-#: gui/mainMenuBar.py:92
-msgid "Export fitting to another format"
-msgstr "导出装配为其他格式"
-
-#: gui/mainMenuBar.py:95
-msgid "&Optimize Fit Price"
-msgstr "优化装配价格(&O)"
-
-#: gui/mainMenuBar.py:96
-msgid "&Graphs"
-msgstr "图表(&G)"
-
-#: gui/mainMenuBar.py:101 gui/mainMenuBar.py:202
-msgid "Disable Fitting Re&strictions"
-msgstr "关闭装配资源限制(&S)"
-
-#: gui/mainMenuBar.py:104
-msgid "&Browse ESI Fittings"
-msgstr "浏览游戏内装配(&B)"
-
-#: gui/mainMenuBar.py:105
-msgid "E&xport to ESI"
-msgstr "导出到游戏(&X)"
-
-#: gui/mainMenuBar.py:111
-msgid "&Character"
-msgstr "角色(&C)"
-
-#: gui/mainMenuBar.py:113
-msgid "&Save Character"
-msgstr "保存角色(&S)"
-
-#: gui/mainMenuBar.py:114
-msgid "Save Character &As..."
-msgstr "保存角色为...(&A)"
-
-#: gui/mainMenuBar.py:115
-msgid "&Revert Character"
-msgstr "还原角色(&R)"
-
-#: gui/mainMenuBar.py:118
-msgid "&Import Character File"
-msgstr "导入角色文件(&I)"
-
-#: gui/mainMenuBar.py:118
-msgid "Import characters into pyfa from file"
-msgstr "从文件导入角色信息"
-
-#: gui/mainMenuBar.py:119
-msgid "&Export Skills Needed"
-msgstr "导出所需技能列表(&E)"
-
-#: gui/mainMenuBar.py:119
-msgid "Export skills needed for this fitting"
-msgstr "导出使用本装配所需技能"
-
-#: gui/mainMenuBar.py:122
-msgid "&Manage ESI Characters"
-msgstr "管理游戏内角色(&M)"
-
-#: gui/mainMenuBar.py:128
-msgid "Attribute &Overrides"
-msgstr "自定义属性(&O)"
-
-#: gui/mainMenuBar.py:135
-msgid "&Global"
-msgstr "全局设置(&G)"
-
-#: gui/mainMenuBar.py:137
-msgid "&Preferences"
-msgstr "偏好设置(&P)"
-
-#: gui/mainMenuBar.py:143
-msgid "&Editors"
-msgstr "编辑器(&E)"
-
-#: gui/mainMenuBar.py:144
-msgid "&Character Editor"
-msgstr "角色编辑器(&C)"
-
-#: gui/mainMenuBar.py:147
-msgid "&Implant Set Editor"
-msgstr "植入体配置编辑器(&I)"
-
-#: gui/mainMenuBar.py:150
-msgid "&Damage Pattern Editor"
-msgstr "伤害模型编辑器(&D)"
-
-#: gui/mainMenuBar.py:153
-msgid "&Target Profile Editor"
-msgstr "目标属性编辑器(&T)"
-
-#: gui/mainMenuBar.py:159
-msgid "&Help"
-msgstr "帮助(&H)"
-
-#: gui/mainMenuBar.py:160
-msgid "&Wiki"
-msgstr "百科(&W)"
-
-#: gui/mainMenuBar.py:160
-msgid "Go to wiki on GitHub"
-msgstr "转到GitHub上的百科页"
-
-#: gui/mainMenuBar.py:161
-msgid "&Forums"
-msgstr "论坛(&F)"
-
-#: gui/mainMenuBar.py:161
-msgid "Go to EVE Online Forum thread"
-msgstr "转到EvE Online论坛讨论贴"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Wid&gets Inspect tool"
-msgstr "打开控件检查工具(&G)"
-
-#: gui/mainMenuBar.py:166
-msgid "Open Widgets Inspect tool"
-msgstr "打开控件检查工具"
-
-#: gui/mainMenuBar.py:167
-msgid "Open &Dev Tools"
-msgstr "打开开发者工具(&D)"
-
-#: gui/mainMenuBar.py:167
-msgid "Dev Tools"
-msgstr "开发者工具"
-
-#: gui/mainMenuBar.py:200
-msgid "Enable Fitting Re&strictions"
-msgstr "开启装配限制(&S)"
-
-#: gui/multiSwitch.py:41
-msgid "Empty Tab"
-msgstr "空白标签页"
-
-#: gui/patternEditor.py:51
-msgid "You must supply a name for your Damage Profile!"
-msgstr "您必须填写一个伤害模型名！"
-
-#: gui/patternEditor.py:53
-msgid "Damage Profile name already in use, please choose another."
-msgstr "伤害模型名已占用，请使用其他名称。"
-
-#: gui/patternEditor.py:65
-msgid "Damage Profile"
-msgstr "伤害模型"
-
-#: gui/patternEditor.py:99
-msgid "Damage Pattern Editor"
-msgstr "伤害模型编辑器"
-
-#: gui/patternEditor.py:171
-msgid "Import patterns from clipboard"
-msgstr "从剪贴板导入伤害模型"
-
-#: gui/patternEditor.py:172
-msgid "Export patterns to clipboard"
-msgstr "导出伤害模型到剪贴板"
-
-#: gui/patternEditor.py:276 gui/setEditor.py:210
-msgid "Patterns successfully imported from clipboard"
-msgstr "从剪贴板导入伤害模型成功"
-
-#: gui/patternEditor.py:283 gui/setEditor.py:218
-msgid "Could not import from clipboard: unknown errors"
-msgstr "无法从剪贴板导入：未知错误"
-
-#: gui/patternEditor.py:290 gui/setEditor.py:222 gui/targetProfileEditor.py:366
-msgid "Could not import from clipboard"
-msgstr "无法从剪贴板导入"
-
-#: gui/patternEditor.py:295
-msgid "Patterns exported to clipboard"
-msgstr "伤害模型已导出到剪贴板"
-
-#: gui/preferenceDialog.py:31
-msgid "Preferences"
-msgstr "偏好设置"
-
-#: gui/propertyEditor.py:28
-msgid "Attribute Editor"
-msgstr "属性编辑器"
-
-#: gui/propertyEditor.py:38
-msgid "Import"
-msgstr "导入"
-
-#: gui/propertyEditor.py:38 gui/propertyEditor.py:39
-msgid "Import overrides"
-msgstr "导入自定义属性"
-
-#: gui/propertyEditor.py:39
-msgid "Export"
-msgstr "导出"
-
-#: gui/propertyEditor.py:40
-msgid "Clear All"
-msgstr "清除所有"
-
-#: gui/propertyEditor.py:40
-msgid "Clear all overrides"
-msgstr "清除所有自定义属性"
-
-#: gui/propertyEditor.py:71
-msgid "Remove Overides for Item"
-msgstr "删除物品的自定义属性"
-
-#: gui/propertyEditor.py:107
-msgid "Import pyfa override file"
-msgstr "导入Pyfa属性自定义文件"
-
-#: gui/propertyEditor.py:108
-msgid "pyfa override file"
-msgstr "Pyfa属性自定义文件"
-
-#: gui/propertyEditor.py:130
-msgid "Save Overrides As..."
-msgstr "保存自定义属性为..."
-
-#: gui/propertyEditor.py:131
-msgid "pyfa overrides"
-msgstr "Pyfa属性自定义文件"
-
-#: gui/propertyEditor.py:146
-msgid "Are you sure you want to delete all overrides?"
-msgstr "您确定要删除所有自定义属性吗？"
-
-#: gui/propertyEditor.py:271
-#, python-format
-msgid "Default Value: %0.3f"
-msgstr "默认值：%0.3f"
-
-#: gui/setEditor.py:48
-msgid "You must supply a name for the Implant Set!"
-msgstr "您必须填写一个植入体配置名！"
-
-#: gui/setEditor.py:50
-msgid "Implant Set name already in use, please choose another."
-msgstr "植入体配置名已使用，请选择其他名称。"
-
-#: gui/setEditor.py:62
-msgid "Implant Set"
-msgstr "植入体配置"
-
-#: gui/setEditor.py:122
-msgid "Implant Set Editor"
-msgstr "植入体配置编辑器"
-
-#: gui/setEditor.py:148
-msgid "Import implant sets from clipboard"
-msgstr "从剪贴板导入植入体配置"
-
-#: gui/setEditor.py:149
-msgid "Export implant sets to clipboard"
-msgstr "导出植入体配置到剪贴板"
-
-#: gui/setEditor.py:229
-msgid "Sets exported to clipboard"
-msgstr "植入体配置已导出到剪贴板"
-
-#: gui/ssoLogin.py:15 gui/ssoLogin.py:49
-msgid "SSO Login"
-msgstr "通过EVE登录"
-
-#: gui/ssoLogin.py:20
-msgid "Copy and paste the block of text provided by pyfa.io"
-msgstr "请复制和粘贴pyfa.io提供的字符串"
-
-#: gui/ssoLogin.py:62
-msgid "Waiting for character login through EVE Single Sign-On."
-msgstr "正在等待角色通过EvE登录。"
-
-#: gui/targetProfileEditor.py:50
-msgid "Incorrect formatting (decimals only)"
-msgstr "格式无效（仅允许小数）"
-
-#: gui/targetProfileEditor.py:52
-msgid "Incorrect range (must be 0-100)"
-msgstr "范围无效（必须是 0-100）"
-
-#: gui/targetProfileEditor.py:71
-msgid "You must supply a name for your Target Profile!"
-msgstr "您必须填写一个目标属性名！"
-
-#: gui/targetProfileEditor.py:73
-msgid "Target Profile name already in use, please choose another."
-msgstr "目标属性名已使用，请选择其他名称。"
-
-#: gui/targetProfileEditor.py:86
-msgid "Target Profile"
-msgstr "目标属性"
-
-#: gui/targetProfileEditor.py:119
-msgid "EM resistance"
-msgstr "电磁抗性"
-
-#: gui/targetProfileEditor.py:124
-msgid "Maximum speed"
-msgstr "亚光速航速"
-
-#: gui/targetProfileEditor.py:125
-msgid ""
-"Signature radius\n"
-"Leave blank for infinitely big value"
+#: gui/builtinContextMenus/moduleSpool.py:83
+msgid "{} (default)"
+msgstr "{}（默认值）"
+
+#: gui/characterEditor.py:284
+msgid "{} Copy"
+msgstr "复制{}"
+
+#: gui/builtinContextMenus/itemStats.py:38
+msgid "{} Stats"
+msgstr "{}属性"
+
+#: gui/builtinViewColumns/baseName.py:103
+msgid "{} {} Slot"
 msgstr ""
-"信号半径\n"
-"保持为空表示信号半径无限大"
-
-#: gui/targetProfileEditor.py:126
-msgid "Radius"
-msgstr "信号半径"
-
-#: gui/targetProfileEditor.py:130
-msgid "Target Profile Editor"
-msgstr "目标属性编辑器"
-
-#: gui/targetProfileEditor.py:221
-msgid "Import profiles from clipboard"
-msgstr "从剪贴板导入目标属性"
-
-#: gui/targetProfileEditor.py:222
-msgid "Export profiles to clipboard"
-msgstr "导出目标属性到剪贴板"
-
-#: gui/targetProfileEditor.py:352
-msgid "Profiles successfully imported from clipboard"
-msgstr "已成功从剪贴板导入目标属性"
-
-#: gui/targetProfileEditor.py:359
-msgid "Could not import from clipboard:"
-msgstr "无法从剪贴板导入："
-
-#: gui/targetProfileEditor.py:372
-msgid "Profiles exported to clipboard"
-msgstr "目标属性已导出到剪贴板"
-
-#: gui/updateDialog.py:54
-msgid "Update Available"
-msgstr "有更新可用"
-
-#: gui/updateDialog.py:102
-msgid "Don't remind me again for this release"
-msgstr "不再提示此更新"
-


### PR DESCRIPTION
It seems that the default output from GNU gettext is sorted by file, or not sorted at all. Currently I'm using `-s` option for various GNU gettext tools to sort lang.po by msgid.
