### PR TITLE
Fix tab switch when projected is mutually applied

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1108,10 +1108,7 @@ class Fit:
         if type == CalcType.COMMAND and targetFit in self.commandFits:
             pyfalog.debug("{} is in the command listing for COMMAND ({}), do not mark self as calculated (recursive)".format(repr(targetFit), repr(self)))
         elif type == CalcType.PROJECTED:
-            # A projected-source pass only applies this fit's remote effects to the target; it is not a full local
-            # calculation of this fit. Marking calculated would make switchFit skip recalc, so bidirectional
-            # projections show wrong stats when switching tabs until the projection is toggled.
-            pass
+            pyfalog.debug("{} is projecting onto {} (PROJECTED), do not mark self as calculated (not a full local calc)".format(repr(self), repr(targetFit)))
         else:
             self.__calculated = True
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1107,6 +1107,11 @@ class Fit:
         # tabs. See GH issue 1193
         if type == CalcType.COMMAND and targetFit in self.commandFits:
             pyfalog.debug("{} is in the command listing for COMMAND ({}), do not mark self as calculated (recursive)".format(repr(targetFit), repr(self)))
+        elif type == CalcType.PROJECTED:
+            # A projected-source pass only applies this fit's remote effects to the target; it is not a full local
+            # calculation of this fit. Marking calculated would make switchFit skip recalc, so bidirectional
+            # projections show wrong stats when switching tabs until the projection is toggled.
+            pass
         else:
             self.__calculated = True
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -19,6 +19,7 @@
 
 import datetime
 import time
+from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain
 from math import ceil, log, sqrt
@@ -66,6 +67,22 @@ class Fit:
     """Represents a fitting, with modules, ship, implants, etc."""
 
     PEAK_RECHARGE = 0.25
+
+    # When > 0, __resetDependentCalcs does not mark projection victims stale.
+    # Sequential full recalcs for mutually-projected fits (e.g. graph) would
+    # otherwise set victim.calculated = False without clearing them; the next
+    # PROJECTED pass then runs clear() and wipes that fit after it was just
+    # calculated correctly.
+    _suspendVictimCalcResetDepth = 0
+
+    @classmethod
+    @contextmanager
+    def suspendVictimCalcReset(cls):
+        cls._suspendVictimCalcResetDepth += 1
+        try:
+            yield
+        finally:
+            cls._suspendVictimCalcResetDepth -= 1
 
     def __init__(self, ship=None, name=""):
         """Initialize a fit from the program"""
@@ -973,6 +990,8 @@ class Fit:
 
     def __resetDependentCalcs(self):
         self.calculated = False
+        if Fit._suspendVictimCalcResetDepth > 0:
+            return
         for value in list(self.projectedOnto.values()):
             if value.victim_fit:  # removing a self-projected fit causes victim fit to be None. @todo: look into why. :3
                 value.victim_fit.calculated = False

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -970,8 +970,14 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut, M
         # Determine if we'll take into account reload time or not
         if reloadOverride is not None:
             factorReload = reloadOverride
+        elif self.forceReload is not None:
+            factorReload = self.forceReload
+        elif self.owner is None:
+            # Owner can be temporarily unset during fit/tab transitions; default to
+            # no reload factoring until association is restored.
+            factorReload = False
         else:
-            factorReload = self.owner.factorReload if self.forceReload is None else self.forceReload
+            factorReload = self.owner.factorReload
 
         cycles_until_reload = self.numShots
         if cycles_until_reload == 0:

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -25,13 +25,11 @@ from logbook import Logger
 import gui.display
 import gui.globalEvents as GE
 import gui.mainFrame
-from eos.saveddata.fit import Fit as EosFit
 from graphs.data.base import FitGraph
 from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
 from gui.bitmap_loader import BitmapLoader
 from service.const import GraphCacheCleanupReason
-from service.fit import Fit
 from service.settings import GraphSettings
 from . import canvasPanel
 from .ctrlPanel import GraphControlPanel
@@ -241,35 +239,7 @@ class GraphFrame(AuxiliaryFrame):
     def clearCache(self, reason, extraData=None):
         self.getView().clearCache(reason, extraData)
 
-    def _ensureGraphFitsRecalculated(self):
-        """
-        Recalculate every fit shown in the graph when multiple ships are listed.
-
-        The main window only runs a full local calculation for the active tab. Other
-        loaded fits can keep stale ship attributes for incoming projections (mutual
-        projected effects) until they become active, which breaks multi-fit graphs.
-        """
-        ctrl = self.ctrlPanel
-        sFit = Fit.getInstance()
-        seen = set()
-        fits = []
-        for wrapper in ctrl.sources + ctrl.targets:
-            if not wrapper.isFit or wrapper.item.ID in seen:
-                continue
-            seen.add(wrapper.item.ID)
-            fits.append(wrapper.item)
-        if len(fits) < 2:
-            return
-        # Without this, each recalc's __resetDependentCalcs marks projection victims
-        # as not calculated; the next fit's calculation then invokes those victims in
-        # PROJECTED mode with calculated=False, which runs clear() and wipes ship state
-        # built by the previous recalc in the batch.
-        with EosFit.suspendVictimCalcReset():
-            for fit in fits:
-                sFit.recalc(fit)
-
     def draw(self):
-        self._ensureGraphFitsRecalculated()
         self.canvasPanel.draw()
 
     def resetXMark(self):

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -30,6 +30,7 @@ from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
 from gui.bitmap_loader import BitmapLoader
 from service.const import GraphCacheCleanupReason
+from service.fit import Fit
 from service.settings import GraphSettings
 from . import canvasPanel
 from .ctrlPanel import GraphControlPanel
@@ -239,7 +240,30 @@ class GraphFrame(AuxiliaryFrame):
     def clearCache(self, reason, extraData=None):
         self.getView().clearCache(reason, extraData)
 
+    def _ensureGraphFitsRecalculated(self):
+        """
+        Recalculate every fit shown in the graph when multiple ships are listed.
+
+        The main window only runs a full local calculation for the active tab. Other
+        loaded fits can keep stale ship attributes for incoming projections (mutual
+        projected effects) until they become active, which breaks multi-fit graphs.
+        """
+        ctrl = self.ctrlPanel
+        sFit = Fit.getInstance()
+        seen = set()
+        fits = []
+        for wrapper in ctrl.sources + ctrl.targets:
+            if not wrapper.isFit or wrapper.item.ID in seen:
+                continue
+            seen.add(wrapper.item.ID)
+            fits.append(wrapper.item)
+        if len(fits) < 2:
+            return
+        for fit in fits:
+            sFit.recalc(fit)
+
     def draw(self):
+        self._ensureGraphFitsRecalculated()
         self.canvasPanel.draw()
 
     def resetXMark(self):

--- a/graphs/gui/frame.py
+++ b/graphs/gui/frame.py
@@ -25,6 +25,7 @@ from logbook import Logger
 import gui.display
 import gui.globalEvents as GE
 import gui.mainFrame
+from eos.saveddata.fit import Fit as EosFit
 from graphs.data.base import FitGraph
 from graphs.events import RESIST_MODE_CHANGED
 from gui.auxWindow import AuxiliaryFrame
@@ -259,8 +260,13 @@ class GraphFrame(AuxiliaryFrame):
             fits.append(wrapper.item)
         if len(fits) < 2:
             return
-        for fit in fits:
-            sFit.recalc(fit)
+        # Without this, each recalc's __resetDependentCalcs marks projection victims
+        # as not calculated; the next fit's calculation then invokes those victims in
+        # PROJECTED mode with calculated=False, which runs clear() and wipes ship state
+        # built by the previous recalc in the batch.
+        with EosFit.suspendVictimCalcReset():
+            for fit in fits:
+                sFit.recalc(fit)
 
     def draw(self):
         self._ensureGraphFitsRecalculated()


### PR DESCRIPTION
# Problem

When 2 fits are mutually applied in Projected tabs to each other, the first fit loses the projected effect.

For example, we have fit1:
<img width="902" height="631" alt="image" src="https://github.com/user-attachments/assets/28e659a5-8cc9-431e-bdf4-1d7c0cdd0fc0" />


and fit2:
<img width="901" height="630" alt="image" src="https://github.com/user-attachments/assets/89a4a31b-e6a9-4cf4-9139-a8f2efaa4a84" />

Each one has a Stasis Webifier.

When the first fit applies projected effect from the second one everything is fine:
<img width="901" height="633" alt="image" src="https://github.com/user-attachments/assets/e6699343-5adf-4888-950d-84903a39d76e" />

When the second fit applies projected effect from the first one everything is fine:
<img width="897" height="628" alt="image" src="https://github.com/user-attachments/assets/ff285133-8d34-4a17-b448-59e525271d40" />

When we switch back to the first fit tab, the projected effect is lost:
<img width="900" height="628" alt="image" src="https://github.com/user-attachments/assets/c360e071-b452-4080-b6ee-86e1c418284a" />

It can be restored by re-enabling the projected effect, but then the effect is lost on the second fit tab:
<img width="902" height="633" alt="image" src="https://github.com/user-attachments/assets/e9988129-75d3-48ad-b650-729103d38a3e" />

If we re-enable it here, the first fit loses the projected effect and so on.

# Solution

Don't skip recalculation of modified attributes for projected calculation type (similar to command, see #1193).