### PR TITLE
macOS Fixes

### DIFF
--- a/gui/bitmap_loader.py
+++ b/gui/bitmap_loader.py
@@ -102,11 +102,13 @@ class BitmapLoader:
         if img is None:
             pyfalog.warning("Missing icon file: {0}/{1}".format(location, filename))
             return None
+        return BitmapLoader.getScaledBitmap(image=img, scale=scale)
 
-        bmp: wx.Bitmap = img.ConvertToBitmap()
+    @staticmethod
+    def getScaledBitmap(image: wx.Image, scale: int) -> wx.Bitmap:
         if scale > 1:
-            bmp.SetSize((bmp.GetWidth() // scale, bmp.GetHeight() // scale))
-        return bmp
+            image.Rescale(image.GetWidth() // scale, image.GetHeight() // scale)
+        return image.ConvertToBitmap()
 
     @classmethod
     def loadScaledBitmap(cls, name, location, scale=0):

--- a/gui/builtinShipBrowser/fitItem.py
+++ b/gui/builtinShipBrowser/fitItem.py
@@ -418,6 +418,7 @@ class FitItem(SFItem.SFBrowserItem):
                 if self.dragMotionTrigger < 0:
                     if not self.HasCapture():
                         self.CaptureMouse()
+                    self._updateDragBitmap()
                     self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)
                     self.dragWindow.Show()
                     self.dragged = True
@@ -429,6 +430,18 @@ class FitItem(SFItem.SFBrowserItem):
                 pos.y += 3
                 self.dragWindow.SetPosition(pos)
             return
+
+    def _updateDragBitmap(self):
+        dc = wx.ClientDC(self)
+        bufferedDC = wx.BufferedDC(dc)
+        self.DrawItem(dc)
+
+        rect = self.GetRect()
+        tdc = wx.MemoryDC()
+        self.dragTLFBmp = wx.Bitmap((self.toolbarx if self.toolbarx < 200 else 200), rect.height, 24)
+        tdc.SelectObject(self.dragTLFBmp)
+        tdc.Blit(0, 0, (self.toolbarx if self.toolbarx < 200 else 200), rect.height, bufferedDC, 0, 0, wx.COPY)
+        tdc.SelectObject(wx.NullBitmap)
 
     def selectFit(self, event=None, newTab=False):
         if newTab:
@@ -477,6 +490,7 @@ class FitItem(SFItem.SFBrowserItem):
         self.thoverw = wlabel
 
     def DrawItem(self, mdc):
+        self.dragTLFBmp = None
         rect = self.GetRect()
 
         windowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
@@ -519,11 +533,6 @@ class FitItem(SFItem.SFBrowserItem):
         if self.tcFitName.IsShown():
             self.AdjustControlSizePos(self.tcFitName, self.textStartx, self.toolbarx - self.editWidth - self.padding)
 
-        tdc = wx.MemoryDC()
-        self.dragTLFBmp = wx.Bitmap((self.toolbarx if self.toolbarx < 200 else 200), rect.height, 24)
-        tdc.SelectObject(self.dragTLFBmp)
-        tdc.Blit(0, 0, (self.toolbarx if self.toolbarx < 200 else 200), rect.height, mdc, 0, 0, wx.COPY)
-        tdc.SelectObject(wx.NullBitmap)
 
     def AdjustControlSizePos(self, editCtl, start, end):
         fnEditSize = editCtl.GetSize()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-wxPython == 4.0.6
+wxPython == 4.1.1
 logbook >= 1.0.0
-numpy == 1.19.2
-matplotlib == 3.2.2
+numpy == 1.20.2
+matplotlib == 3.4.1
 python-dateutil
 requests >= 2.0.0
 sqlalchemy == 1.3.23


### PR DESCRIPTION
This is attempt to #2304 (fdb9d23). I have not tested this on anything but macOS.
Please see the commit for details on the cause and the solution.

I have also updated wxPython to 4.1.1 in an initial attempt to resolve the `Blit()` issue, and have kept.

b10599d contains a fix for an assertion on Retina MacBooks when scaling images to 2x.