### PR TITLE
Prepend Current Fit's Ship and Name to the Window's Title

### DIFF
--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -234,6 +234,9 @@ class MainFrame(wx.Frame):
 
         self.Bind(GE.EVT_SSO_LOGIN, self.onSSOLogin)
 
+        self.Bind(GE.FIT_CHANGED, self.onFitChanged)
+        self.Bind(GE.FIT_RENAMED, self.onFitRenamed)
+
     @property
     def command(self) -> wx.CommandProcessor:
         return Fit.getCommandProcessor(self.getActiveFit())
@@ -996,3 +999,37 @@ class MainFrame(wx.Frame):
         if not wnd:
             wnd = self
         InspectionTool().Show(wnd, True)
+
+    def onFitChanged(self, event):
+        """
+        Triggered by a FIT_CHANGED event (which is posted when the active fit changes)
+        This method updates the windows's title via `_updateTitle()`.
+        """
+        activeFitID = self.getActiveFit()
+        if activeFitID is not None and activeFitID not in event.fitIDs:
+            return
+        self._updateTitle(fitID=activeFitID)
+
+    def onFitRenamed(self, event):
+        """
+        Triggered by a FIT_RENAMED event.
+        This method updates the windows's title via `_updateTitle()` if the current fit is renamed.
+        """
+        if self.getActiveFit() != event.fitID:
+            return
+        self._updateTitle(fitID=event.fitID)
+
+    def _updateTitle(self, fitID):
+        """
+        This method updates the frame's title with information from the fit with ID `fitID`.
+        """
+        fit = Fit.getInstance().getFit(fitID)
+        fitName = fit and fit.name or None
+        shipName = fit and fit.ship.name or None
+
+        newTitle = ""
+        if fitName is not None and shipName is not None:
+            newTitle = f'{shipName} "{fitName}" — {self.title}'
+        else:
+            newTitle = self.title
+        self.SetTitle(newTitle)


### PR DESCRIPTION
When you have multiple fits open, the names of the fits in the tabs get truncated and it's hard to tell which fit is which (especially when looking at different variations of the same fit).

This PR solves the issue by adding extra information to the window's title—the ship and the fit name.

Format is `<ship name> "<fit name>" — <default title>`
`<default title>` is the title, either "pyfa" or "pyfa v1.2.3 - Python Fitting Assistant"

The title is update when the active fit changes (via the tab switcher) or the current fit is renamed.