### PR TITLE
Add High DPI Support for Windows

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -36,6 +36,22 @@ class PyfaApp(wx.App):
         # Set language stuff and update to last used language.
         self.UpdateLanguage(config.language)
 
+        try:
+            from ctypes import OleDLL
+            # Turn on high-DPI awareness to make sure rendering is sharp on big
+            # monitors with font scaling enabled.
+            OleDLL('shcore').SetProcessDpiAwareness(1)
+        except AttributeError:
+            # We're on a non-Windows box.
+            pass
+        except OSError:
+            # exc.winerror is often E_ACCESSDENIED (-2147024891/0x80070005).
+            # This occurs after the first run, when the parameter is reset in the
+            # executable's manifest and then subsequent calls raise this exception
+            # See last paragraph of Remarks at
+            # [https://msdn.microsoft.com/en-us/library/dn302122(v=vs.85).aspx](https://msdn.microsoft.com/en-us/library/dn302122(v=vs.85).aspx)
+            pass
+        
         return True
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
This makes Pyfa much more readable on 4K displays, and shouldn't cause any issues on non-windows machines.