### PR TITLE
Bundle SDL2 in the Linux AppImage

### DIFF
--- a/dist_assets/linux/AppImageBuilder.yml
+++ b/dist_assets/linux/AppImageBuilder.yml
@@ -34,6 +34,7 @@ AppDir:
       - libpcre2-32-0  # https://github.com/pyfa-org/Pyfa/issues/2572
       - libnotify4  # https://github.com/pyfa-org/Pyfa/issues/2598
       - libwayland-client0  # https://github.com/pyfa-org/Pyfa/issues/2600
+      - libsdl2-2.0-0  # wx core links against it, host copy is sdl2-compat on Debian testing and aborts on load  # https://github.com/pyfa-org/Pyfa/issues/2740
     exclude:
       - hicolor-icon-theme
       - humanity-icon-theme


### PR DESCRIPTION
forgive me for being lazy, i typed it out in the issue, generated the PR


## agent output

The AppImage never bundled `libSDL2-2.0.so.0`, even though wxPython's `libwx_gtk3u_core-3.2.so.0` has a hard `DT_NEEDED` on it and pulls it in on every `import wx`. The wheel is pip-installed in `after_bundle`, after appimage-builder has finished resolving apt dependencies, so nothing ever pulled SDL in and the host copy was used instead.

That works where the host has real SDL2 (Fedora), but on Debian testing `libsdl2-2.0-0` is now built from `sdl2-compat`, whose library constructor calls `abort()` when it cannot `dlopen("libSDL3.so.0")`. It cannot, because the AppDir libraries come first on the search path and host SDL3 3.4.14 needs a newer `libxkbcommon` than the bundled jammy 1.4.0. pyfa dies during `import wx` with `Failed loading SDL3 library.` and SIGABRT, before any of its own code runs. Details in #2740.

Adding `libsdl2-2.0-0` to `apt.include` bundles jammy's real SDL 2.0.20, so the host copy is never loaded. Verified by staging that library into an extracted v2.68.0 AppDir and running it in a `debian:testing` container: the bundled copy is the one initialised, and the main window comes up instead of aborting.