### PR TITLE
fix runtime bitmap scaling error on macos sonoma

### DIFF
--- a/gui/bitmap_loader.py
+++ b/gui/bitmap_loader.py
@@ -103,10 +103,9 @@ class BitmapLoader:
             pyfalog.warning("Missing icon file: {0}/{1}".format(location, filename))
             return None
 
-        bmp: wx.Bitmap = img.ConvertToBitmap()
         if scale > 1:
-            bmp.SetSize((bmp.GetWidth() // scale, bmp.GetHeight() // scale))
-        return bmp
+            return img.Scale(img.GetWidth() // scale, img.GetHeight() // scale).ConvertToBitmap()
+        return img.ConvertToBitmap()
 
     @classmethod
     def loadScaledBitmap(cls, name, location, scale=0):


### PR DESCRIPTION
This little change combined with the other changes in this branch + dependency updates makes pyfa run on macos sonoma

some part of the upgrade breaks the rendering of fits when dragged in the interface on macos (including on Ventura), which should be fixed, but having the release work on latest os version is more important.

Part of wx upgrade also made pyfa reactive to system theme (Dark mode) which does not look great, working on making it look nicer

Tested on M1 Mac, x86 Mac, and Windows