### PR TITLE
fix infinite redraws on macos

### DIFF
--- a/gui/builtinShipBrowser/fitItem.py
+++ b/gui/builtinShipBrowser/fitItem.py
@@ -424,6 +424,7 @@ class FitItem(SFItem.SFBrowserItem):
                         tdc.SetBrush(wx.Brush(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)))
                         tdc.DrawRectangle(0, 0, bmpWidth, self.GetRect().height)
                         self.DrawItem(tdc)
+                        tdc.SelectObject(wx.NullBitmap)
                     if not self.HasCapture():
                         self.CaptureMouse()
                     self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)  

--- a/gui/builtinShipBrowser/fitItem.py
+++ b/gui/builtinShipBrowser/fitItem.py
@@ -195,8 +195,9 @@ class FitItem(SFItem.SFBrowserItem):
             self.dragged = False
             if self.HasCapture():
                 self.ReleaseMouse()
-            self.dragWindow.Show(False)
-            self.dragWindow = None
+            # TODO: re-enable this once rendring of drag window is fixed
+            #self.dragWindow.Show(False)
+            #self.dragWindow = None
 
     def OnContextMenu(self, event):
         """ Handles context menu for fit. Dragging is handled by MouseLeftUp() """
@@ -418,9 +419,10 @@ class FitItem(SFItem.SFBrowserItem):
                 if self.dragMotionTrigger < 0:
                     if not self.HasCapture():
                         self.CaptureMouse()
-                    self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)
-                    self.dragWindow.Show()
-                    self.dragged = True
+                    # self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)
+                    # TODO: re-enable this once rendring of drag window is fixed    
+                    #self.dragWindow.Show()
+                    #self.dragged = True
                     self.dragMotionTrigger = self.dragMotionTrail
                 else:
                     self.dragMotionTrigger -= 1
@@ -519,11 +521,12 @@ class FitItem(SFItem.SFBrowserItem):
         if self.tcFitName.IsShown():
             self.AdjustControlSizePos(self.tcFitName, self.textStartx, self.toolbarx - self.editWidth - self.padding)
 
-        tdc = wx.MemoryDC()
-        self.dragTLFBmp = wx.Bitmap((self.toolbarx if self.toolbarx < 200 else 200), rect.height, 24)
-        tdc.SelectObject(self.dragTLFBmp)
-        tdc.Blit(0, 0, (self.toolbarx if self.toolbarx < 200 else 200), rect.height, mdc, 0, 0, wx.COPY)
-        tdc.SelectObject(wx.NullBitmap)
+        # TODO: migrate this away from a bitmap
+        #tdc = wx.MemoryDC()
+        #self.dragTLFBmp = wx.Bitmap((self.toolbarx if self.toolbarx < 200 else 200), rect.height, 24)
+        #tdc.SelectObject(self.dragTLFBmp)
+        #tdc.Blit(0, 0, (self.toolbarx if self.toolbarx < 200 else 200), rect.height, mdc, 0, 0, wx.COPY)
+        #tdc.SelectObject(wx.NullBitmap)
 
     def AdjustControlSizePos(self, editCtl, start, end):
         fnEditSize = editCtl.GetSize()

--- a/gui/builtinShipBrowser/fitItem.py
+++ b/gui/builtinShipBrowser/fitItem.py
@@ -195,9 +195,8 @@ class FitItem(SFItem.SFBrowserItem):
             self.dragged = False
             if self.HasCapture():
                 self.ReleaseMouse()
-            # TODO: re-enable this once rendring of drag window is fixed
-            #self.dragWindow.Show(False)
-            #self.dragWindow = None
+            self.dragWindow.Show(False)
+            self.dragWindow = None
 
     def OnContextMenu(self, event):
         """ Handles context menu for fit. Dragging is handled by MouseLeftUp() """
@@ -417,12 +416,18 @@ class FitItem(SFItem.SFBrowserItem):
         if self.dragging:
             if not self.dragged:
                 if self.dragMotionTrigger < 0:
+                    if not self.dragTLFBmp:
+                        tdc = wx.MemoryDC()
+                        self.dragTLFBmp = wx.Bitmap(200, self.GetRect().height)    
+                        tdc.SelectObject(self.dragTLFBmp)
+                        tdc.SetBrush(wx.Brush(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)))
+                        tdc.DrawRectangle(0, 0, 200, self.GetRect().height)
+                        self.DrawItem(tdc)
                     if not self.HasCapture():
                         self.CaptureMouse()
-                    # self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)
-                    # TODO: re-enable this once rendring of drag window is fixed    
-                    #self.dragWindow.Show()
-                    #self.dragged = True
+                    self.dragWindow = PFBitmapFrame(self, pos, self.dragTLFBmp)  
+                    self.dragWindow.Show()
+                    self.dragged = True
                     self.dragMotionTrigger = self.dragMotionTrail
                 else:
                     self.dragMotionTrigger -= 1
@@ -521,12 +526,6 @@ class FitItem(SFItem.SFBrowserItem):
         if self.tcFitName.IsShown():
             self.AdjustControlSizePos(self.tcFitName, self.textStartx, self.toolbarx - self.editWidth - self.padding)
 
-        # TODO: migrate this away from a bitmap
-        #tdc = wx.MemoryDC()
-        #self.dragTLFBmp = wx.Bitmap((self.toolbarx if self.toolbarx < 200 else 200), rect.height, 24)
-        #tdc.SelectObject(self.dragTLFBmp)
-        #tdc.Blit(0, 0, (self.toolbarx if self.toolbarx < 200 else 200), rect.height, mdc, 0, 0, wx.COPY)
-        #tdc.SelectObject(wx.NullBitmap)
 
     def AdjustControlSizePos(self, editCtl, start, end):
         fnEditSize = editCtl.GetSize()

--- a/gui/builtinShipBrowser/fitItem.py
+++ b/gui/builtinShipBrowser/fitItem.py
@@ -418,10 +418,11 @@ class FitItem(SFItem.SFBrowserItem):
                 if self.dragMotionTrigger < 0:
                     if not self.dragTLFBmp:
                         tdc = wx.MemoryDC()
-                        self.dragTLFBmp = wx.Bitmap(200, self.GetRect().height)    
+                        bmpWidth = self.toolbarx if self.toolbarx < 200 else 200
+                        self.dragTLFBmp = wx.Bitmap(bmpWidth, self.GetRect().height)    
                         tdc.SelectObject(self.dragTLFBmp)
                         tdc.SetBrush(wx.Brush(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)))
-                        tdc.DrawRectangle(0, 0, 200, self.GetRect().height)
+                        tdc.DrawRectangle(0, 0, bmpWidth, self.GetRect().height)
                         self.DrawItem(tdc)
                     if not self.HasCapture():
                         self.CaptureMouse()


### PR DESCRIPTION
Copying out of the buffer containing the fit object inside of the draw function causes infinite redraws on macos, moved the functionality outside of the draw function itself 

Tested on M1 mac on Ventura/Sonoma and Windows