### PR TITLE
Improve AutoListCtrl legibility in dark mode

### DIFF
--- a/gui/builtinItemStatsViews/helpers.py
+++ b/gui/builtinItemStatsViews/helpers.py
@@ -10,7 +10,10 @@ class AutoListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.ListRowH
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
         listmix.ListCtrlAutoWidthMixin.__init__(self)
         listmix.ListRowHighlighter.__init__(self)
-
+        if wx.SystemSettings.GetAppearance().IsDark():
+            listcol = wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOX)
+            highlight = listcol.ChangeLightness(110)
+            listmix.ListRowHighlighter.SetHighlightColor(self, highlight)
 
 class AutoListCtrlNoHighlight(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.ListRowHighlighter):
     def __init__(self, parent, ID, pos=wx.DefaultPosition, size=wx.DefaultSize, style=0):


### PR DESCRIPTION
WxWidgets in theory respects system-level dark modes, and most of the components behave in a sane way by default. `listmix.ListRowHighlighter` however mixes SYS_COLOUR_LISTBOX with SYS_COLOUR_HIGHLIGHT, which has a very different effect with dark system colors resulting in half of the rows being illegible with the intended white font. This change manually overrides ListRowHighlighter's highlight colour with a lightened SYS_COLOUR_LISTBOX when in dark mode.

Before:
![image](https://github.com/pyfa-org/Pyfa/assets/32265025/eee97680-6f05-424f-937d-e581bd7b7e22)

After:
<img width="936" alt="image" src="https://github.com/pyfa-org/Pyfa/assets/32265025/227d515b-32d9-4f11-9a42-a14baf9fe4e7">
