### PR TITLE
Stop displaying None for units without displayName

### DIFF
--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -23,6 +23,7 @@ import re
 
 from logbook import Logger
 from sqlalchemy.orm import reconstructor
+from gui.utils.numberFormatter import formatAmount
 
 import eos.effects
 import eos.db
@@ -700,6 +701,22 @@ class Unit(EqBase):
             return override[1](value), override[2](self.displayName)
 
         return value, self.displayName
+
+    def FormatValue(self, value, rounding='prec', digits=3):
+        """Formats a value / unit combination into a string"""
+        preformatedValue = self.PreformatValue(value)[0]
+        unit = self.PreformatValue(value)[1]
+
+        if isinstance(preformatedValue, (int, float)) and rounding == 'prec':
+            fvalue = formatAmount(value, digits, 0, 0)
+        elif isinstance(preformatedValue, (int, float)) and rounding == 'dec':
+            fvalue = roundDec(value, digits)
+        else:
+            fvalue = preformatedValue
+
+        if unit is not None:
+            return "%s %s" % (fvalue, unit)
+        return fvalue
 
     def SimplifyValue(self, value):
         """Takes the internal representation value and convert it into the display value"""

--- a/gui/builtinItemStatsViews/itemAttributes.py
+++ b/gui/builtinItemStatsViews/itemAttributes.py
@@ -326,14 +326,14 @@ class ItemParams(wx.Panel):
         if self.toggleView == AttributeView.RAW:
             valueUnit = str(value)
         elif info and info.unit:
-            valueUnit = self.FormatValue(*info.unit.PreformatValue(value))
+            valueUnit = info.unit.FormatValue(value)
         else:
             valueUnit = formatAmount(value, 3, 0, 0)
 
         if self.toggleView == AttributeView.RAW:
             valueUnitDefault = str(valueDefault)
         elif info and info.unit:
-            valueUnitDefault = self.FormatValue(*info.unit.PreformatValue(valueDefault))
+            valueUnitDefault = info.unit.FormatValue(valueDefault)
         else:
             valueUnitDefault = formatAmount(valueDefault, 3, 0, 0)
 
@@ -344,15 +344,3 @@ class ItemParams(wx.Panel):
         # if self.stuff is not None:
         #     self.paramList.SetItemText(index, valueUnitDefault, 2)
         # self.paramList.SetItemImage(index, attrIcon, which=wx.TreeItemIcon_Normal)
-
-    @staticmethod
-    def FormatValue(value, unit, rounding='prec', digits=3):
-        """Formats a value / unit combination into a string
-        @todo: move this to a more central location, since this is also used in the item mutator panel"""
-        if isinstance(value, (int, float)) and rounding == 'prec':
-            fvalue = formatAmount(value, digits, 0, 0)
-        elif isinstance(value, (int, float)) and rounding == 'dec':
-            fvalue = roundDec(value, digits)
-        else:
-            fvalue = value
-        return "%s %s" % (fvalue, unit)

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -164,7 +164,7 @@ class ItemCompare(wx.Panel):
                     if self.toggleView != 1:
                         valueUnit = str(value)
                     elif info and info.unit and self.toggleView == 1:
-                        valueUnit = self.TranslateValueUnit(value, info.unit.displayName, info.unit.name)
+                        valueUnit = info.unit.FormatValue(value)
                     else:
                         valueUnit = formatAmount(value, 3, 0, 0)
 
@@ -175,43 +175,3 @@ class ItemCompare(wx.Panel):
 
         self.paramList.RefreshRows()
         self.Layout()
-
-    @staticmethod
-    def TranslateValueUnit(value, unitName, unitDisplayName):
-        def itemIDCallback():
-            item = Market.getInstance().getItem(value)
-            return "%s (%d)" % (item.name, value) if item is not None else str(value)
-
-        def groupIDCallback():
-            group = Market.getInstance().getGroup(value)
-            return "%s (%d)" % (group.name, value) if group is not None else str(value)
-
-        def attributeIDCallback():
-            attribute = Attribute.getInstance().getAttributeInfo(value)
-            return "%s (%d)" % (attribute.name.capitalize(), value)
-
-        trans = {
-            "Inverse Absolute Percent": (lambda: (1 - value) * 100, unitName),
-            "Inversed Modifier Percent": (lambda: (1 - value) * 100, unitName),
-            "Modifier Percent": (lambda: ("%+.2f" if ((value - 1) * 100) % 1 else "%+d") % ((value - 1) * 100), unitName),
-            "Volume": (lambda: value, "m\u00B3"),
-            "Sizeclass": (lambda: value, ""),
-            "Absolute Percent": (lambda: (value * 100), unitName),
-            "Milliseconds": (lambda: value / 1000.0, unitName),
-            "typeID": (itemIDCallback, ""),
-            "groupID": (groupIDCallback, ""),
-            "attributeID": (attributeIDCallback, "")
-        }
-
-        override = trans.get(unitDisplayName)
-        if override is not None:
-            v = override[0]()
-            if isinstance(v, str):
-                fvalue = v
-            elif isinstance(v, (int, float)):
-                fvalue = formatAmount(v, 3, 0, 0)
-            else:
-                fvalue = v
-            return "%s %s" % (fvalue, override[1])
-        else:
-            return "%s %s" % (formatAmount(value, 3, 0), unitName)

--- a/gui/builtinItemStatsViews/itemMutator.py
+++ b/gui/builtinItemStatsViews/itemMutator.py
@@ -148,11 +148,11 @@ class ItemMutatorList(wx.ScrolledWindow):
 
             headingSizer.Add(displayName, 3, wx.ALL | wx.EXPAND, 0)
 
-            worseVal = ItemParams.FormatValue(*m.attribute.unit.PreformatValue(worseRange[0]), rounding='dec')
+            worseVal = m.attribute.unit.FormatValue(worseRange[0], rounding='dec')
             worseText = wx.StaticText(self, wx.ID_ANY, worseVal)
             worseText.SetForegroundColour(badColor)
 
-            betterVal = ItemParams.FormatValue(*m.attribute.unit.PreformatValue(betterRange[0]), rounding='dec')
+            betterVal = m.attribute.unit.FormatValue(betterRange[0], rounding='dec')
             betterText = wx.StaticText(self, wx.ID_ANY, betterVal)
             betterText.SetForegroundColour(goodColor)
 


### PR DESCRIPTION
Closes #2354 

I chose to stop displaying None for units without a displayName.
An other solution would have been to give a displayName to the "Fitting Slots" unit in dogmaunits.0.json
