### PR TITLE
Issue 2450 : ECM Burst Jammers burst range is 0 when exported to EFS

### DIFF
--- a/service/port/efs.py
+++ b/service/port/efs.py
@@ -28,7 +28,7 @@ pyfaVersion = getVersion()
 
 class EfsPort:
     wepTestSet = {}
-    version = 0.05
+    version = 0.06
 
     @staticmethod
     def attrDirectMap(values, target, source):
@@ -243,7 +243,10 @@ class EfsPort:
                 pyfalog.error("Projected module {0} lacks efs export implementation".format(mod.item.typeName))
             if mod.getModifiedItemAttr("maxRange", None) is None:
                 pyfalog.error("Projected module {0} has no maxRange".format(mod.item.typeName))
-            stats["optimal"] = mod.getModifiedItemAttr("maxRange", maxRangeDefault)
+
+            # Burst jammer maxRange is 0 if the value is retrieved using mod.getModifiedItemAttr("maxRange")
+            # Despite it is correct, it still pulls 0.0.
+            stats["optimal"] = mod.getModifiedItemAttr("maxRange", maxRangeDefault) if mod.item.group.name != "Burst Jammer" else mod.maxRange
             stats["falloff"] = mod.getModifiedItemAttr("falloffEffectiveness", falloffDefault)
             EfsPort.attrDirectMap(["duration", "capacitorNeed"], stats, mod)
             projections.append(stats)


### PR DESCRIPTION
FIX: Added check to correct add the burst jammer's burst radius

https://github.com/pyfa-org/Pyfa/issues/2450