### PR TITLE
Use onedir PyInstaller bundles for faster macOS launch

### DIFF
--- a/dist_assets/mac/pyfa.spec
+++ b/dist_assets/mac/pyfa.spec
@@ -65,20 +65,28 @@ pyz = PYZ(a.pure, a.zipped_data,
 
 exe = EXE(pyz,
           a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,
+          exclude_binaries=True,
           name='pyfa',
           debug=False,
           strip=False,
           upx=True,
-          runtime_tmpdir=None,
           console=False ,
           icon=icon,
+          contents_directory='app',
           )
 
-app = BUNDLE(
+coll = COLLECT(
     exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    name='pyfa',
+)
+
+app = BUNDLE(
+    coll,
     name='pyfa.app',
     version=os.getenv('PYFA_VERSION'),
     icon=icon,

--- a/pyfa.spec
+++ b/pyfa.spec
@@ -116,7 +116,7 @@ if platform.system() == 'Darwin':
         'CFBundleVersion': '1.2.3',
         'CFBundleShortVersionString': '1.2.3',
     }
-    app = BUNDLE(exe,
+    app = BUNDLE(coll,
         name='pyfa.app',
         icon=icon,
         bundle_identifier=None,

--- a/scripts/osx-package.sh
+++ b/scripts/osx-package.sh
@@ -7,5 +7,5 @@ echo "Building distributive..."
 python3 -m PyInstaller -y --clean dist_assets/mac/pyfa.spec
 echo "Compressing distributive..."
 cd dist
-zip -r "pyfa-$PYFA_VERSION-mac.zip" pyfa.app
+zip -yr "pyfa-$PYFA_VERSION-mac.zip" pyfa.app
 md5 -r "pyfa-$PYFA_VERSION-mac.zip"


### PR DESCRIPTION
## Summary

This changes the macOS PyInstaller bundle from onefile to onedir.

The current onefile app has a large amount of work before pyfa itself starts. On macOS that makes the packaged app look like it is hanging for a long time before any window appears. With onedir, the bundled files live inside the app bundle instead of being unpacked into a temp directory on every launch.

This keeps the output as `pyfa.app` and does not change pyfa startup/runtime code.

The packaging script now uses `zip -y` so macOS bundle symlinks are stored as symlinks in the release archive instead of being followed and duplicated.

Refs #1605.

## Measurements

Measured on:

- Apple M3 Max
- macOS 26.3.1
- Python 3.11.9
- PyInstaller 6.2.0, matching `scripts/osx-setup.sh`
- local package builds from `scripts/osx-package.sh`

| Build | Package format | First window |
| --- | --- | --- |
| `upstream/master` at `a46ad2b81` | onefile app bundle | no window within the 60s timeout in 3/3 measured runs |
| this branch | onedir app bundle | 1.54s / 1.59s / 1.68s, median 1.59s |

I also used a temporary instrumented build to split out the pre-Python time. That instrumentation is not included in this PR. With the onedir bundle, the median timing was:

- first pyfa bytecode: 0.158s
- `MainFrame.Show()`: 1.48s
- first idle: 1.66s

## Tradeoff

The installed app bundle is larger and contains more files, but preserving symlinks in the zip keeps the release archive close to the current onefile size:

| Build | App bundle | Zip | Bundle contents |
| --- | ---: | ---: | ---: |
| onefile baseline | ~80M | ~81M | 4 files |
| onedir | ~251M | ~96M | 5,062 files + 94 symlinks |

## QA

- `python scripts/compile_lang.py`
- `python db_update.py`
- `PYFA_VERSION=qa-pyi62-onedir-symlinkzip bash scripts/osx-package.sh` using PyInstaller 6.2.0
- extracted the script-built zip with `/usr/bin/unzip` and verified it preserved 94 symlinks
- `codesign --verify --deep --strict --verbose=2` on the extracted app
- extracted-app launch check with a 5s settle between relaunches: 1.64s / 1.65s / 1.65s / 1.71s / 1.99s, median 1.65s
- `git diff --check`

Local pytest note: I did not treat pytest as the validation path for this packaging-only change. In this checkout, current local collection fails before tests run due existing test setup/import issues (`saveddata.db` path on normal run, then `IPortUser` import under `TRAVIS=true`).
