### PR TITLE
Feature: Display Omega icons for hulls and modules

### DIFF
--- a/db_update.py
+++ b/db_update.py
@@ -664,6 +664,27 @@ def update_db():
             else:
                 attr.value = value
 
+    def processCloneGradeRestrictions():
+        print('processing clone grade restrictions')
+        alpha_caps = {}
+        for clone in eos.db.gamedata_session.query(eos.gamedata.AlphaClone).all():
+            for skill in clone.skills:
+                alpha_caps[skill.typeID] = skill.level
+        for item in eos.db.gamedata_session.query(eos.gamedata.Item).all():
+            if not item.reqskills:
+                continue
+            try:
+                reqskills = json.loads(item.reqskills)
+            except (ValueError, TypeError):
+                continue
+            for skill_type_id, required_level in reqskills.items():
+                max_alpha_level = alpha_caps.get(int(skill_type_id))
+                if max_alpha_level is None or required_level > max_alpha_level:
+                    _hardcodeAttribs(item.ID, {"cloneGradeRestriction": 1})
+                    break
+
+    processCloneGradeRestrictions()
+
     def _hardcodeEffects(typeID, effectMap, clearEffects=True):
         item = eos.db.gamedata_session.query(eos.gamedata.Item).filter(eos.gamedata.Item.ID == typeID).one()
         if clearEffects:

--- a/gui/builtinMarketBrowser/itemView.py
+++ b/gui/builtinMarketBrowser/itemView.py
@@ -20,7 +20,8 @@ pyfalog = Logger(__name__)
 
 class ItemView(Display):
 
-    DEFAULT_COLS = ["Base Icon",
+    DEFAULT_COLS = ["Omega",
+                    "Base Icon",
                     "Base Name",
                     "attr:power,,,True",
                     "attr:cpu,,,True"]

--- a/gui/builtinMarketBrowser/itemView.py
+++ b/gui/builtinMarketBrowser/itemView.py
@@ -6,6 +6,7 @@ import gui.globalEvents as GE
 from config import slotColourMap, slotColourMapDark
 from eos.saveddata.module import Module
 from gui.builtinMarketBrowser.events import ItemSelected, RECENTLY_USED_MODULES, CHARGES_FOR_FIT
+from gui.builtinViewColumns.omega import Omega as OmegaCol
 from gui.contextMenu import ContextMenu
 from gui.display import Display
 from gui.utils.staticHelpers import DragDropHelper
@@ -59,6 +60,15 @@ class ItemView(Display):
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
 
         self.active = []
+        self.updateOmegaColumn()
+
+    def updateOmegaColumn(self):
+        show = Fit.getInstance().serviceFittingOptions["showOmegaIcons"]
+        omega_idx = self.getColIndex(OmegaCol)
+        if show and omega_idx is None:
+            self.insertColumnBySpec(0, "Omega")
+        elif not show and omega_idx is not None:
+            self.removeColumn(self.activeColumns[omega_idx])
 
     def delaySearch(self, evt):
         sFit = Fit.getInstance()

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -141,6 +141,14 @@ class PFGeneralPref(PreferenceView):
                                                     wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbShowShipBrowserTooltip, 0, wx.ALL | wx.EXPAND, 5)
 
+        self.cbShowOmegaIcons = wx.CheckBox(panel, wx.ID_ANY, _t("Show Omega icons for hulls and modules"),
+                                            wx.DefaultPosition, wx.DefaultSize, 0)
+        if "wxGTK" not in wx.PlatformInfo:
+            self.cbShowOmegaIcons.SetCursor(helpCursor)
+        self.cbShowOmegaIcons.SetToolTip(wx.ToolTip(
+                _t('Shows icons for items that require Omega clone access.')))
+        mainSizer.Add(self.cbShowOmegaIcons, 0, wx.ALL | wx.EXPAND, 5)
+
         self.cbReloadAll = wx.CheckBox(panel, wx.ID_ANY, _t("Change charge in all modules of the same type"),
                                        wx.DefaultPosition, wx.DefaultSize, 0)
         if "wxGTK" not in wx.PlatformInfo:
@@ -176,6 +184,7 @@ class PFGeneralPref(PreferenceView):
         self.cbGaugeAnimation.SetValue(self.sFit.serviceFittingOptions["enableGaugeAnimation"])
         self.cbOpenFitInNew.SetValue(self.sFit.serviceFittingOptions["openFitInNew"])
         self.cbShowShipBrowserTooltip.SetValue(self.sFit.serviceFittingOptions["showShipBrowserTooltip"])
+        self.cbShowOmegaIcons.SetValue(self.sFit.serviceFittingOptions["showOmegaIcons"])
         self.cbReloadAll.SetValue(self.sFit.serviceFittingOptions["ammoChangeAll"])
         self.cbExpMutants.SetValue(self.sFit.serviceFittingOptions["expandedMutantNames"])
         self.rbAddLabels.SetSelection(self.sFit.serviceFittingOptions["additionsLabels"])
@@ -192,6 +201,7 @@ class PFGeneralPref(PreferenceView):
         self.cbGaugeAnimation.Bind(wx.EVT_CHECKBOX, self.onCBGaugeAnimation)
         self.cbOpenFitInNew.Bind(wx.EVT_CHECKBOX, self.onCBOpenFitInNew)
         self.cbShowShipBrowserTooltip.Bind(wx.EVT_CHECKBOX, self.onCBShowShipBrowserTooltip)
+        self.cbShowOmegaIcons.Bind(wx.EVT_CHECKBOX, self.onCBShowOmegaIcons)
         self.cbReloadAll.Bind(wx.EVT_CHECKBOX, self.onCBReloadAll)
         self.cbExpMutants.Bind(wx.EVT_CHECKBOX, self.onCBExpMutants)
 
@@ -272,6 +282,25 @@ class PFGeneralPref(PreferenceView):
 
     def onCBShowShipBrowserTooltip(self, event):
         self.sFit.serviceFittingOptions["showShipBrowserTooltip"] = self.cbShowShipBrowserTooltip.GetValue()
+
+    def onCBShowOmegaIcons(self, event):
+        self.sFit.serviceFittingOptions["showOmegaIcons"] = self.cbShowOmegaIcons.GetValue()
+
+        from gui.builtinViews.fittingView import FittingView
+        for page in self.mainFrame.fitMultiSwitch._pages:
+            if isinstance(page, FittingView):
+                page.updateOmegaColumn()
+
+        iView = self.mainFrame.marketBrowser.itemView
+        iView.updateOmegaColumn()
+        if iView.active:
+            iView.update(iView.active)
+
+        fitID = self.mainFrame.getActiveFit()
+        if fitID is not None:
+            wx.PostEvent(self.mainFrame, GE.FitChanged(fitIDs=(fitID,)))
+
+        event.Skip()
 
     def onCBReloadAll(self, event):
         self.sFit.serviceFittingOptions["ammoChangeAll"] = self.cbReloadAll.GetValue()

--- a/gui/builtinShipBrowser/shipItem.py
+++ b/gui/builtinShipBrowser/shipItem.py
@@ -93,6 +93,10 @@ class ShipItem(SFItem.SFBrowserItem):
         self.marketInstance = Market.getInstance()
         self.baseItem = self.marketInstance.getItem(self.shipID)
 
+        self.omegaBmp = None
+        if self.baseItem.getAttribute("cloneGradeRestriction", 0) > 0:
+            self.omegaBmp = BitmapLoader.getBitmap("25874", "icons")
+
         # =====================================================================
         # DISABLED - it will be added as an option in PREFERENCES
 
@@ -211,7 +215,12 @@ class ShipItem(SFItem.SFBrowserItem):
         self.raceBmpx = self.shipEffx + self.shipEffBk.GetWidth() + self.padding
         self.raceBmpy = (rect.height - self.raceBmp.GetHeight()) / 2
 
-        self.textStartx = self.raceBmpx + self.raceBmp.GetWidth() + self.padding
+        self.omegaBmpx = self.raceBmpx + self.raceBmp.GetWidth() + self.padding
+        omegaWidth = self.omegaBmp.GetWidth() if self.omegaBmp else 0
+        omegaHeight = self.omegaBmp.GetHeight() if self.omegaBmp else 0
+        self.omegaBmpy = (rect.height - omegaHeight) / 2
+
+        self.textStartx = self.omegaBmpx + omegaWidth + self.padding
 
         self.shipNamey = (rect.height - self.shipBmp.GetHeight()) / 2
 
@@ -253,6 +262,9 @@ class ShipItem(SFItem.SFBrowserItem):
 
         mdc.DrawBitmap(self.raceDropShadowBmp, round(self.raceBmpx + 1), round(self.raceBmpy + 1))
         mdc.DrawBitmap(self.raceBmp, round(self.raceBmpx), round(self.raceBmpy))
+
+        if self.omegaBmp:
+            mdc.DrawBitmap(self.omegaBmp, round(self.omegaBmpx), round(self.omegaBmpy))
 
         shipName, shipTrait, fittings = self.shipFittingInfo
 

--- a/gui/builtinShipBrowser/shipItem.py
+++ b/gui/builtinShipBrowser/shipItem.py
@@ -94,8 +94,6 @@ class ShipItem(SFItem.SFBrowserItem):
         self.baseItem = self.marketInstance.getItem(self.shipID)
 
         self.omegaBmp = None
-        if self.baseItem.getAttribute("cloneGradeRestriction", 0) > 0:
-            self.omegaBmp = BitmapLoader.getBitmap("25874", "icons")
 
         # =====================================================================
         # DISABLED - it will be added as an option in PREFERENCES
@@ -215,9 +213,13 @@ class ShipItem(SFItem.SFBrowserItem):
         self.raceBmpx = self.shipEffx + self.shipEffBk.GetWidth() + self.padding
         self.raceBmpy = (rect.height - self.raceBmp.GetHeight()) / 2
 
-        self.omegaBmpx = self.raceBmpx + self.raceBmp.GetWidth() + self.padding
+        sFit = Fit.getInstance()
+        self.omegaBmp = None
+        if sFit.serviceFittingOptions["showOmegaIcons"] and self.baseItem.getAttribute("cloneGradeRestriction", 0) > 0:
+            self.omegaBmp = BitmapLoader.getBitmap("25874", "icons")
         omegaWidth = self.omegaBmp.GetWidth() if self.omegaBmp else 0
         omegaHeight = self.omegaBmp.GetHeight() if self.omegaBmp else 0
+        self.omegaBmpx = self.raceBmpx + self.raceBmp.GetWidth() + self.padding
         self.omegaBmpy = (rect.height - omegaHeight) / 2
 
         self.textStartx = self.omegaBmpx + omegaWidth + self.padding

--- a/gui/builtinViewColumns/omega.py
+++ b/gui/builtinViewColumns/omega.py
@@ -26,8 +26,7 @@ class Omega(ViewColumn):
 
     def __init__(self, fittingView, params):
         ViewColumn.__init__(self, fittingView)
-        self.size = 16
-        self.maxsize = self.size
+        self.size = 20
         self.mask = wx.LIST_MASK_IMAGE
         self.columnText = "\u03A9"
 

--- a/gui/builtinViewColumns/omega.py
+++ b/gui/builtinViewColumns/omega.py
@@ -1,0 +1,54 @@
+# noinspection PyPackageRequirements
+import wx
+
+import eos.db
+from eos.saveddata.module import Module, Rack
+from eos.saveddata.drone import Drone
+from gui.viewColumn import ViewColumn
+
+
+_alpha_skill_caps = None
+
+
+def _get_alpha_skill_caps():
+    global _alpha_skill_caps
+    if _alpha_skill_caps is None:
+        _alpha_skill_caps = {}
+        alpha_clone = eos.db.getAlphaClone(1)
+        if alpha_clone is not None:
+            for skill_entry in alpha_clone.skills:
+                _alpha_skill_caps[skill_entry.typeID] = skill_entry.level
+    return _alpha_skill_caps
+
+
+class Omega(ViewColumn):
+    name = "Omega"
+
+    def __init__(self, fittingView, params):
+        ViewColumn.__init__(self, fittingView)
+        self.size = 16
+        self.maxsize = self.size
+        self.mask = wx.LIST_MASK_IMAGE
+        self.columnText = "\u03A9"
+
+    def getImageId(self, stuff):
+        if isinstance(stuff, (Module, Drone)):
+            if stuff.isEmpty:
+                return -1
+            item = stuff.item
+        else:
+            item = getattr(stuff, "item", stuff)
+        if item is None:
+            return -1
+        if item.getAttribute("cloneGradeRestriction", 0) > 0:
+            return self.fittingView.imageList.GetImageIndex(25874, "icons")
+        caps = _get_alpha_skill_caps()
+        if caps:
+            for skill_item, required_level in item.requiredSkills.items():
+                max_alpha_level = caps.get(skill_item.ID)
+                if max_alpha_level is None or required_level > max_alpha_level:
+                    return self.fittingView.imageList.GetImageIndex(25874, "icons")
+        return -1
+
+
+Omega.register()

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -138,6 +138,7 @@ class FittingViewDrop(wx.DropTarget):
 
 class FittingView(d.Display):
     DEFAULT_COLS = ["State",
+                    "Omega",
                     "Ammo Icon",
                     "Base Icon",
                     "Base Name",

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -35,6 +35,7 @@ from eos.const import FittingSlot
 from gui.bitmap_loader import BitmapLoader
 from gui.builtinMarketBrowser.events import ITEM_SELECTED
 from gui.builtinShipBrowser.events import EVT_FIT_SELECTED, FitSelected
+from gui.builtinViewColumns.omega import Omega as OmegaCol
 from gui.builtinViewColumns.state import State
 from gui.chrome_tabs import EVT_NOTEBOOK_PAGE_CHANGED
 from gui.contextMenu import ContextMenu
@@ -154,6 +155,7 @@ class FittingView(d.Display):
 
     def __init__(self, parent):
         d.Display.__init__(self, parent, size=(0, 0), style=wx.BORDER_NONE)
+        self.updateOmegaColumn()
         self.Show(False)
         self.parent = parent
         self.mainFrame.Bind(GE.FIT_CHANGED, self.fitChanged)
@@ -184,6 +186,14 @@ class FittingView(d.Display):
         self.parent.Bind(EVT_NOTEBOOK_PAGE_CHANGED, self.pageChanged)
         pyfalog.debug("------------------ new fitting view -------------------")
         pyfalog.debug(self)
+
+    def updateOmegaColumn(self):
+        show = Fit.getInstance().serviceFittingOptions["showOmegaIcons"]
+        omega_idx = self.getColIndex(OmegaCol)
+        if show and omega_idx is None:
+            self.insertColumnBySpec(1, "Omega")
+        elif not show and omega_idx is not None:
+            self.removeColumn(self.activeColumns[omega_idx])
 
     def OnLeaveWindow(self, event):
         self.SetToolTip(None)

--- a/gui/display.py
+++ b/gui/display.py
@@ -88,7 +88,7 @@ class Display(wx.ListCtrl):
 
     # noinspection PyPropertyAccess
     def addColumn(self, i, col):
-        self.activeColumns.append(col)
+        self.activeColumns.insert(i, col)
         info = wx.ListItem()
         info.SetMask(col.mask | wx.LIST_MASK_FORMAT)
         if col.imageId not in (None, -1):
@@ -124,7 +124,7 @@ class Display(wx.ListCtrl):
             col = ViewColumn.getColumn(colSpec)(self, None)
 
         self.addColumn(i, col)
-        self.columnsMinWidth.append(self.GetColumnWidth(i))
+        self.columnsMinWidth.insert(i, self.GetColumnWidth(i))
 
     def removeColumn(self, col):
         i = self.getColIndex(type(col))

--- a/gui/viewColumn.py
+++ b/gui/viewColumn.py
@@ -86,6 +86,7 @@ from gui.builtinViewColumns import (  # noqa: E402, F401
     heat,
     maxRange,
     misc,
+    omega,
     price,
     projectionRange,
     propertyDisplay,

--- a/service/fit.py
+++ b/service/fit.py
@@ -94,6 +94,7 @@ class Fit:
             "ammoChangeAll": False,
             "additionsLabels": 1,
             "expandedMutantNames": False,
+            "showOmegaIcons": False,
         }
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(


### PR DESCRIPTION
# Problem
Some hulls and modules can be used by Omega clones only, but it's not reflected in Pyfa item list.

This makes building Alpha-clone friendly fits difficult, as there is no clear indication if a module will work.

# Solution

Display Omega icons for hulls and modules both in item list and fits:

<img width="1543" height="693" alt="image_2026-06-08_09-47-11" src="https://github.com/user-attachments/assets/f77592d5-7cc3-4dae-8422-eb5865ea27ae" />
<img width="1543" height="693" alt="image_2026-06-08_09-47-54" src="https://github.com/user-attachments/assets/afde7512-8a18-4344-8c61-f5c07e1e9a90" />

## Implementation details

The Omega modules/hulls are gated by skills only (proof: https://github.com/esi/esi-issues/issues/133#issuecomment-341815740)
The Omega attribute is calculated and persisted for better performance.