### PR TITLE
Feature/compare highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,5 @@ gitversion
 *.fsdbinary
 /locale/progress.json
 
-launch.json
-eve.db
+# vscode settings
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ target/
 
 # pyenv
 .python-version
+PyfaEnv/
 
 # celery beat schedule file
 celerybeat-schedule
@@ -123,3 +124,6 @@ gitversion
 
 *.fsdbinary
 /locale/progress.json
+
+launch.json
+eve.db

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -36,6 +36,10 @@ class ItemCompare(wx.Panel):
         self.item = item
         self.items = sorted(items, key=defaultSort)
         self.attrs = {}
+        self.defaultRowBackgroundColour = None
+        self.HighlightOn = wx.Colour(255, 255, 0, wx.ALPHA_OPAQUE)
+        self.HighlightOff = wx.Colour(-1, -1, -1, -127)
+        self.highlightedRows = []
 
         # get a dict of attrName: attrInfo of all unique attributes across all items
         for item in self.items:
@@ -87,6 +91,24 @@ class ItemCompare(wx.Panel):
 
         self.toggleViewBtn.Bind(wx.EVT_TOGGLEBUTTON, self.ToggleViewMode)
         self.Bind(wx.EVT_LIST_COL_CLICK, self.SortCompareCols)
+
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.HighlightRow)
+
+    def HighlightRow(self, event):
+        itemIdx = event.GetIndex()
+        item = self.paramList.GetItem(itemIdx)
+        if itemIdx in self.highlightedRows:
+            item.SetBackgroundColour(self.HighlightOff)
+            f = item.GetFont()
+            f.SetWeight(wx.FONTWEIGHT_NORMAL)
+            item.SetFont(f)
+            self.highlightedRows.remove(itemIdx)
+        else:
+            item.SetBackgroundColour(self.HighlightOn)
+            item.SetFont(item.GetFont().MakeBold())
+            self.highlightedRows.append(itemIdx)
+        self.paramList.SetItem(item)
+        
 
     def SortCompareCols(self, event):
         self.Freeze()

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -237,3 +237,4 @@ class ItemCompare(wx.Panel):
             return "%s %s" % (fvalue, override[1])
         else:
             return "%s %s" % (formatAmount(value, 3, 0), unitName)
+            

--- a/gui/builtinItemStatsViews/itemCompare.py
+++ b/gui/builtinItemStatsViews/itemCompare.py
@@ -36,7 +36,6 @@ class ItemCompare(wx.Panel):
         self.item = item
         self.items = sorted(items, key=defaultSort)
         self.attrs = {}
-        self.defaultRowBackgroundColour = None
         self.HighlightOn = wx.Colour(255, 255, 0, wx.ALPHA_OPAQUE)
         self.HighlightOff = wx.Colour(-1, -1, -1, -127)
         self.highlightedRows = []
@@ -237,4 +236,3 @@ class ItemCompare(wx.Panel):
             return "%s %s" % (fvalue, override[1])
         else:
             return "%s %s" % (formatAmount(value, 3, 0), unitName)
-            


### PR DESCRIPTION
Double clicking an item in the Compare window will now highlight and bold that row, can be returned to normal by double clicking again
![compare](https://user-images.githubusercontent.com/23041803/188330120-eac50171-295e-4607-ae3d-c329107aa8b8.png)
