### PR TITLE
Set up a basic nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716330097,
+        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5710852ba686cc1fd0d3b8e22b3117d43ba374c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Nix Flake for Pyfa";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    {
+      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
+
+      ##### x86_64-linux #####
+      packages.x86_64-linux = {
+        pyfa =
+          let
+            pkgs = import nixpkgs { system = "x86_64-linux"; };
+            name = "pyfa";
+            version = "v2.58.3";
+            src = pkgs.fetchurl {
+              url = "https://github.com/pyfa-org/Pyfa/releases/download/${version}/pyfa-${version}-linux.AppImage";
+              sha256 = "opzZSiVWfJv//KONocL9byZKqX/hWkPU+ssdceUDXh0=";
+            };
+          in
+          pkgs.appimageTools.wrapType2 { inherit name version src; };
+
+        default = self.packages.x86_64-linux.pyfa;
+      };
+      apps.x86_64-linux = {
+        pyfa = {
+          type = "app";
+          program = "${self.packages.x86_64-linux.pyfa}/bin/pyfa";
+        };
+
+        default = self.apps.x86_64-linux.pyfa;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,17 @@
               url = "https://github.com/pyfa-org/Pyfa/releases/download/${version}/pyfa-${version}-linux.AppImage";
               sha256 = "opzZSiVWfJv//KONocL9byZKqX/hWkPU+ssdceUDXh0=";
             };
+            appimageContents = pkgs.appimageTools.extractType2 {inherit name src;};
           in
-          pkgs.appimageTools.wrapType2 { inherit name version src; };
+        pkgs.appimageTools.wrapType2 {
+          inherit name version src;
+          extraInstallCommands = ''
+            install -m 444 -D ${appimageContents}/pyfa.desktop $out/share/applications/pyfa.desktop
+            install -m 444 -D ${appimageContents}/pyfa.png $out/share/icons/hicolor/512x512/apps/pyfa.png
+            substituteInPlace $out/share/applications/pyfa.desktop \
+            --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
+          '';
+        };
 
         default = self.packages.x86_64-linux.pyfa;
       };


### PR DESCRIPTION
This allows for usage of pyfa in on any x86-64 immutable operating system that supports the nix package manager
and allows it to be added to dmenu and the application list