### PR TITLE
_TabsContainer.CheckTabSelected no longer posts PageChanged event twice

### DIFF
--- a/gui/chrome_tabs.py
+++ b/gui/chrome_tabs.py
@@ -975,9 +975,6 @@ class _TabsContainer(wx.Panel):
             sel_tab = self.tabs.index(tab)
             self.Parent.SetSelection(sel_tab)
 
-            wx.PostEvent(self.Parent, PageChanged(self.tabs.index(old_sel_tab),
-                                                  self.tabs.index(tab)))
-
             return True
 
         return False


### PR DESCRIPTION
It was doing it once via `self.Parent.SetSelection(sel_tab)` and then directly itself.