### PR TITLE
Add "Charges For Active Fit" market tree shortcut

### DIFF
--- a/gui/builtinMarketBrowser/events.py
+++ b/gui/builtinMarketBrowser/events.py
@@ -5,3 +5,5 @@ import wx.lib.newevent
 ItemSelected, ITEM_SELECTED = wx.lib.newevent.NewEvent()
 
 RECENTLY_USED_MODULES = -2
+
+CHARGES_FOR_FIT = -3

--- a/gui/builtinMarketBrowser/itemView.py
+++ b/gui/builtinMarketBrowser/itemView.py
@@ -55,7 +55,7 @@ class ItemView(Display):
         self.Bind(wx.EVT_LIST_BEGIN_DRAG, self.startDrag)
 
         # the "charges for active fitting" needs to listen to fitting changes
-        self.mainFrame.Bind(GE.FIT_CHANGED, self.selectedFittingChanged)
+        self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
 
         self.active = []
 
@@ -121,6 +121,9 @@ class ItemView(Display):
             # Set toggle buttons / use search mode flag if recently used modules category is selected (in order to have all modules listed and not filtered)
             if seldata == RECENTLY_USED_MODULES:
                 self.marketBrowser.mode = 'recent'
+            
+            if seldata == CHARGES_FOR_FIT:
+                self.marketBrowser.mode = 'charges'
 
             self.setToggles()
             if context == 'tree' and self.marketBrowser.settings.get('marketMGMarketSelectMode') == 1:
@@ -146,11 +149,14 @@ class ItemView(Display):
                 items.add(charge)
         return items
 
-    def selectedFittingChanged(self, event):
+    def fitChanged(self, event):
         # skip the event so the other handlers also get called
         event.Skip()
-        activeFitID = self.mainFrame.getActiveFit()
 
+        if self.marketBrowser.mode != 'charges':
+            return
+
+        activeFitID = self.mainFrame.getActiveFit()
         # if it was not the active fitting that was changed, do not do anything
         if activeFitID is not None and activeFitID not in event.fitIDs:
             return

--- a/gui/builtinMarketBrowser/marketTree.py
+++ b/gui/builtinMarketBrowser/marketTree.py
@@ -35,7 +35,8 @@ class MarketTree(wx.TreeCtrl):
         # Add recently used modules node
         rumIconId = self.addImage("market_small", "gui")
         self.AppendItem(self.root, _t("Recently Used Items"), rumIconId, data=RECENTLY_USED_MODULES)
-        self.AppendItem(self.root, "Charges For Active Fit", rumIconId, data=CHARGES_FOR_FIT)
+        cffIconId = self.addImage("damagePattern_small", "gui")
+        self.AppendItem(self.root, _t("Charges For Active Fit"), cffIconId, data=CHARGES_FOR_FIT)
 
         # Bind our lookup method to when the tree gets expanded
         self.Bind(wx.EVT_TREE_ITEM_EXPANDING, self.expandLookup)

--- a/gui/builtinMarketBrowser/marketTree.py
+++ b/gui/builtinMarketBrowser/marketTree.py
@@ -35,6 +35,7 @@ class MarketTree(wx.TreeCtrl):
         # Add recently used modules node
         rumIconId = self.addImage("market_small", "gui")
         self.AppendItem(self.root, _t("Recently Used Items"), rumIconId, data=RECENTLY_USED_MODULES)
+        # Add charges for active fitting node
         cffIconId = self.addImage("damagePattern_small", "gui")
         self.AppendItem(self.root, _t("Charges For Active Fit"), cffIconId, data=CHARGES_FOR_FIT)
 

--- a/gui/builtinMarketBrowser/marketTree.py
+++ b/gui/builtinMarketBrowser/marketTree.py
@@ -1,7 +1,7 @@
 import wx
 
 from gui.cachingImageList import CachingImageList
-from gui.builtinMarketBrowser.events import RECENTLY_USED_MODULES
+from gui.builtinMarketBrowser.events import RECENTLY_USED_MODULES, CHARGES_FOR_FIT
 
 from logbook import Logger
 
@@ -35,6 +35,7 @@ class MarketTree(wx.TreeCtrl):
         # Add recently used modules node
         rumIconId = self.addImage("market_small", "gui")
         self.AppendItem(self.root, _t("Recently Used Items"), rumIconId, data=RECENTLY_USED_MODULES)
+        self.AppendItem(self.root, "Charges For Active Fit", rumIconId, data=CHARGES_FOR_FIT)
 
         # Bind our lookup method to when the tree gets expanded
         self.Bind(wx.EVT_TREE_ITEM_EXPANDING, self.expandLookup)

--- a/gui/marketBrowser.py
+++ b/gui/marketBrowser.py
@@ -146,7 +146,7 @@ class MarketBrowser(wx.Panel):
         setting = self.settings.get('marketMGSearchMode')
         # We turn on all meta buttons for the duration of search/recents
         if setting == 1:
-            if newMode in ('search', 'recent'):
+            if newMode in ('search', 'recent', 'charges'):
                 for btn in self.metaButtons:
                     btn.setUserSelection(True)
             if newMode == 'normal':


### PR DESCRIPTION
This pull requests adds a new entry in the market browser tree below "Recently Used Modules": "Charges for Active Fit".

![image](https://github.com/pyfa-org/Pyfa/assets/9085102/072b8d28-bd3a-4607-9d4b-ce2ec9974991)

It lists all charges that can be fitted to a module of the currently open fit tab. It can be used to e.g. quickly creat the needed cargo items. It is inspired by the similiar ingame ghost fitting feature.

I added a new entry, which needs a translation btw, with the same icon as "damage pattern". Benchmarks of the feature resulted in unconclusive results, the calculation of the needed modules took between 2 and 30ms on my machine. Updating the list might be the bottleneck, but I am not sure how it is implemented.

Happy for any feedback, first python / pyfa pull request in a while.