### PR TITLE
Vaults

### DIFF
--- a/_development/helpers.py
+++ b/_development/helpers.py
@@ -92,7 +92,7 @@ def DBInMemory_test():
     return helper
 
 # noinspection PyUnresolvedReferences,PyUnusedLocal
-@pytest.fixture
+@pytest.fixture(name='DB')
 def DBInMemory():
     print("Creating database in memory")
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -1,0 +1,97 @@
+# Writing Tests for Pyfa
+
+Writing tests for Pyfa is fairly simple. Follow these guidelines so tests stay maintainable and failures are easy to track.
+
+Any rule can be broken, but there's a cost. If the cost is too high, the pull request may be rejected until the tests are rewritten.
+
+## Write more tests
+
+Nearly any code outside of the GUI can have tests. If you submit a PR, you are expected to add tests that cover the code in the PR. Sometimes this means writing broader tests, because your PR may only touch a small part of a method.
+
+## One thing per test
+
+Each test should target **one specific behavior**. Avoid lumping multiple behaviors into a single test. That increases run time but makes tests focused and makes it easier to find the root cause when they fail.
+
+- **Good**: Many assert statements that all check one scenario (e.g. all attributes on a fit after adding a single module).
+- **Bad**: Few assert statements spread across many steps (e.g. how a fit changes over time when adding multiple modules).
+
+## Use helper fixtures
+
+Use the existing helper fixtures instead of reimplementing setup. Request them as test parameters so pytest injects them.
+
+To initialize the database and configure Eos:
+
+```python
+def test_example(DB):
+    ...
+```
+
+This gives you a `DB` dictionary. Example: `DB['db'].getItem("Co-Processor II")`.
+
+`Gamedata` and `Saveddata` work the same way. Example – get the "All 0" character:
+
+```python
+char0 = Saveddata['Character'].getAll0()
+```
+
+Available fixtures include: `DB`, `Gamedata`, `Saveddata`, `RifterFit`, `KeepstarFit`, `CurseFit`, `HeronFit`, `StrongBluePillBooster`. Define new ones in `_development/` when you need them.
+
+## Name tests clearly
+
+Test function names must start with `test_` or the test will not run.
+
+Make the rest of the name descriptive. Recommended pattern:
+
+**`test_<method or behavior under test>_<scenario>`**
+
+- Bad: `test_newtest`
+- Good: `test_getFitsWithShip_RifterFit` (we know the function and the scenario)
+
+## Where tests go
+
+Tests are split by purpose:
+
+- **test_modules** – Mirrors the source layout. Low-level, method-specific tests.  
+  If the code lives in `eos.saveddata.fit`, the test file is  
+  `tests/test_modules/test_eos/test_saveddata/test_fit.py`.  
+  Folder names under `test_modules` start with `test_` to avoid shadowing the real packages.
+
+- **test_smoketests** – Higher-level tests that exercise a broad flow (e.g. a fit with a booster and a specific character) without targeting one method. Use this when you want to check that high-level actions work together.
+
+## Clean up after yourself
+
+Tests are not guaranteed to run in a fixed order. Any change to the environment (e.g. saving a fit to the DB) must be reverted before the test ends.
+
+Example: save a fit, assert, then remove it.
+
+```python
+def test_getFitsWithShip_RifterFit(DB, RifterFit):
+    DB['db'].save(RifterFit)
+    assert Fit.getFitsWithShip(587)[0][1] == 'My Rifter Fit'
+    DB['db'].remove(RifterFit)
+```
+
+If several tests need the same setup, use a class to group them and build the environment once.
+
+## Running tests
+
+1. Activate the project virtual environment:
+   - **cmd.exe**: `PyfaEnv\scripts\activate.bat`
+   - **PowerShell**: `PyfaEnv\Scripts\Activate.ps1`
+   - **bash**: `source <venv>/Scripts/activate`
+
+2. Install pytest (if needed):
+   ```bash
+   pip install pytest
+   ```
+
+3. From the project root (the directory containing `pyfa.py`), run:
+   ```bash
+   python -m pytest
+   ```
+   or
+   ```bash
+   py.test
+   ```
+
+To run only a subset of tests, pass a path or pattern, e.g. `python -m pytest tests/test_modules/test_service/`.

--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -118,7 +118,7 @@ from eos.db.gamedata import alphaClones, attribute, category, effect, group, ite
 pyfalog.debug('Importing saveddata DB scheme')
 # noinspection PyPep8
 from eos.db.saveddata import booster, cargo, character, damagePattern, databaseRepair, drone, fighter, fit, implant, implantSet, \
-    miscData, mutatorMod, mutatorDrone, module, override, price, queries, skill, targetProfile, user
+    miscData, mutatorMod, mutatorDrone, module, override, price, queries, skill, targetProfile, user, vault
 
 pyfalog.debug('Importing gamedata queries')
 # noinspection PyPep8

--- a/eos/db/migrations/upgrade50.py
+++ b/eos/db/migrations/upgrade50.py
@@ -1,0 +1,33 @@
+"""
+Migration 50
+
+- Add vaults table and vaultID to fits. All existing fits are assigned to the Default vault.
+"""
+
+import sqlalchemy
+
+
+def upgrade(saveddata_engine):
+    # Create vaults table
+    try:
+        saveddata_engine.execute("SELECT ID FROM vaults LIMIT 1")
+    except sqlalchemy.exc.DatabaseError:
+        saveddata_engine.execute("""
+            CREATE TABLE vaults (
+                "ID" INTEGER NOT NULL PRIMARY KEY,
+                name VARCHAR NOT NULL,
+                "sortOrder" INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        saveddata_engine.execute("INSERT INTO vaults (name, \"sortOrder\") VALUES ('Default', 0)")
+
+    # Add vaultID column to fits
+    try:
+        saveddata_engine.execute("SELECT vaultID FROM fits LIMIT 1")
+    except sqlalchemy.exc.DatabaseError:
+        saveddata_engine.execute("ALTER TABLE fits ADD COLUMN vaultID INTEGER REFERENCES vaults(ID)")
+
+    # Assign every existing fit to the default vault so no data is lost
+    saveddata_engine.execute(
+        "UPDATE fits SET vaultID = (SELECT ID FROM vaults LIMIT 1) WHERE vaultID IS NULL"
+    )

--- a/eos/db/saveddata/__init__.py
+++ b/eos/db/saveddata/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "character",
     "fit",
     "mutatorMod",
+    "vault",
     "mutatorDrone",
     "module",
     "user",

--- a/eos/db/saveddata/fit.py
+++ b/eos/db/saveddata/fit.py
@@ -43,6 +43,7 @@ from eos.saveddata.implant import Implant
 from eos.saveddata.module import Module
 from eos.saveddata.targetProfile import TargetProfile
 from eos.saveddata.user import User
+from eos.saveddata.vault import Vault
 
 
 fits_table = Table("fits", saveddata_meta,
@@ -65,6 +66,7 @@ fits_table = Table("fits", saveddata_meta,
                    Column("modified", DateTime, nullable=True, default=datetime.datetime.now, onupdate=datetime.datetime.now),
                    Column("systemSecurity", Integer, nullable=True),
                    Column("pilotSecurity", Float, nullable=True),
+                   Column("vaultID", ForeignKey("vaults.ID"), nullable=True, index=True),
                    )
 
 projectedFits_table = Table("projectedFits", saveddata_meta,
@@ -240,6 +242,7 @@ mapper(es_Fit, fits_table,
            "_Fit__builtinDamagePatternID": fits_table.c.builtinDamagePatternID,
            "_Fit__userTargetProfile": relation(TargetProfile),
            "_Fit__builtinTargetProfileID": fits_table.c.builtinTargetResistsID,
+           "_Fit__vault": relation(Vault, backref="fits"),
            "projectedOnto": projectedFitSourceRel,
            "victimOf": relationship(
                    ProjectedFit,

--- a/eos/db/saveddata/vault.py
+++ b/eos/db/saveddata/vault.py
@@ -1,0 +1,34 @@
+# ===============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of eos.
+#
+# eos is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# eos is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with eos.  If not, see <http://www.gnu.org/licenses/>.
+# ===============================================================================
+
+from sqlalchemy import Column, Integer, String, Table
+from sqlalchemy.orm import mapper
+
+from eos.db import saveddata_meta
+from eos.saveddata.vault import Vault
+
+vaults_table = Table(
+    "vaults",
+    saveddata_meta,
+    Column("ID", Integer, primary_key=True),
+    Column("name", String, nullable=False),
+    Column("sortOrder", Integer, nullable=False, default=0),
+)
+
+mapper(Vault, vaults_table)

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -263,6 +263,19 @@ class Fit:
         self.__character = char
 
     @property
+    def vault(self):
+        return getattr(self, '_Fit__vault', None)
+
+    @vault.setter
+    def vault(self, v):
+        if hasattr(self, '_Fit__vault'):
+            object.__setattr__(self, '_Fit__vault', v)
+        if v is not None:
+            self.vaultID = v.ID
+        else:
+            self.vaultID = None
+
+    @property
     def calculated(self):
         return self.__calculated
 

--- a/eos/saveddata/vault.py
+++ b/eos/saveddata/vault.py
@@ -1,0 +1,29 @@
+# ===============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of eos.
+#
+# eos is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# eos is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with eos.  If not, see <http://www.gnu.org/licenses/>.
+# ===============================================================================
+
+
+class Vault:
+    """Named container for groupings of fittings (e.g. PvP, Exploration, ESI imports)."""
+
+    def __init__(self, name="", sortOrder=0):
+        self.name = name
+        self.sortOrder = sortOrder
+
+    def __repr__(self):
+        return "Vault(ID={}, name={!r})".format(getattr(self, 'ID', None), self.name)

--- a/gui/ammoBreakdown/__init__.py
+++ b/gui/ammoBreakdown/__init__.py
@@ -1,0 +1,20 @@
+# =============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================
+
+from .frame import AmmoBreakdownFrame

--- a/gui/ammoBreakdown/frame.py
+++ b/gui/ammoBreakdown/frame.py
@@ -1,0 +1,156 @@
+# =============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================
+
+import csv
+# noinspection PyPackageRequirements
+import wx
+
+import gui.globalEvents as GE
+import gui.mainFrame
+from gui.auxWindow import AuxiliaryFrame
+from service.ammoBreakdown import get_ammo_breakdown
+from service.fit import Fit
+
+_t = wx.GetTranslation
+
+COL_AMMO_NAME = 0
+COL_OPTIMAL = 1
+COL_FALLOFF = 2
+COL_ALPHA = 3
+COL_DPS = 4
+
+
+class AmmoBreakdownFrame(AuxiliaryFrame):
+
+    def __init__(self, parent):
+        super().__init__(parent, title=_t('Ammo Breakdown'), size=(640, 400), resizeable=True)
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+        self._data = []
+
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.listCtrl = wx.ListCtrl(
+            self, wx.ID_ANY,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN
+        )
+        self.listCtrl.AppendColumn(_t('Ammo Name'), wx.LIST_FORMAT_LEFT, 180)
+        self.listCtrl.AppendColumn(_t('Optimal'), wx.LIST_FORMAT_LEFT, 120)
+        self.listCtrl.AppendColumn(_t('Falloff'), wx.LIST_FORMAT_LEFT, 120)
+        self.listCtrl.AppendColumn(_t('Alpha'), wx.LIST_FORMAT_RIGHT, 90)
+        self.listCtrl.AppendColumn(_t('DPS'), wx.LIST_FORMAT_RIGHT, 90)
+        mainSizer.Add(self.listCtrl, 1, wx.EXPAND | wx.ALL, 5)
+
+        self.emptyLabel = wx.StaticText(self, wx.ID_ANY, _t('No ammo in cargo usable by fitted weapons.'))
+        self.emptyLabel.Hide()
+        mainSizer.Add(self.emptyLabel, 0, wx.ALL, 10)
+
+        btnSizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.exportBtn = wx.Button(self, wx.ID_ANY, _t('Export…'))
+        self.exportBtn.Bind(wx.EVT_BUTTON, self.OnExport)
+        btnSizer.Add(self.exportBtn, 0, wx.RIGHT, 5)
+        self.copyBtn = wx.Button(self, wx.ID_ANY, _t('Copy to clipboard'))
+        self.copyBtn.Bind(wx.EVT_BUTTON, self.OnCopyToClipboard)
+        btnSizer.Add(self.copyBtn, 0)
+        mainSizer.Add(btnSizer, 0, wx.ALL, 5)
+
+        self.SetSizer(mainSizer)
+
+        self.mainFrame.Bind(GE.FIT_CHANGED, self.OnFitChanged)
+        self.Bind(wx.EVT_CLOSE, self.OnClose)
+
+        self.refresh()
+
+    def _get_fit(self):
+        fitID = self.mainFrame.getActiveFit()
+        if fitID is None:
+            return None
+        return Fit.getInstance().getFit(fitID)
+
+    def refresh(self):
+        fit = self._get_fit()
+        self._data = get_ammo_breakdown(fit) if fit else []
+        self.listCtrl.DeleteAllItems()
+        if not self._data:
+            self.listCtrl.Hide()
+            self.emptyLabel.Show()
+            self.exportBtn.Enable(False)
+            self.copyBtn.Enable(False)
+        else:
+            self.emptyLabel.Hide()
+            self.listCtrl.Show()
+            for row in self._data:
+                idx = self.listCtrl.InsertItem(self.listCtrl.GetItemCount(), row['ammoName'])
+                self.listCtrl.SetItem(idx, COL_OPTIMAL, row['optimal'])
+                self.listCtrl.SetItem(idx, COL_FALLOFF, row['falloff'])
+                self.listCtrl.SetItem(idx, COL_ALPHA, '{:.1f}'.format(row['alpha']))
+                self.listCtrl.SetItem(idx, COL_DPS, '{:.1f}'.format(row['dps']))
+            self.exportBtn.Enable(True)
+            self.copyBtn.Enable(True)
+        self.Layout()
+
+    def OnFitChanged(self, event):
+        event.Skip()
+        self.refresh()
+
+    def OnClose(self, event):
+        self.mainFrame.Unbind(GE.FIT_CHANGED, handler=self.OnFitChanged)
+        event.Skip()
+
+    def _get_csv_content(self):
+        lines = []
+        lines.append([_t('Ammo Name'), _t('Optimal'), _t('Falloff'), _t('Alpha'), _t('DPS')])
+        for row in self._data:
+            lines.append([
+                row['ammoName'],
+                row['optimal'],
+                row['falloff'],
+                '{:.1f}'.format(row['alpha']),
+                '{:.1f}'.format(row['dps']),
+            ])
+        return lines
+
+    def OnExport(self, event):
+        if not self._data:
+            return
+        fit = self._get_fit()
+        defaultFile = 'ammo_breakdown.csv'
+        if fit and fit.ship and fit.ship.item:
+            defaultFile = '{} - ammo_breakdown.csv'.format(fit.ship.item.name.replace('/', '-'))
+        with wx.FileDialog(
+                self, _t('Export ammo breakdown'), '', defaultFile,
+                _t('CSV files') + ' (*.csv)|*.csv', wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
+        ) as dlg:
+            if dlg.ShowModal() != wx.ID_OK:
+                return
+            path = dlg.GetPath()
+        with open(path, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f, delimiter=',')
+            for line in self._get_csv_content():
+                writer.writerow(line)
+        event.Skip()
+
+    def OnCopyToClipboard(self, event):
+        if not self._data:
+            return
+        lines = self._get_csv_content()
+        text = '\n'.join(','.join(str(c) for c in row) for row in lines)
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(wx.TextDataObject(text))
+            wx.TheClipboard.Close()
+        event.Skip()

--- a/gui/ammoBreakdown/frame.py
+++ b/gui/ammoBreakdown/frame.py
@@ -30,10 +30,11 @@ from service.fit import Fit
 _t = wx.GetTranslation
 
 COL_AMMO_NAME = 0
-COL_OPTIMAL = 1
-COL_FALLOFF = 2
-COL_ALPHA = 3
-COL_DPS = 4
+COL_DAMAGE_TYPE = 1
+COL_OPTIMAL = 2
+COL_FALLOFF = 3
+COL_ALPHA = 4
+COL_DPS = 5
 
 
 class AmmoBreakdownFrame(AuxiliaryFrame):
@@ -50,6 +51,7 @@ class AmmoBreakdownFrame(AuxiliaryFrame):
             style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SUNKEN
         )
         self.listCtrl.AppendColumn(_t('Ammo Name'), wx.LIST_FORMAT_LEFT, 180)
+        self.listCtrl.AppendColumn(_t('Damage Type'), wx.LIST_FORMAT_LEFT, 110)
         self.listCtrl.AppendColumn(_t('Optimal'), wx.LIST_FORMAT_LEFT, 120)
         self.listCtrl.AppendColumn(_t('Falloff'), wx.LIST_FORMAT_LEFT, 120)
         self.listCtrl.AppendColumn(_t('Alpha'), wx.LIST_FORMAT_RIGHT, 90)
@@ -96,6 +98,7 @@ class AmmoBreakdownFrame(AuxiliaryFrame):
             self.listCtrl.Show()
             for row in self._data:
                 idx = self.listCtrl.InsertItem(self.listCtrl.GetItemCount(), row['ammoName'])
+                self.listCtrl.SetItem(idx, COL_DAMAGE_TYPE, row['damageType'])
                 self.listCtrl.SetItem(idx, COL_OPTIMAL, row['optimal'])
                 self.listCtrl.SetItem(idx, COL_FALLOFF, row['falloff'])
                 self.listCtrl.SetItem(idx, COL_ALPHA, '{:.1f}'.format(row['alpha']))
@@ -114,10 +117,11 @@ class AmmoBreakdownFrame(AuxiliaryFrame):
 
     def _get_csv_content(self):
         lines = []
-        lines.append([_t('Ammo Name'), _t('Optimal'), _t('Falloff'), _t('Alpha'), _t('DPS')])
+        lines.append([_t('Ammo Name'), _t('Damage Type'), _t('Optimal'), _t('Falloff'), _t('Alpha'), _t('DPS')])
         for row in self._data:
             lines.append([
                 row['ammoName'],
+                row['damageType'],
                 row['optimal'],
                 row['falloff'],
                 '{:.1f}'.format(row['alpha']),

--- a/gui/builtinShipBrowser/navigationPanel.py
+++ b/gui/builtinShipBrowser/navigationPanel.py
@@ -260,9 +260,10 @@ class NavigationPanel(SFItem.SFBrowserItem):
 
         self.bkBitmap = drawUtils.RenderGradientBar(windowColor, rect.width, rect.height, sFactor, eFactor, mFactor, 2)
 
-        self.bkBitmap.sFactor = sFactor
-        self.bkBitmap.eFactor = eFactor
-        self.bkBitmap.mFactor = mFactor
+        if self.bkBitmap is not None:
+            self.bkBitmap.sFactor = sFactor
+            self.bkBitmap.eFactor = eFactor
+            self.bkBitmap.mFactor = mFactor
 
     def gotoStage(self, stage, data=None):
         self.shipBrowser.recentFits = False

--- a/gui/builtinShipBrowser/sfBrowserItem.py
+++ b/gui/builtinShipBrowser/sfBrowserItem.py
@@ -286,7 +286,8 @@ class SFBrowserItem(wx.Window):
 
         self.RenderBackground()
 
-        mdc.DrawBitmap(self.bkBitmap, 0, 0)
+        if self.bkBitmap is not None:
+            mdc.DrawBitmap(self.bkBitmap, 0, 0)
 
         self.DrawItem(mdc)
         self.toolbar.Render(mdc)

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -38,6 +38,7 @@ import gui.globalEvents as GE
 from eos.config import gamedata_date, gamedata_version
 from eos.modifiedAttributeDict import ModifiedAttributeDict
 from graphs import GraphFrame
+from gui.ammoBreakdown import AmmoBreakdownFrame
 from gui.additionsPane import AdditionsPane
 from gui.bitmap_loader import BitmapLoader
 from gui.builtinMarketBrowser.events import ItemSelected
@@ -434,6 +435,9 @@ class MainFrame(wx.Frame):
     def OnShowGraphFrame(self, event):
         GraphFrame.openOne(self)
 
+    def OnShowAmmoBreakdownFrame(self, event):
+        AmmoBreakdownFrame.openOne(self)
+
     def OnShowGraphFrameHidden(self, event):
         GraphFrame.openOne(self, includeHidden=True)
 
@@ -566,6 +570,7 @@ class MainFrame(wx.Frame):
         # Graphs
         self.Bind(wx.EVT_MENU, self.OnShowGraphFrame, id=menuBar.graphFrameId)
         self.Bind(wx.EVT_MENU, self.OnShowGraphFrameHidden, id=self.hiddenGraphsId)
+        self.Bind(wx.EVT_MENU, self.OnShowAmmoBreakdownFrame, id=menuBar.ammoBreakdownFrameId)
 
         toggleSearchBoxId = wx.NewId()
         toggleShipMarketId = wx.NewId()

--- a/gui/mainMenuBar.py
+++ b/gui/mainMenuBar.py
@@ -40,6 +40,7 @@ class MainMenuBar(wx.MenuBar):
         self.targetProfileEditorId = wx.NewId()
         self.implantSetEditorId = wx.NewId()
         self.graphFrameId = wx.NewId()
+        self.ammoBreakdownFrameId = wx.NewId()
         self.backupFitsId = wx.NewId()
         self.exportSkillsNeededId = wx.NewId()
         self.importCharacterId = wx.NewId()
@@ -93,6 +94,8 @@ class MainMenuBar(wx.MenuBar):
 
         fitMenu.AppendSeparator()
         fitMenu.Append(self.optimizeFitPrice, _t("&Optimize Fit Price") + "\tCTRL+D")
+        fitMenu.Append(self.ammoBreakdownFrameId, _t("Ammo Break&down"), _t("Cargo ammo stats and export"))
+        self.Enable(self.ammoBreakdownFrameId, False)
         graphFrameItem = wx.MenuItem(fitMenu, self.graphFrameId, _t("&Graphs") + "\tCTRL+G")
         graphFrameItem.SetBitmap(BitmapLoader.getBitmap("graphs_small", "gui"))
         fitMenu.Append(graphFrameItem)
@@ -191,6 +194,7 @@ class MainMenuBar(wx.MenuBar):
         self.Enable(self.revertCharId, char.isDirty)
 
         self.Enable(self.toggleIgnoreRestrictionID, enable)
+        self.Enable(self.ammoBreakdownFrameId, enable)
 
         if activeFitID:
             sFit = Fit.getInstance()

--- a/locale/lang.pot
+++ b/locale/lang.pot
@@ -93,6 +93,14 @@ msgstr ""
 msgid "&Global"
 msgstr ""
 
+#: gui/mainMenuBar.py:97
+msgid "Ammo Break&down"
+msgstr ""
+
+#: gui/mainMenuBar.py:97
+msgid "Cargo ammo stats and export"
+msgstr ""
+
 #: gui/mainMenuBar.py:96
 msgid "&Graphs"
 msgstr ""
@@ -1754,6 +1762,46 @@ msgstr ""
 
 #: gui/mainFrame.py:832
 msgid "Exporting skills needed..."
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Ammo Breakdown"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Ammo Name"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Optimal"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Falloff"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Alpha"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "DPS"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "No ammo in cargo usable by fitted weapons."
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Export…"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Copy to clipboard"
+msgstr ""
+
+#: gui/ammoBreakdown/frame.py
+msgid "Export ammo breakdown"
 msgstr ""
 
 #: gui/builtinPreferenceViews/pyfaGeneralPreferences.py:160

--- a/service/ammoBreakdown.py
+++ b/service/ammoBreakdown.py
@@ -58,7 +58,7 @@ def get_ammo_breakdown(fit):
     """
     if fit is None:
         return []
-    default_spool = eos.config.settings.get('globalDefaultSpoolupPercentage', 1.0)
+    default_spool = eos.config.settings['globalDefaultSpoolupPercentage'] or 1.0
     spool_opts = SpoolOptions(SpoolType.SPOOL_SCALE, default_spool, False)
 
     ammo_items = get_ammo_in_cargo_usable_by_weapons(fit)

--- a/service/ammoBreakdown.py
+++ b/service/ammoBreakdown.py
@@ -23,6 +23,27 @@ from eos.utils.stats import DmgTypes
 from service.fit import Fit
 
 
+def _damage_type_string(volley):
+    """
+    Return primary damage type, or "Primary / Secondary" if secondary > 0.
+    Returns "—" if all four damage types are 0.
+    """
+    ordered = [
+        (volley.em, 'EM'),
+        (volley.thermal, 'Thermal'),
+        (volley.kinetic, 'Kinetic'),
+        (volley.explosive, 'Explosive'),
+    ]
+    ordered.sort(key=lambda x: x[0], reverse=True)
+    primary = ordered[0]
+    if primary[0] <= 0:
+        return "—"
+    secondary = ordered[1]
+    if secondary[0] <= 0:
+        return primary[1]
+    return "{} / {}".format(primary[1], secondary[1])
+
+
 def get_ammo_in_cargo_usable_by_weapons(fit):
     """
     Return set of charge items that are in fit.cargo and can be used by at least
@@ -53,7 +74,7 @@ def get_ammo_breakdown(fit):
     aggregated DPS, Alpha (volley), Optimal, and Falloff assuming all such
     weapons are loaded with that ammo.
 
-    Returns a list of dicts with keys: ammoName, optimal, falloff, alpha, dps.
+    Returns a list of dicts with keys: ammoName, damageType, optimal, falloff, alpha, dps.
     optimal/falloff may be strings (e.g. "12.5 – 18.2 km") or "—" for N/A.
     alpha and dps are floats (total).
     """
@@ -130,6 +151,7 @@ def get_ammo_breakdown(fit):
 
         result.append({
             'ammoName': charge.name,
+            'damageType': _damage_type_string(total_volley),
             'optimal': optimal_str,
             'falloff': falloff_str,
             'alpha': alpha,

--- a/service/ammoBreakdown.py
+++ b/service/ammoBreakdown.py
@@ -20,6 +20,7 @@
 import eos.config
 from eos.utils.spoolSupport import SpoolOptions, SpoolType
 from eos.utils.stats import DmgTypes
+from service.fit import Fit
 
 
 def get_ammo_in_cargo_usable_by_weapons(fit):
@@ -89,6 +90,8 @@ def get_ammo_breakdown(fit):
         try:
             for m in mods:
                 m.charge = charge
+            fit.calculated = False
+            fit.calculateModifiedAttributes()
             total_dps = DmgTypes.default()
             total_volley = DmgTypes.default()
             optimals = []
@@ -134,4 +137,6 @@ def get_ammo_breakdown(fit):
         })
     # Sort by ammo name
     result.sort(key=lambda r: r['ammoName'])
+    if result:
+        Fit.getInstance().recalc(fit)
     return result

--- a/service/ammoBreakdown.py
+++ b/service/ammoBreakdown.py
@@ -1,0 +1,137 @@
+# =============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================
+
+import eos.config
+from eos.utils.spoolSupport import SpoolOptions, SpoolType
+from eos.utils.stats import DmgTypes
+
+
+def get_ammo_in_cargo_usable_by_weapons(fit):
+    """
+    Return set of charge items that are in fit.cargo and can be used by at least
+    one turret or launcher on the fit.
+    """
+    if fit is None:
+        return set()
+    cargo_item_ids = {c.itemID for c in fit.cargo if c.item is not None and getattr(c.item, 'isCharge', False)}
+    if not cargo_item_ids:
+        return set()
+    usable = set()
+    for mod in fit.modules:
+        if not mod.canDealDamage():
+            continue
+        try:
+            valid = mod.getValidCharges()
+        except Exception:
+            continue
+        for charge in valid:
+            if charge.ID in cargo_item_ids:
+                usable.add(charge)
+    return usable
+
+
+def get_ammo_breakdown(fit):
+    """
+    For each ammo type in cargo that at least one weapon can use, compute
+    aggregated DPS, Alpha (volley), Optimal, and Falloff assuming all such
+    weapons are loaded with that ammo.
+
+    Returns a list of dicts with keys: ammoName, optimal, falloff, alpha, dps.
+    optimal/falloff may be strings (e.g. "12.5 – 18.2 km") or "—" for N/A.
+    alpha and dps are floats (total).
+    """
+    if fit is None:
+        return []
+    default_spool = eos.config.settings.get('globalDefaultSpoolupPercentage', 1.0)
+    spool_opts = SpoolOptions(SpoolType.SPOOL_SCALE, default_spool, False)
+
+    ammo_items = get_ammo_in_cargo_usable_by_weapons(fit)
+    if not ammo_items:
+        return []
+
+    # Modules that can use each charge (by charge ID)
+    charge_id_to_mods = {}
+    for mod in fit.modules:
+        if not mod.canDealDamage():
+            continue
+        try:
+            valid = mod.getValidCharges()
+        except Exception:
+            continue
+        for charge in valid:
+            if charge in ammo_items:
+                charge_id_to_mods.setdefault(charge.ID, []).append(mod)
+
+    result = []
+    for charge in ammo_items:
+        mods = charge_id_to_mods.get(charge.ID, [])
+        if not mods:
+            continue
+
+        # Save and restore charges
+        saved_charges = [(m, m.charge) for m in mods]
+        try:
+            for m in mods:
+                m.charge = charge
+            total_dps = DmgTypes.default()
+            total_volley = DmgTypes.default()
+            optimals = []
+            falloffs = []
+            for m in mods:
+                total_dps += m.getDps(spoolOptions=spool_opts)
+                total_volley += m.getVolley(spoolOptions=spool_opts)
+                try:
+                    r = m.maxRange
+                    if r is not None:
+                        optimals.append(r)
+                except Exception:
+                    pass
+                try:
+                    f = m.falloff
+                    if f is not None:
+                        falloffs.append(f)
+                except Exception:
+                    pass
+        finally:
+            for m, ch in saved_charges:
+                m.charge = ch
+
+        alpha = total_volley.total
+        dps = total_dps.total
+        if optimals:
+            opt_min, opt_max = min(optimals), max(optimals)
+            optimal_str = "{:.1f} – {:.1f} km".format(opt_min / 1000, opt_max / 1000) if opt_min != opt_max else "{:.1f} km".format(opt_min / 1000)
+        else:
+            optimal_str = "—"
+        if falloffs:
+            f_min, f_max = min(falloffs), max(falloffs)
+            falloff_str = "{:.1f} – {:.1f} km".format(f_min / 1000, f_max / 1000) if f_min != f_max else "{:.1f} km".format(f_min / 1000)
+        else:
+            falloff_str = "—"
+
+        result.append({
+            'ammoName': charge.name,
+            'optimal': optimal_str,
+            'falloff': falloff_str,
+            'alpha': alpha,
+            'dps': dps,
+        })
+    # Sort by ammo name
+    result.sort(key=lambda r: r['ammoName'])
+    return result

--- a/service/port/port.py
+++ b/service/port/port.py
@@ -31,6 +31,7 @@ from logbook import Logger
 from eos import db
 from eos.const import ImplantLocation
 from service.fit import Fit as svcFit
+from service.vault import Vault as VaultService
 from service.port.dna import exportDna, importDna, importDnaAlt
 from service.port.eft import (
     exportEft, importEft, importEftCfg,
@@ -168,6 +169,9 @@ class Port:
                 else:
                     useCharImplants = sFit.serviceFittingOptions["useCharacterImplantsByDefault"]
                     fit.implantLocation = ImplantLocation.CHARACTER if useCharImplants else ImplantLocation.FIT
+                current_vault_id = VaultService.getInstance().getCurrentVaultID()
+                if current_vault_id is not None:
+                    fit.vaultID = current_vault_id
                 db.save(fit)
                 # IDs.append(fit.ID)
                 if progress:
@@ -207,6 +211,9 @@ class Port:
                 else:
                     useCharImplants = sFit.serviceFittingOptions["useCharacterImplantsByDefault"]
                     fit.implantLocation = ImplantLocation.CHARACTER if useCharImplants else ImplantLocation.FIT
+                current_vault_id = VaultService.getInstance().getCurrentVaultID()
+                if current_vault_id is not None:
+                    fit.vaultID = current_vault_id
                 db.save(fit)
         return importType, importData
 

--- a/service/vault.py
+++ b/service/vault.py
@@ -1,0 +1,95 @@
+# =============================================================================
+# Copyright (C) 2010 Diego Duclos
+#
+# This file is part of pyfa.
+#
+# pyfa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyfa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyfa.  If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================
+
+from logbook import Logger
+
+import eos.db
+from service.settings import SettingsProvider
+
+pyfalog = Logger(__name__)
+
+SETTINGS_KEY = "pyfaCurrentVault"
+DEFAULT_SETTINGS = {"vaultID": None}
+
+
+class Vault:
+    instance = None
+
+    @classmethod
+    def getInstance(cls):
+        if cls.instance is None:
+            cls.instance = Vault()
+        return cls.instance
+
+    def __init__(self):
+        self._settings = SettingsProvider.getInstance()
+
+    def getVaultList(self):
+        """Return all vaults ordered by sortOrder, then A-Z by name."""
+        return eos.db.getVaultList()
+
+    def getCurrentVaultID(self):
+        """Return current vault ID from settings. If not set, use first vault (Default)."""
+        s = self._settings.getSettings(SETTINGS_KEY, DEFAULT_SETTINGS)
+        vid = s["vaultID"]
+        if vid is not None:
+            return vid
+        vaults = eos.db.getVaultList()
+        if not vaults:
+            return None
+        default_id = vaults[0].ID
+        self.setCurrentVaultID(default_id)
+        return default_id
+
+    def setCurrentVaultID(self, vaultID):
+        s = self._settings.getSettings(SETTINGS_KEY, DEFAULT_SETTINGS)
+        s["vaultID"] = vaultID
+        s.save()
+
+    def getVault(self, vaultID):
+        return eos.db.getVault(vaultID)
+
+    def countFitsInVault(self, vaultID):
+        return eos.db.countFitsInVault(vaultID)
+
+    def createVault(self, name):
+        return eos.db.createVault(name)
+
+    def renameVault(self, vaultID, name):
+        eos.db.renameVault(vaultID, name)
+
+    def deleteVault(self, vaultID):
+        """Move fits to another vault, then delete. Cannot delete the last remaining vault."""
+        vaults = eos.db.getVaultList()
+        if len(vaults) <= 1:
+            return
+        default_id = next((v.ID for v in vaults if v.ID != vaultID), None)
+        if default_id is None:
+            return
+        current = self.getCurrentVaultID()
+        eos.db.deleteVault(vaultID, default_id)
+        if current == vaultID:
+            self.setCurrentVaultID(default_id)
+
+    def moveFitToVault(self, fitID, vaultID):
+        eos.db.moveFitToVault(fitID, vaultID)
+
+    def reorderVaults(self, vault_ids_in_order):
+        """Persist vault order. vault_ids_in_order is list of vault IDs in display order."""
+        eos.db.updateVaultSortOrder(vault_ids_in_order)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# Load fixtures from _development for use by all tests
+pytest_plugins = [
+    '_development.helpers',
+    '_development.helpers_fits',
+    '_development.helpers_items',
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""
+Pytest configuration for Pyfa tests.
+Ensures project root and _development are on sys.path and exposes shared fixtures.
+Tests can request DB, Gamedata, Saveddata, RifterFit, KeepstarFit, etc. by name.
+"""
+import os
+import sys
+
+# Project root = parent of tests/ (so _development can be imported)
+_root = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+
+# Register fixtures from _development (DBInMemory, Gamedata, Saveddata, fit and item fixtures)
+pytest_plugins = [
+    '_development.helpers',
+    '_development.helpers_fits',
+    '_development.helpers_items',
+]
+
+import pytest
+
+
+@pytest.fixture
+def DB(DBInMemory):
+    """Alias for DBInMemory so tests can request 'DB' by name."""
+    return DBInMemory

--- a/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
+++ b/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
@@ -9,9 +9,10 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..', '..')))
 
 # noinspection PyPackageRequirements
+import pytest
 
 
-def test_calculateModifiedAttributes(DB, RifterFit, KeepstarFit):
+def test_calculateModifiedAttributes_Rifter(DB, RifterFit):
     rifter_modifier_dicts = {
         '_ModifiedAttributeDict__affectedBy'          : 26,
         '_ModifiedAttributeDict__forced'              : 0,
@@ -34,7 +35,10 @@ def test_calculateModifiedAttributes(DB, RifterFit, KeepstarFit):
     for test_dict in rifter_modifier_dicts:
         assert len(getattr(RifterFit.ship.itemModifiedAttributes, test_dict)) == rifter_modifier_dicts[test_dict]
 
-    # Keepstars don't have any basic skills that would change their attributes
+
+@pytest.mark.skip(reason="Needs rewrite to not depend on DB; was disabled with assert 1==1.")
+def test_calculateModifiedAttributes_Keepstar(DB, KeepstarFit):
+    """Keepstars: no basic skills that would change their attributes. Disabled until rewritten."""
     keepstar_modifier_dicts = {
         '_ModifiedAttributeDict__affectedBy'          : 0,
         '_ModifiedAttributeDict__forced'              : 0,
@@ -47,19 +51,14 @@ def test_calculateModifiedAttributes(DB, RifterFit, KeepstarFit):
         '_ModifiedAttributeDict__preAssigns'          : 0,
         '_ModifiedAttributeDict__preIncreases'        : 0,
     }
-
-    # quick hack to disable test. Need to rewrite ttests to not point to the DB
-    assert 1==1
-    return
-    # Test before calculating attributes
     for test_dict in keepstar_modifier_dicts:
         assert len(getattr(KeepstarFit.ship.itemModifiedAttributes, test_dict)) == 0
-
     KeepstarFit.calculateModifiedAttributes()
-
     for test_dict in keepstar_modifier_dicts:
         assert len(getattr(KeepstarFit.ship.itemModifiedAttributes, test_dict)) == keepstar_modifier_dicts[test_dict]
 
+
+@pytest.mark.skip(reason="Projections not working correctly; TODO rewrite. Was disabled with assert 1==1.")
 def test_calculateModifiedAttributes_withProjected(DB, RifterFit, HeronFit):
     # TODO: This test is not currently functional or meaningful as projections are not happening correctly.
     # This is true for all tested branches (master, dev, etc)
@@ -75,10 +74,6 @@ def test_calculateModifiedAttributes_withProjected(DB, RifterFit, HeronFit):
         '_ModifiedAttributeDict__preAssigns'          : 0,
         '_ModifiedAttributeDict__preIncreases'        : 4,
     }
-
-    # quick hack to disable test. Need to rewrite ttests to not point to the DB
-    assert 1==1
-    return
 
     # Test before calculating attributes
     for test_dict in rifter_modifier_dicts:

--- a/tests/test_modules/test_service/test_ammoBreakdown.py
+++ b/tests/test_modules/test_service/test_ammoBreakdown.py
@@ -1,0 +1,202 @@
+# Add root folder to python paths
+# This must be done on every test in order to pass in Travis
+import os
+import sys
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys._called_from_test = True  # need db open for tests (see eos/config.py)
+
+# This import is here to hack around circular import issues
+import pytest
+import gui.mainFrame
+# noinspection PyPackageRequirements
+from eos.saveddata.cargo import Cargo
+from service.ammoBreakdown import get_ammo_in_cargo_usable_by_weapons, get_ammo_breakdown
+
+
+# noinspection PyShadowingNames
+@pytest.fixture
+def RifterWithProjectileAmmo():
+    """Rifter fit with 200mm Autocannon IIs and projectile ammo (EMP S, Fusion S) in cargo."""
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter - AC Test]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+
+EMP S x500
+Fusion S x500
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    return fit
+
+
+# ---- get_ammo_in_cargo_usable_by_weapons ----
+
+def test_get_ammo_in_cargo_usable_by_weapons_NoneFit():
+    assert get_ammo_in_cargo_usable_by_weapons(None) == set()
+
+
+def test_get_ammo_in_cargo_usable_by_weapons_EmptyCargo():
+    from service.port import Port
+    eft_lines = """[Rifter, Empty Rifter]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    fit.cargo.clear()  # Remove any cargo from imported fit
+    assert get_ammo_in_cargo_usable_by_weapons(fit) == set()
+
+
+def test_get_ammo_in_cargo_usable_by_weapons_NoWeapons():
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter No Guns]
+
+EMP S x500
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    fit.modules.clear()  # Remove any modules
+    assert get_ammo_in_cargo_usable_by_weapons(fit) == set()
+
+
+def test_get_ammo_in_cargo_usable_by_weapons_AmmoNotUsable():
+    from service.port import Port
+    import eos.db
+    eft_lines = """[Rifter, Rifter Wrong Ammo]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+
+Multifrequency S x100
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    # Replace cargo with only laser crystal (not usable by projectile guns)
+    fit.cargo.clear()
+    crystal = Cargo(eos.db.getItem("Multifrequency S"))
+    crystal.amount = 100
+    fit.cargo.append(crystal)
+    assert get_ammo_in_cargo_usable_by_weapons(fit) == set()
+
+
+def test_imported_fit_has_modules_and_cargo():
+    """Sanity check: EFT import produces fit with both modules and cargo."""
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter Single Ammo]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+
+EMP S x500
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    assert len(fit.modules) >= 1
+    assert len(fit.cargo) >= 1
+
+
+def test_get_ammo_in_cargo_usable_by_weapons_SingleAmmoUsable():
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter Single Ammo]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+
+EMP S x500
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    usable = get_ammo_in_cargo_usable_by_weapons(fit)
+    assert len(usable) >= 1
+    names = {c.name for c in usable}
+    assert "EMP S" in names
+
+
+def test_get_ammo_in_cargo_usable_by_weapons_MultipleAmmoUsable(RifterWithProjectileAmmo):
+    fit = RifterWithProjectileAmmo
+    usable = get_ammo_in_cargo_usable_by_weapons(fit)
+    names = {c.name for c in usable}
+    assert "EMP S" in names
+    assert "Fusion S" in names
+    assert len(usable) >= 2
+
+
+# ---- get_ammo_breakdown ----
+
+def test_get_ammo_breakdown_NoneFit():
+    assert get_ammo_breakdown(None) == []
+
+
+def test_get_ammo_breakdown_NoUsableAmmo():
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter No Cargo]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    fit.cargo.clear()
+    assert get_ammo_breakdown(fit) == []
+
+
+def test_get_ammo_breakdown_SingleAmmo():
+    from service.port import Port
+    eft_lines = """[Rifter, Rifter Single Ammo]
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+200mm Autocannon II, EMP S
+
+EMP S x500
+"""
+    fit = Port.importEft(eft_lines.splitlines())
+    assert fit is not None
+    result = get_ammo_breakdown(fit)
+    assert len(result) == 1
+    row = result[0]
+    assert row['ammoName'] == "EMP S"
+    assert 'damageType' in row
+    assert 'optimal' in row
+    assert 'falloff' in row
+    assert isinstance(row['alpha'], (int, float))
+    assert isinstance(row['dps'], (int, float))
+
+
+def test_get_ammo_breakdown_ResultSortedByName(RifterWithProjectileAmmo):
+    result = get_ammo_breakdown(RifterWithProjectileAmmo)
+    assert len(result) >= 2
+    names = [r['ammoName'] for r in result]
+    assert names == sorted(names)
+
+
+def test_get_ammo_breakdown_ResultStructure(RifterWithProjectileAmmo):
+    result = get_ammo_breakdown(RifterWithProjectileAmmo)
+    assert len(result) >= 1
+    required_keys = {'ammoName', 'damageType', 'optimal', 'falloff', 'alpha', 'dps'}
+    for row in result:
+        assert required_keys.issubset(row.keys())
+        assert isinstance(row['ammoName'], str)
+        assert isinstance(row['damageType'], str)
+        assert isinstance(row['optimal'], str)
+        assert isinstance(row['falloff'], str)
+        assert isinstance(row['alpha'], (int, float))
+        assert isinstance(row['dps'], (int, float))
+
+
+def test_get_ammo_breakdown_DamageTypeFormat(RifterWithProjectileAmmo):
+    result = get_ammo_breakdown(RifterWithProjectileAmmo)
+    for row in result:
+        dt = row['damageType']
+        assert dt in ("EM", "Thermal", "Kinetic", "Explosive", "—") or " / " in dt
+
+
+def test_get_ammo_breakdown_OptimalFalloffFormat(RifterWithProjectileAmmo):
+    result = get_ammo_breakdown(RifterWithProjectileAmmo)
+    for row in result:
+        assert "km" in row['optimal'] or row['optimal'] == "—"
+        assert "km" in row['falloff'] or row['falloff'] == "—"

--- a/tests/test_smoketests/README.md
+++ b/tests/test_smoketests/README.md
@@ -1,0 +1,7 @@
+# Smoke tests
+
+This directory is for **high-level smoke tests** that exercise a broad range of code without targeting a single method.
+
+Use `test_smoketests` when you want to verify that complex scenarios work end-to-end (e.g. a fit with a booster and a specific character). For low-level, method-specific tests, use `test_modules` instead and mirror the source layout there.
+
+See [Writing tests for Pyfa](../../docs/writing-tests.md) (from repo root: `docs/writing-tests.md`) for full guidelines.

--- a/tests/test_smoketests/test_cross_vault_booster.py
+++ b/tests/test_smoketests/test_cross_vault_booster.py
@@ -23,6 +23,7 @@ def _make_booster_fit(DB, Gamedata, Saveddata):
     ship = Saveddata["Ship"](ship_item)
     fit = Saveddata["Fit"](ship, "Booster Stork")
     fit.booster = True
+    fit.implantLocation = 0  # FIT; required for fits table NOT NULL
     mod = Saveddata["Module"](burst_item)
     mod.state = Saveddata["State"].ONLINE
     fit.modules.append(mod)
@@ -42,6 +43,7 @@ def test_cross_vault_booster_combat_ship_gets_boost_calculated(DB, Gamedata, Sav
         pytest.skip("Gamedata missing Stork or Shield Command Burst I")
 
     combat_fit = RifterFit
+    combat_fit.implantLocation = 0  # FIT; required for fits table NOT NULL
 
     # Save both fits so they get IDs
     eos_db.save(booster_fit)

--- a/tests/test_smoketests/test_cross_vault_booster.py
+++ b/tests/test_smoketests/test_cross_vault_booster.py
@@ -1,0 +1,88 @@
+"""
+Smoketest: combat ship in one vault receives boost from a booster ship in another vault.
+
+Verifies that boost calculation is vault-agnostic: when the booster fit lives in vault A
+and the combat fit in vault B, linking them and recalculating the combat fit should
+apply command bonuses correctly (commandBonuses populated).
+"""
+import pytest
+
+# No GUI imports - use eos.db and fixtures only so test runs without gui.mainFrame/Market
+
+
+def _make_booster_fit(DB, Gamedata, Saveddata):
+    """Build a minimal booster fit: command destroyer + Shield Command Burst I."""
+    ship_item = DB["gamedata_session"].query(Gamedata["Item"]).filter(
+        Gamedata["Item"].name == "Stork"
+    ).first()
+    if ship_item is None:
+        return None
+    burst_item = DB["db"].getItem("Shield Command Burst I")
+    if burst_item is None:
+        return None
+    ship = Saveddata["Ship"](ship_item)
+    fit = Saveddata["Fit"](ship, "Booster Stork")
+    fit.booster = True
+    mod = Saveddata["Module"](burst_item)
+    mod.state = Saveddata["State"].ONLINE
+    fit.modules.append(mod)
+    return fit
+
+
+def test_cross_vault_booster_combat_ship_gets_boost_calculated(DB, Gamedata, Saveddata, RifterFit):
+    """
+    Booster in vault A, combat ship in vault B: link them and assert combat fit
+    receives command bonuses after recalc (boost calculated correctly).
+    """
+    eos_db = DB["db"]
+
+    # Create booster fit (may be None if gamedata lacks Stork / Shield Command Burst I)
+    booster_fit = _make_booster_fit(DB, Gamedata, Saveddata)
+    if booster_fit is None:
+        pytest.skip("Gamedata missing Stork or Shield Command Burst I")
+
+    combat_fit = RifterFit
+
+    # Save both fits so they get IDs
+    eos_db.save(booster_fit)
+    eos_db.save(combat_fit)
+    booster_id = booster_fit.ID
+    combat_id = combat_fit.ID
+
+    existing_vaults = eos_db.getVaultList()
+    default_vault_id = existing_vaults[0].ID if existing_vaults else None
+
+    vault_a_id = eos_db.createVault("VaultA")
+    vault_b_id = eos_db.createVault("VaultB")
+
+    try:
+        # Assign booster to vault A, combat to vault B
+        eos_db.moveFitToVault(booster_fit.ID, vault_a_id)
+        eos_db.moveFitToVault(combat_fit.ID, vault_b_id)
+
+        # Reload so vaultID is set on the instances
+        combat_fit = eos_db.getFit(combat_fit.ID)
+        booster_fit = eos_db.getFit(booster_fit.ID)
+
+        # Link booster to combat (same as GUI add command fit)
+        combat_fit.commandFitDict[booster_fit.ID] = booster_fit
+        eos_db.saveddata_session.flush()
+        eos_db.saveddata_session.refresh(booster_fit)
+
+        # Recalc combat fit so command effects are applied
+        combat_fit.clear()
+        combat_fit.calculateModifiedAttributes()
+
+        # Boost calculated correctly: combat ship should have command bonuses from the booster
+        assert len(combat_fit.commandBonuses) > 0, (
+            "Combat ship in vault B should receive boost from booster in vault A; commandBonuses was empty"
+        )
+    finally:
+        # Cleanup: remove fits, then delete our vaults (need an existing vault as default)
+        for fit_id in (combat_id, booster_id):
+            fit = eos_db.getFit(fit_id)
+            if fit is not None:
+                eos_db.remove(fit)
+        if default_vault_id is not None:
+            eos_db.deleteVault(vault_a_id, default_vault_id)
+            eos_db.deleteVault(vault_b_id, default_vault_id)

--- a/tests/test_smoketests/test_smoke_placeholder.py
+++ b/tests/test_smoketests/test_smoke_placeholder.py
@@ -1,0 +1,9 @@
+"""
+Placeholder for smoke tests. Add high-level tests here or in new test_*.py files
+that exercise broad flows (e.g. fit + booster + character) per docs/writing-tests.md.
+"""
+
+
+def test_smoketests_directory_used():
+    """Smoke test directory is in use; replace with real smoke tests as needed."""
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements.txt
     -rrequirements_test.txt
 basepython = python3.11
-commands = py.test -vv --cov Pyfa tests2/
+commands = py.test -vv --cov Pyfa tests/
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Pyfa Vaults is a way to group fittings into logical collections, such as personal, corporation, or alliance vaults. You can move fittings between vaults at any time or delete an entire vault along with all of its fittings if you no longer need it. The goal is to let you quickly find the specific fits you are interested in without scrolling through every saved fit you have. This code was originally generated with AI; if it does not fit the direction of the main project, that is completely fine, but I wanted to share it so anyone can use or build on it.


Vault Example
<img width="342" height="251" alt="image" src="https://github.com/user-attachments/assets/c3a59072-7139-4c45-bced-67322baacd50" />

<img width="339" height="692" alt="image" src="https://github.com/user-attachments/assets/f664394f-aa94-40b4-ad09-72a7ccd2decb" />

<img width="349" height="267" alt="image" src="https://github.com/user-attachments/assets/789aab72-32ec-4b40-b9d6-ac48deb46f90" />

<img width="354" height="197" alt="image" src="https://github.com/user-attachments/assets/98f899bb-ec72-4120-82c3-3c341910a221" />

