### PR TITLE
Refresh tokens when pyfa start to avoid expiry

### DIFF
--- a/pyfa.py
+++ b/pyfa.py
@@ -150,6 +150,12 @@ if __name__ == "__main__":
         mf = MainFrame(options.title)
         ErrorHandler.SetParent(mf)
 
+        # Start ESI token validation, this helps avoid token expiry
+        from service.esi import Esi
+        esi = Esi.getInstance()
+        esi.startTokenValidation()
+        pyfalog.info("ESI token validation started")
+
         if options.profile_path:
             profile_path = os.path.join(options.profile_path, 'pyfa-{}.profile'.format(datetime.datetime.now().strftime('%Y%m%d_%H%M%S')))
             pyfalog.debug("Starting pyfa with a profiler, saving to {}".format(profile_path))


### PR DESCRIPTION
ESI tokens have two components, accesstokens and refreshtokens. Access tokens expire fast and refreshtokens are supposed to be indefinitely available according to CCP. However, refreshtokens in fact have a lifetime of around 30 days. If they are not accessed within 30days you will have to login again. If you have a lot of characters that are infrequently accessed, it is quite troublesome to have to reauth all of them. 

This PR ensures that refreshtoken will not expire by validating them and forcing use of refreshtoken when pyfa starts in a background thread so that they will be valid indefinitely.