### PR TITLE
Ignore _TabRenderer.SetSize when new size is the same as old size

### DIFF
--- a/gui/chrome_tabs.py
+++ b/gui/chrome_tabs.py
@@ -402,6 +402,10 @@ class _TabRenderer:
         width = max(width, self.min_width)
         height = max(height, self.min_height)
 
+        cur_width, cur_height = self.tab_size
+        if (width == cur_width) and (height == cur_height):
+            return
+
         self.tab_size = (width, height)
         self.InitTab()
 


### PR DESCRIPTION
When switching fit tabs, _TabRenderer.InitTab is called a whopping 140 times, making tab-switching annoyingly slow.
This reduces the number of these calls to merely 6, and switching is much faster now (although still not instantaneous, as I'd like)