### PR TITLE
fix(export): use type names for mutated module EFT export

### DIFF
--- a/service/port/muta.py
+++ b/service/port/muta.py
@@ -28,8 +28,8 @@ from service.esiAccess import EsiAccess
 
 def renderMutant(mutant, firstPrefix='', prefix=''):
     exportLines = []
-    exportLines.append('{}{}'.format(firstPrefix, mutant.baseItem.name))
-    exportLines.append('{}{}'.format(prefix, mutant.mutaplasmid.item.name))
+    exportLines.append('{}{}'.format(firstPrefix, mutant.baseItem.typeName))
+    exportLines.append('{}{}'.format(prefix, mutant.mutaplasmid.item.typeName))
     exportLines.append('{}{}'.format(prefix, renderMutantAttrs(mutant)))
     return '\n'.join(exportLines)
 


### PR DESCRIPTION
## Summary

This PR fixes an EFT export issue when pyfa is running under a non-English locale.

When exporting a fit to clipboard with mutated attributes enabled, the mutation detail block could include a localized module name. Since EFT import expects canonical type names, the exported fit could not be imported again.

This change makes the export path use canonical type names for mutated module entries, regardless of the current UI language.

## Problem

Example exported mutation block under a Chinese locale:

```text
[1] 重型盗墓者紧凑型掠能器
  不稳定的重型掠能器突变质体
  cpu 40.0, maxRange 16000.0, power 1800.0, powerTransferAmount 110.0
```

The localized module name makes the EFT export invalid for re-import.

## Fix

Use the item type name when generating mutated module export text instead of the localized display name.

Expected output:

```text
[1] Heavy Ghoul Compact Energy Nosferatu
  Unstable Heavy Energy Nosferatu Mutaplasmid
  cpu 40.0, maxRange 16000.0, power 1800.0, powerTransferAmount 110.0
```

## Testing

* Exported a fit containing mutated modules with mutated attributes enabled.
* Verified that the mutation block uses canonical type names.
* Verified that the exported EFT can be imported again.
