### PR TITLE
Do not sleep for half a second in OpenFitsThread.run()

### DIFF
--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -110,8 +110,6 @@ class OpenFitsThread(threading.Thread):
         self.start()
 
     def run(self):
-        time.sleep(0.5)  # Give GUI some time to finish drawing
-
         # `startup` tells FitSpawner that we are loading fits are startup, and
         # has 3 values:
         # False = Set as default in FitSpawner itself, never set here


### PR DESCRIPTION
From the comment on that line, it looks like it was a workaround for some bug.
It seems to work fine without it on Mac OS X. Would appreciate testing on Linux/Windows.