### PR TITLE
Fixed exception reporting when migrating database

### DIFF
--- a/eos/config.py
+++ b/eos/config.py
@@ -10,7 +10,7 @@ pyfalog = Logger(__name__)
 debug = False
 gamedataCache = True
 saveddataCache = True
-gamedata_version = ""
+gamedata_version = "0"
 gamedata_date = ""
 gamedata_connectionstring = 'sqlite:///' + realpath(join(dirname(abspath(__file__)), "..", "eve.db"))
 


### PR DESCRIPTION
After updating to Pyfa v2.32.1, PyFa could not start any more on my computer. This was caused by an exception in the update database process.

See issue #2295 for details.