### PR TITLE
Fixed bug with Clipboard on Wayland

### DIFF
--- a/gui/utils/clipboard.py
+++ b/gui/utils/clipboard.py
@@ -1,22 +1,69 @@
 # noinspection PyPackageRequirements
 import wx
+from logbook import Logger
+
+logger = Logger(__name__)
 
 
 def toClipboard(text):
-    clip = wx.TheClipboard
-    clip.Open()
-    data = wx.TextDataObject(text)
-    clip.SetData(data)
-    clip.Close()
+    """
+    Copy text to clipboard. Explicitly uses CLIPBOARD selection, not PRIMARY.
+
+    On X11 systems, wxPython can confuse between PRIMARY and CLIPBOARD selections,
+    causing "already open" errors. This function ensures we always use CLIPBOARD.
+
+    See: https://discuss.wxpython.org/t/wx-theclipboard-pasting-different-content-on-every-second-paste/35361
+    """
+    clipboard = wx.Clipboard()
+    try:
+        # Explicitly use CLIPBOARD selection, not PRIMARY selection
+        # This prevents X11 confusion between the two clipboard types
+        clipboard.UsePrimarySelection(False)
+
+        if clipboard.Open():
+            try:
+                data = wx.TextDataObject(text)
+                clipboard.SetData(data)
+                clipboard.Flush()  # Ensure clipboard manager gets the data
+                return True
+            finally:
+                clipboard.Close()
+        else:
+            logger.debug("Failed to open clipboard for writing")
+            return False
+    except Exception as e:
+        logger.warning("Error writing to clipboard: {}", e)
+        return False
 
 
 def fromClipboard():
-    clip = wx.TheClipboard
-    clip.Open()
-    data = wx.TextDataObject("")
-    if clip.GetData(data):
-        clip.Close()
-        return data.GetText()
-    else:
-        clip.Close()
+    """
+    Read text from clipboard. Explicitly uses CLIPBOARD selection, not PRIMARY.
+
+    On X11 systems, wxPython can confuse between PRIMARY and CLIPBOARD selections,
+    causing "already open" errors. This function ensures we always use CLIPBOARD.
+
+    See: https://discuss.wxpython.org/t/wx-theclipboard-pasting-different-content-on-every-second-paste/35361
+    """
+    clipboard = wx.Clipboard()
+    try:
+        # Explicitly use CLIPBOARD selection, not PRIMARY selection
+        # This prevents X11 confusion between the two clipboard types
+        clipboard.UsePrimarySelection(False)
+
+        if clipboard.Open():
+            try:
+                data = wx.TextDataObject()
+                if clipboard.GetData(data):
+                    return data.GetText()
+                else:
+                    logger.debug("Clipboard open but no CLIPBOARD data available")
+                    return None
+            finally:
+                clipboard.Close()
+        else:
+            logger.debug("Failed to open clipboard for reading")
+            return None
+    except Exception as e:
+        logger.warning("Error reading from clipboard: {}", e)
         return None


### PR DESCRIPTION
There's currently a bug with the Linux release under Wayland where the copy/paste functionality doesn't work. It doesn't reliable access the clipboard as expected, so it'll silently fail to copy _from_ clipboard, and most applications are unable to access things paste _to_ the clipboard.

This PR fixes that by forcing it to use the actual Clipboard instead of Primary. Primary is a neat feature, but the behaviour is inconsistent if your application isn't built with its special usage in mind.

## Testing

I've tested this on Wayland Linux, but I'd suggest double checking it works as expected on Windows and Mac before merging. I'm trying to see if I can get some help with that.