### PR TITLE
Filter graphs on selection

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -19,6 +19,7 @@
 
 import datetime
 import time
+from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain
 from math import ceil, log, sqrt
@@ -66,6 +67,22 @@ class Fit:
     """Represents a fitting, with modules, ship, implants, etc."""
 
     PEAK_RECHARGE = 0.25
+
+    # When > 0, __resetDependentCalcs does not mark projection victims stale.
+    # Sequential full recalcs for mutually-projected fits (e.g. graph) would
+    # otherwise set victim.calculated = False without clearing them; the next
+    # PROJECTED pass then runs clear() and wipes that fit after it was just
+    # calculated correctly.
+    _suspendVictimCalcResetDepth = 0
+
+    @classmethod
+    @contextmanager
+    def suspendVictimCalcReset(cls):
+        cls._suspendVictimCalcResetDepth += 1
+        try:
+            yield
+        finally:
+            cls._suspendVictimCalcResetDepth -= 1
 
     def __init__(self, ship=None, name=""):
         """Initialize a fit from the program"""
@@ -973,6 +990,8 @@ class Fit:
 
     def __resetDependentCalcs(self):
         self.calculated = False
+        if Fit._suspendVictimCalcResetDepth > 0:
+            return
         for value in list(self.projectedOnto.values()):
             if value.victim_fit:  # removing a self-projected fit causes victim fit to be None. @todo: look into why. :3
                 value.victim_fit.calculated = False

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -19,7 +19,6 @@
 
 import datetime
 import time
-from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain
 from math import ceil, log, sqrt
@@ -67,22 +66,6 @@ class Fit:
     """Represents a fitting, with modules, ship, implants, etc."""
 
     PEAK_RECHARGE = 0.25
-
-    # When > 0, __resetDependentCalcs does not mark projection victims stale.
-    # Sequential full recalcs for mutually-projected fits (e.g. graph) would
-    # otherwise set victim.calculated = False without clearing them; the next
-    # PROJECTED pass then runs clear() and wipes that fit after it was just
-    # calculated correctly.
-    _suspendVictimCalcResetDepth = 0
-
-    @classmethod
-    @contextmanager
-    def suspendVictimCalcReset(cls):
-        cls._suspendVictimCalcResetDepth += 1
-        try:
-            yield
-        finally:
-            cls._suspendVictimCalcResetDepth -= 1
 
     def __init__(self, ship=None, name=""):
         """Initialize a fit from the program"""
@@ -990,8 +973,6 @@ class Fit:
 
     def __resetDependentCalcs(self):
         self.calculated = False
-        if Fit._suspendVictimCalcResetDepth > 0:
-            return
         for value in list(self.projectedOnto.values()):
             if value.victim_fit:  # removing a self-projected fit causes victim fit to be None. @todo: look into why. :3
                 value.victim_fit.calculated = False

--- a/graphs/gui/canvasPanel.py
+++ b/graphs/gui/canvasPanel.py
@@ -30,11 +30,57 @@ import wx
 from logbook import Logger
 
 
+from eos.saveddata.fit import Fit
+from eos.saveddata.targetProfile import TargetProfile
 from graphs.style import BASE_COLORS, LIGHTNESSES, STYLES, hsl_to_hsv
 from gui.utils.numberFormatter import roundToPrec
 
 
 pyfalog = Logger(__name__)
+
+
+def _graph_item_key(item):
+    if isinstance(item, Fit):
+        return ('fit', item.ID)
+    if isinstance(item, TargetProfile):
+        return ('profile', item.ID)
+    return None
+
+
+def expand_reverse_filtered_matchups(ctrl, base_pairs):
+    """
+    For each (attacker, target) in base_pairs, optionally add (targetShip as attacker, attackerShip as target)
+    using the SourceWrapper / TargetWrapper instances from the full lists when present.
+    """
+    if not ctrl.showReverseFilteredMatchups:
+        return base_pairs
+    src_by_key = {}
+    for w in ctrl.sources:
+        k = _graph_item_key(w.item)
+        if k:
+            src_by_key[k] = w
+    tgt_by_key = {}
+    for w in ctrl.targets:
+        k = _graph_item_key(w.item)
+        if k:
+            tgt_by_key[k] = w
+    seen = set((id(s), id(t)) for s, t in base_pairs)
+    out = list(base_pairs)
+    for s, t in base_pairs:
+        ks = _graph_item_key(t.item)
+        kt = _graph_item_key(s.item)
+        if ks is None or kt is None:
+            continue
+        rev_s = src_by_key.get(ks)
+        rev_t = tgt_by_key.get(kt)
+        if rev_s is None or rev_t is None:
+            continue
+        key = (id(rev_s), id(rev_t))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((rev_s, rev_t))
+    return out
 
 
 try:
@@ -116,9 +162,11 @@ class GraphCanvasPanel(wx.Panel):
 
         mainInput, miscInputs = self.graphFrame.ctrlPanel.getValues()
         view = self.graphFrame.getView()
-        sources = self.graphFrame.ctrlPanel.sources
+        ctrl = self.graphFrame.ctrlPanel
+        sources = ctrl.filteredSources
         if view.hasTargets:
-            iterList = tuple(itertools.product(sources, self.graphFrame.ctrlPanel.targets))
+            base_pairs = list(itertools.product(sources, ctrl.filteredTargets))
+            iterList = tuple(expand_reverse_filtered_matchups(ctrl, base_pairs))
         else:
             iterList = tuple((f, None) for f in sources)
 

--- a/graphs/gui/canvasPanel.py
+++ b/graphs/gui/canvasPanel.py
@@ -30,8 +30,6 @@ import wx
 from logbook import Logger
 
 
-from eos.saveddata.fit import Fit
-from eos.saveddata.targetProfile import TargetProfile
 from graphs.style import BASE_COLORS, LIGHTNESSES, STYLES, hsl_to_hsv
 from gui.utils.numberFormatter import roundToPrec
 
@@ -39,11 +37,13 @@ from gui.utils.numberFormatter import roundToPrec
 pyfalog = Logger(__name__)
 
 
-def _graph_item_key(item):
-    if isinstance(item, Fit):
-        return ('fit', item.ID)
-    if isinstance(item, TargetProfile):
-        return ('profile', item.ID)
+def _graph_wrapper_key(wrapper):
+    if wrapper is None or wrapper.item is None:
+        return None
+    if wrapper.isFit:
+        return 'fit', wrapper.item.ID
+    if wrapper.isProfile:
+        return 'profile', wrapper.item.ID
     return None
 
 
@@ -56,20 +56,20 @@ def expand_reverse_filtered_matchups(ctrl, base_pairs):
         return base_pairs
     src_by_key = {}
     for w in ctrl.sources:
-        k = _graph_item_key(w.item)
+        k = _graph_wrapper_key(w)
         if k:
             src_by_key[k] = w
     tgt_by_key = {}
     for w in ctrl.targets:
-        k = _graph_item_key(w.item)
+        k = _graph_wrapper_key(w)
         if k:
             tgt_by_key[k] = w
     seen = set((id(s), id(t)) for s, t in base_pairs)
     out = list(base_pairs)
     for s, t in base_pairs:
         # Reverse matchup means target ship becomes attacker and vice versa.
-        reverse_src_key = _graph_item_key(t.item)
-        reverse_tgt_key = _graph_item_key(s.item)
+        reverse_src_key = _graph_wrapper_key(t)
+        reverse_tgt_key = _graph_wrapper_key(s)
         if reverse_src_key is None or reverse_tgt_key is None:
             continue
         rev_s = src_by_key.get(reverse_src_key)

--- a/graphs/gui/canvasPanel.py
+++ b/graphs/gui/canvasPanel.py
@@ -67,12 +67,13 @@ def expand_reverse_filtered_matchups(ctrl, base_pairs):
     seen = set((id(s), id(t)) for s, t in base_pairs)
     out = list(base_pairs)
     for s, t in base_pairs:
-        ks = _graph_item_key(t.item)
-        kt = _graph_item_key(s.item)
-        if ks is None or kt is None:
+        # Reverse matchup means target ship becomes attacker and vice versa.
+        reverse_src_key = _graph_item_key(t.item)
+        reverse_tgt_key = _graph_item_key(s.item)
+        if reverse_src_key is None or reverse_tgt_key is None:
             continue
-        rev_s = src_by_key.get(ks)
-        rev_t = tgt_by_key.get(kt)
+        rev_s = src_by_key.get(reverse_src_key)
+        rev_t = tgt_by_key.get(reverse_tgt_key)
         if rev_s is None or rev_t is None:
             continue
         key = (id(rev_s), id(rev_t))

--- a/graphs/gui/ctrlPanel.py
+++ b/graphs/gui/ctrlPanel.py
@@ -76,6 +76,13 @@ class GraphControlPanel(wx.Panel):
         self.showY0Cb.SetValue(True)
         self.showY0Cb.Bind(wx.EVT_CHECKBOX, self.OnShowY0Change)
         commonOptsSizer.Add(self.showY0Cb, 0, wx.EXPAND | wx.TOP, 5)
+        self.reverseFilteredMatchupsCb = wx.CheckBox(
+            self, wx.ID_ANY, _t('Include reverse matchups when filtered'), wx.DefaultPosition, wx.DefaultSize, 0)
+        self.reverseFilteredMatchupsCb.SetValue(False)
+        self.reverseFilteredMatchupsCb.Bind(wx.EVT_CHECKBOX, self.OnReverseFilteredMatchupsChange)
+        self.reverseFilteredMatchupsCb.SetToolTip(wx.ToolTip(_t(
+            'Also plot target→attacker for the same ships. Add each ship to both attacker and target lists.')))
+        commonOptsSizer.Add(self.reverseFilteredMatchupsCb, 0, wx.EXPAND | wx.TOP, 5)
         optsSizer.Add(commonOptsSizer, 0, wx.EXPAND | wx.RIGHT, 10)
 
         graphOptsSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -158,6 +165,7 @@ class GraphControlPanel(wx.Panel):
         # Source and target list
         self.refreshColumns(layout=False)
         self.targetList.Show(view.hasTargets)
+        self.reverseFilteredMatchupsCb.Show(view.hasTargets)
 
         # Inputs
         self._updateInputs(storeInputs=False)
@@ -327,6 +335,10 @@ class GraphControlPanel(wx.Panel):
         event.Skip()
         self.graphFrame.draw()
 
+    def OnReverseFilteredMatchupsChange(self, event):
+        event.Skip()
+        self.graphFrame.draw()
+
     def OnYTypeUpdate(self, event):
         event.Skip()
         self._updateInputs()
@@ -416,6 +428,34 @@ class GraphControlPanel(wx.Panel):
     @property
     def targets(self):
         return self.targetList.wrappers
+
+    @property
+    def filteredSources(self):
+        srcs = self.sources
+        selected = self.sourceList.getSelectedWrappers()
+        if not selected:
+            return srcs
+        sel = set(selected)
+        return [w for w in srcs if w in sel]
+
+    @property
+    def filteredTargets(self):
+        tgts = self.targets
+        selected = self.targetList.getSelectedWrappers()
+        if not selected:
+            return tgts
+        sel = set(selected)
+        return [w for w in tgts if w in sel]
+
+    @property
+    def isGraphFiltered(self):
+        return bool(self.sourceList.getSelectedWrappers()) or bool(self.targetList.getSelectedWrappers())
+
+    @property
+    def showReverseFilteredMatchups(self):
+        if not self.graphFrame.getView().hasTargets or not self.isGraphFiltered:
+            return False
+        return self.reverseFilteredMatchupsCb.GetValue()
 
     # Fit events
     def OnFitRenamed(self, event):

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -19,6 +19,8 @@
 
 
 # noinspection PyPackageRequirements
+from contextlib import nullcontext
+
 import wx
 from logbook import Logger
 
@@ -260,7 +262,8 @@ class GraphFrame(AuxiliaryFrame):
             fits.append(wrapper.item)
         if len(fits) < 2:
             return
-        with EosFit.suspendVictimCalcReset():
+        suspend_ctx = getattr(EosFit, 'suspendVictimCalcReset', None)
+        with (suspend_ctx() if callable(suspend_ctx) else nullcontext()):
             for fit in fits:
                 sFit.recalc(fit)
 

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -25,7 +25,6 @@ from logbook import Logger
 import gui.display
 import gui.globalEvents as GE
 import gui.mainFrame
-from eos.saveddata.fit import Fit as EosFit
 from graphs.data.base import FitGraph
 from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
@@ -260,13 +259,8 @@ class GraphFrame(AuxiliaryFrame):
             fits.append(wrapper.item)
         if len(fits) < 2:
             return
-        # Without this, each recalc's __resetDependentCalcs marks projection victims
-        # as not calculated; the next fit's calculation then invokes those victims in
-        # PROJECTED mode with calculated=False, which runs clear() and wipes ship state
-        # built by the previous recalc in the batch.
-        with EosFit.suspendVictimCalcReset():
-            for fit in fits:
-                sFit.recalc(fit)
+        for fit in fits:
+            sFit.recalc(fit)
 
     def draw(self):
         self._ensureGraphFitsRecalculated()

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -30,6 +30,7 @@ from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
 from gui.bitmap_loader import BitmapLoader
 from service.const import GraphCacheCleanupReason
+from service.fit import Fit
 from service.settings import GraphSettings
 from . import canvasPanel
 from .ctrlPanel import GraphControlPanel
@@ -239,7 +240,30 @@ class GraphFrame(AuxiliaryFrame):
     def clearCache(self, reason, extraData=None):
         self.getView().clearCache(reason, extraData)
 
+    def _ensureGraphFitsRecalculated(self):
+        """
+        Recalculate every fit shown in the graph when multiple ships are listed.
+
+        The main window only runs a full local calculation for the active tab. Other
+        loaded fits can keep stale ship attributes for incoming projections (mutual
+        projected effects) until they become active, which breaks multi-fit graphs.
+        """
+        ctrl = self.ctrlPanel
+        sFit = Fit.getInstance()
+        seen = set()
+        fits = []
+        for wrapper in ctrl.sources + ctrl.targets:
+            if not wrapper.isFit or wrapper.item.ID in seen:
+                continue
+            seen.add(wrapper.item.ID)
+            fits.append(wrapper.item)
+        if len(fits) < 2:
+            return
+        for fit in fits:
+            sFit.recalc(fit)
+
     def draw(self):
+        self._ensureGraphFitsRecalculated()
         self.canvasPanel.draw()
 
     def resetXMark(self):

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -25,6 +25,7 @@ from logbook import Logger
 import gui.display
 import gui.globalEvents as GE
 import gui.mainFrame
+from eos.saveddata.fit import Fit as EosFit
 from graphs.data.base import FitGraph
 from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
@@ -259,8 +260,9 @@ class GraphFrame(AuxiliaryFrame):
             fits.append(wrapper.item)
         if len(fits) < 2:
             return
-        for fit in fits:
-            sFit.recalc(fit)
+        with EosFit.suspendVictimCalcReset():
+            for fit in fits:
+                sFit.recalc(fit)
 
     def draw(self):
         self._ensureGraphFitsRecalculated()

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -25,6 +25,7 @@ from logbook import Logger
 import gui.display
 import gui.globalEvents as GE
 import gui.mainFrame
+from eos.saveddata.fit import Fit as EosFit
 from graphs.data.base import FitGraph
 from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
@@ -259,8 +260,13 @@ class GraphFrame(AuxiliaryFrame):
             fits.append(wrapper.item)
         if len(fits) < 2:
             return
-        for fit in fits:
-            sFit.recalc(fit)
+        # Without this, each recalc's __resetDependentCalcs marks projection victims
+        # as not calculated; the next fit's calculation then invokes those victims in
+        # PROJECTED mode with calculated=False, which runs clear() and wipes ship state
+        # built by the previous recalc in the batch.
+        with EosFit.suspendVictimCalcReset():
+            for fit in fits:
+                sFit.recalc(fit)
 
     def draw(self):
         self._ensureGraphFitsRecalculated()

--- a/graphs/gui/lists.py
+++ b/graphs/gui/lists.py
@@ -44,8 +44,11 @@ class BaseWrapperList(gui.display.Display):
 
         self.hoveredRow = None
         self.hoveredColumn = None
+        self._graphSelectionRedrawPending = False
 
         self.Bind(wx.EVT_CHAR_HOOK, self.kbEvent)
+        self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnGraphListSelectionChanged)
+        self.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnGraphListSelectionChanged)
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)
         self.Bind(wx.EVT_LEFT_DCLICK, self.OnLeftDClick)
         self.Bind(wx.EVT_MOTION, self.OnMouseMove)
@@ -55,6 +58,16 @@ class BaseWrapperList(gui.display.Display):
     def wrappers(self):
         # Sort fits first, then target profiles
         return sorted(self._wrappers, key=lambda w: not w.isFit)
+
+    def OnGraphListSelectionChanged(self, event):
+        event.Skip()
+        if not self._graphSelectionRedrawPending:
+            self._graphSelectionRedrawPending = True
+            wx.CallAfter(self._flushGraphSelectionRedraw)
+
+    def _flushGraphSelectionRedraw(self):
+        self._graphSelectionRedrawPending = False
+        self.graphFrame.draw()
 
     # UI-related stuff
     @property
@@ -121,23 +134,24 @@ class BaseWrapperList(gui.display.Display):
 
     def OnLeftDown(self, event):
         row, _ = self.HitTest(event.Position)
-        if row != -1:
-            pickers = {
-                self.getColIndex(GraphColor): ColorPickerPopup,
-                self.getColIndex(GraphLightness): LightnessPickerPopup,
-                self.getColIndex(GraphLineStyle): LineStylePickerPopup}
-            # In case we had no index for some column, remove None
-            pickers.pop(None, None)
-            col = self.getColumn(event.Position)
-            if col in pickers:
-                picker = pickers[col]
-                wrapper = self.getWrapper(row)
-                if wrapper is not None:
-                    win = picker(parent=self, wrapper=wrapper)
-                    pos = wx.GetMousePosition()
-                    win.Position(pos, (0, 0))
-                    win.Popup()
-                    return
+        if row == -1:
+            self.unselectAll()
+            event.Skip()
+            return
+        pickers = {
+            self.getColIndex(GraphColor): ColorPickerPopup,
+            self.getColIndex(GraphLightness): LightnessPickerPopup,
+            self.getColIndex(GraphLineStyle): LineStylePickerPopup}
+        pickers.pop(None, None)
+        col = self.getColumn(event.Position)
+        if col in pickers:
+            wrapper = self.getWrapper(row)
+            if wrapper is not None:
+                win = pickers[col](parent=self, wrapper=wrapper)
+                pos = wx.GetMousePosition()
+                win.Position(pos, (0, 0))
+                win.Popup()
+                return
         event.Skip()
 
     def OnLineStyleChange(self):
@@ -310,7 +324,7 @@ class SourceWrapperList(BaseWrapperList):
 
     @property
     def defaultTTText(self):
-        return _t('Drag a fit into this list to graph it')
+        return _t('Drag a fit into this list to graph it. Select rows to filter attackers (Shift/Ctrl); click empty space to show all attackers.')
 
 
 class TargetWrapperList(BaseWrapperList):
@@ -367,7 +381,7 @@ class TargetWrapperList(BaseWrapperList):
 
     @property
     def defaultTTText(self):
-        return _t('Drag a fit into this list to have your fits graphed against it')
+        return _t('Drag a fit into this list to have your fits graphed against it. Select rows to filter targets (Shift/Ctrl); click empty space to show all targets.')
 
     # Context menu handlers
     def addProfile(self, profile):


### PR DESCRIPTION
# Problem

Showing multiple fits in Graph window becomes a mess quickly even for trivial cases when you want to compare how 2 fits perform against each other. This produces N*M graphs which are hard to read even with with color keys.

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/0eb9f193-dc32-4630-96bd-2f49d195a3f1" />

# Solution

Take selections in attacker and target lists into account so only graphs for selected fits are displayed.

If no fit is selected the behavior is unchanged.

Examples:

## Selecting attackers

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/8f0b06c5-53a6-44a6-b347-9ba857c5ac0b" />

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/2a61694c-61f4-4e91-b236-788fa5f47f4f" />

## Selecting targets

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/c0076328-1ff1-49ec-818e-45cfc75a2d73" />

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/c190acdb-8236-4787-bf9b-b4c843a5e651" />

## Selecting attackers and targets

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/f9844857-d7e1-4675-87db-7a32c03c60c2" />

### Selecting attackers and targets with reverse matchups

<img width="752" height="652" alt="image" src="https://github.com/user-attachments/assets/284e5522-3156-49a2-beec-7e387f201e14" />
