### PR TITLE
Improve font sizes on Linux

### DIFF
--- a/gui/statsPane.py
+++ b/gui/statsPane.py
@@ -85,6 +85,8 @@ class StatsPane(wx.Panel):
 
         if "__WXMAC__" in wx.PlatformInfo:
             self.SetWindowVariant(wx.WINDOW_VARIANT_SMALL)
+        elif "__WXGTK__" in wx.PlatformInfo:
+            self.SetWindowVariant(wx.WINDOW_VARIANT_SMALL)
         else:
             standardFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
             standardFont.SetPointSize(8)

--- a/gui/utils/fonts.py
+++ b/gui/utils/fonts.py
@@ -8,6 +8,8 @@ import wx
 
 if 'wxMac' in wx.PlatformInfo:
     sizes = (10, 11, 12)
+elif 'wxGTK' in wx.PlatformInfo:
+    sizes = (8, 9, 10)
 else:
     sizes = (7, 8, 9)
 


### PR DESCRIPTION
Linux font sizes on the application are all over the place. This makes a small step towards improving that issue.

I may work on a better solution using dynamic sizers from wxPython instead, but this should work as a quick-and-dirty solution for now.