### PR TITLE
Fix Linux startup crash caused by the update notification dialog

### DIFF
--- a/dist_assets/linux/AppImageBuilder.yml
+++ b/dist_assets/linux/AppImageBuilder.yml
@@ -30,7 +30,6 @@ AppDir:
       # wx dependencies
       - libgtk-3-0
       - librsvg2-common  # GTK3 recommendation; without it, search in char editor crashes
-      - libwebkit2gtk-4.0-37  # Needed for wx's HTML lib
       # Unknown
       - libpcre2-32-0  # https://github.com/pyfa-org/Pyfa/issues/2572
       - libnotify4  # https://github.com/pyfa-org/Pyfa/issues/2598

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -242,8 +242,16 @@ class MainFrame(wx.Frame):
         return Fit.getCommandProcessor(fitID)
 
     def ShowUpdateBox(self, release, version):
-        with UpdateDialog(self, release, version) as dlg:
-            dlg.ShowModal()
+        # This runs right after startup, so any failure here must not be able
+        # to take the whole application down with it
+        try:
+            with UpdateDialog(self, release, version) as dlg:
+                dlg.ShowModal()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            pyfalog.error("Caught exception while showing the update notification dialog")
+            pyfalog.error(e)
 
     def LoadPreviousOpenFits(self):
         sFit = Fit.getInstance()

--- a/gui/updateDialog.py
+++ b/gui/updateDialog.py
@@ -21,11 +21,13 @@
 import wx
 # noinspection PyPackageRequirements
 import dateutil.parser
+from logbook import Logger
 from service.settings import UpdateSettings as svc_UpdateSettings
-import wx.html2
 import webbrowser
 import re
 import markdown2
+
+pyfalog = Logger(__name__)
 
 _t = wx.GetTranslation
 
@@ -51,8 +53,8 @@ class UpdateDialog(wx.Dialog):
 
     def __init__(self, parent, release, version):
         super().__init__(
-            parent, id=wx.ID_ANY, title="pyfa {}" + _t("Update Available"), pos=wx.DefaultPosition,
-            size=wx.Size(550, 450), style=wx.DEFAULT_DIALOG_STYLE)
+            parent, id=wx.ID_ANY, title="pyfa {} - {}".format(release['tag_name'], _t("Update Available")),
+            pos=wx.DefaultPosition, size=wx.Size(550, 450), style=wx.DEFAULT_DIALOG_STYLE)
 
         self.UpdateSettings = svc_UpdateSettings.getInstance()
         self.releaseInfo = release
@@ -61,42 +63,22 @@ class UpdateDialog(wx.Dialog):
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
         releaseDate = dateutil.parser.parse(self.releaseInfo['published_at'])
+        releaseNotes = self.releaseInfo.get('body') or ''
         notesSizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.browser = wx.html2.WebView.New(self)
-        self.browser.Bind(wx.html2.EVT_WEBVIEW_NEWWINDOW, self.OnNewWindow)
 
-        link_patterns = [
-            (re.compile(r"#(\d+)", re.I), r"https://github.com/pyfa-org/Pyfa/issues/\1"),
-            (re.compile(r"@(\w+)", re.I), r"https://github.com/\1")
-        ]
-
-        markdowner = markdown2.Markdown(
-            extras=['cuddled-lists', 'fenced-code-blocks', 'target-blank-links', 'toc', 'link-patterns'],
-            link_patterns=link_patterns)
-
-        release_markup = markdowner.convert(self.releaseInfo['body'])
-
-        # run the text through markup again, this time with the hashing pattern. This is required due to bugs in markdown2:
-        # https://github.com/trentm/python-markdown2/issues/287
-        link_patterns = [
-            (re.compile("([0-9a-f]{6,40})", re.I), r"https://github.com/pyfa-org/Pyfa/commit/\1"),
-        ]
-
-        markdowner = markdown2.Markdown(
-            extras=['cuddled-lists', 'fenced-code-blocks', 'target-blank-links', 'toc', 'link-patterns'],
-            link_patterns=link_patterns)
-
-        # The space here is required, again, due to bug. Again, see https://github.com/trentm/python-markdown2/issues/287
-        release_markup = markdowner.convert(' ' + release_markup)
-
-        self.browser.SetPage(html_tmpl.format(
-            self.releaseInfo['tag_name'],
-            releaseDate.strftime('%B %d, %Y'),
-            "<p class='text-danger'><b>This is a pre-release, be prepared for unstable features</b></p>" if version.is_prerelease else "",
-            release_markup
-        ), "")
-
-        notesSizer.Add(self.browser, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+        self.browser = self.createNotesBrowser(releaseDate, releaseNotes, version)
+        if self.browser is None:
+            header = "pyfa {} ({})".format(self.releaseInfo['tag_name'], releaseDate.strftime('%B %d, %Y'))
+            lines = [header, '=' * len(header), '']
+            if version.is_prerelease:
+                lines += [_t("This is a pre-release, be prepared for unstable features"), '']
+            lines.append(releaseNotes)
+            self.notesText = wx.TextCtrl(
+                self, wx.ID_ANY, '\n'.join(lines), wx.DefaultPosition, wx.DefaultSize,
+                wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP)
+            notesSizer.Add(self.notesText, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+        else:
+            notesSizer.Add(self.browser, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
         mainSizer.Add(notesSizer, 1, wx.EXPAND, 5)
 
         self.supressCheckbox = wx.CheckBox(self, wx.ID_ANY, _t("Don't remind me again for this release"),
@@ -130,6 +112,86 @@ class UpdateDialog(wx.Dialog):
         self.UpdateSettings.set('version', None)
 
         self.Centre(wx.BOTH)
+
+    @staticmethod
+    def webViewAvailable():
+        """
+        On wxGTK the wx.html2.WebView widget is backed by WebKitGTK, which cannot
+        be instantiated reliably on every Linux setup. In particular, the AppImage
+        bundles an Ubuntu build of WebKitGTK that fails to spawn its helper
+        processes on other distributions, aborting the whole application
+        (see https://github.com/pyfa-org/Pyfa/issues/2740). Never use the WebView
+        there; on other platforms make sure a backend can be loaded at all.
+        """
+        if 'wxGTK' in wx.PlatformInfo:
+            return False
+        try:
+            from wx import html2
+            return html2.WebView.IsBackendAvailable(html2.WebViewBackendDefault)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            pyfalog.warning("Could not check WebView backend availability: {}", e)
+            return False
+
+    def createNotesBrowser(self, releaseDate, releaseNotes, version):
+        """
+        Build the WebView displaying the release notes. Returns None when the
+        WebView cannot be used, so the caller can fall back to plain text.
+        """
+        if not self.webViewAvailable():
+            return None
+
+        from wx import html2
+        try:
+            browser = html2.WebView.New(self)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            pyfalog.warning("Could not create WebView for the update dialog: {}", e)
+            return None
+
+        browser.Bind(html2.EVT_WEBVIEW_NEWWINDOW, self.OnNewWindow)
+
+        link_patterns = [
+            (re.compile(r"#(\d+)", re.I), r"https://github.com/pyfa-org/Pyfa/issues/\1"),
+            (re.compile(r"@(\w+)", re.I), r"https://github.com/\1")
+        ]
+
+        markdowner = markdown2.Markdown(
+            extras=['cuddled-lists', 'fenced-code-blocks', 'target-blank-links', 'toc', 'link-patterns'],
+            link_patterns=link_patterns)
+
+        release_markup = markdowner.convert(releaseNotes)
+
+        # run the text through markup again, this time with the hashing pattern. This is required due to bugs in markdown2:
+        # https://github.com/trentm/python-markdown2/issues/287
+        link_patterns = [
+            (re.compile("([0-9a-f]{6,40})", re.I), r"https://github.com/pyfa-org/Pyfa/commit/\1"),
+        ]
+
+        markdowner = markdown2.Markdown(
+            extras=['cuddled-lists', 'fenced-code-blocks', 'target-blank-links', 'toc', 'link-patterns'],
+            link_patterns=link_patterns)
+
+        # The space here is required, again, due to bug. Again, see https://github.com/trentm/python-markdown2/issues/287
+        release_markup = markdowner.convert(' ' + release_markup)
+
+        try:
+            browser.SetPage(html_tmpl.format(
+                self.releaseInfo['tag_name'],
+                releaseDate.strftime('%B %d, %Y'),
+                "<p class='text-danger'><b>This is a pre-release, be prepared for unstable features</b></p>" if version.is_prerelease else "",
+                release_markup
+            ), "")
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            pyfalog.warning("Could not load release notes into WebView: {}", e)
+            browser.Destroy()
+            return None
+
+        return browser
 
     def OnClose(self, e):
         self.Close()


### PR DESCRIPTION
Hi! I love pyfa - I've been using it for years. I'm primarily on Linux these days, and it would crash on startup, so I decided to fix that and give some love back to the project. More to follow if you're happy with my work (I was thinking about the dark mode request, but then again, on Linux it's already sort of there, so I'd need to switch machines... eh, we'll see).

## What / why

Addresses #2740 - the Linux AppImage dies ~2-3 s after launch with nothing in the Python log.

## Root cause

The update notification dialog (`gui/updateDialog.py`) is the only user of `wx.html2.WebView`. On wxGTK that's WebKitGTK, and:

1. **AppImage**: the builder bundles jammy's `libwebkit2gtk-4.0-37`. The library loads, but WebKit then tries to spawn its helper processes at the Ubuntu-hardcoded path `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/WebKitNetworkProcess`, which doesn't exist on other distros - a fatal GLib error that aborts the app with no Python traceback. This is why it "appeared" with 2.66.2: `git diff v2.66.1..v2.66.3` touched nothing in the startup/update path - 2.66.2 was simply the first release new enough for the popup to run at all. Reproduced on Fedora 44 with the v2.64.2 AppImage (exit 133 = SIGTRAP):

   ```
   ** (pyfa.py:856537): ERROR **: 20:41:04.016: Unable to spawn a new child process:
   Failed to spawn child process "/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/WebKitNetworkProcess"
   (No such file or directory)
   ```

   In `~/.pyfa/pyfa.log`, every crashed launch ends exactly at `service.update: Starting Check Update Thread.`

2. **From source** on distros without webkit2gtk-4.0 (Fedora today): `import wx.html2` itself fails, so startup dies before the main window - `gui/mainFrame.py` imports the dialog at module level.

## Changes

- `gui/updateDialog.py`: never use the WebView on wxGTK (a native abort can't be caught with try/except) - release notes render in a read-only `wx.TextCtrl` instead; the Download button already opens the release page in a browser. Other platforms keep the WebView but check `IsBackendAvailable()` and guard `WebView.New()`/`SetPage()`, falling back to plain text on failure. `import wx.html2` is now lazy so startup doesn't depend on WebKitGTK being present. Two small guards while there: `releaseInfo['body']` may be `None` (would `TypeError`), and the dialog title contained a literal `{}` - it now shows the release tag.
- `gui/mainFrame.py`: `ShowUpdateBox` wrapped in try/except + logging so a dialog failure can never silently break startup again.
- `dist_assets/linux/AppImageBuilder.yml`: drop `libwebkit2gtk-4.0-37` - nothing loads it on Linux anymore. **Happy to split this into a separate PR if preferred.**

Behavior on Windows/macOS is unchanged (WebView2/WKWebView still used, now guarded).

## Verified

- Reproduced pre-fix: AppImage crash (signature above), and from-source startup failure at `import wx.html2`, both on Fedora 44.
- Post-fix: app starts and stays up from source (venv, wxPython 4.2.1 gtk3 wheels); faked an old version in `version.yml` to force the popup - app survives, dialog opens with plain-text notes; headless `UpdateDialog` construction against live release data passes; flake8 (tox pep8 flags) adds zero findings on changed files.
- Not verified: a rebuilt AppImage (needs appimage-builder on Ubuntu) - but the WebKitGTK code path is gone entirely on Linux.

## Notes

Flagging so that you know: `service/update.py` swallows the primary endpoint's error silently (lines 54-59) and assumes the response is a JSON list (line 61) - might be worth fixing later?

