### PR TITLE
Ignore volume of active fighters for fighterBayUsed

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1320,7 +1320,8 @@ class Fit:
     def fighterBayUsed(self):
         amount = 0
         for f in self.fighters:
-            amount += f.item.attributes['volume'].value * f.amount
+            if not f.active:
+                amount += f.item.attributes['volume'].value * f.amount
 
         return amount
 


### PR DESCRIPTION
Small logic change to ignore the volume of **active fighter squads** when calculating the volume of m3 used in the _Fighters Bay_.

In Eve the active squads are not in the _Fighters Bay_ but in the _Launch Tubes_ of the carrier or the supercarrier. When theory-crafting fits for those ships people have to take into consideration the fact that Pyfa store all the fighters in the _Fighters Bay_ and manually do the math to calculate the amount of fighters the ships need to have under optimal condition. Removing active fighter squads from the volume used in the _Fighters Bay_  let people easily simulate the action of moving fighters from the _Fighters Bay_ to the _Launch Tubes_.