### PR TITLE
Improve system theme and appearance settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ eve.db
 
 # vscode settings
 .vscode
+
+# Local launcher (not for upstream)
+run.ps1

--- a/gui/app.py
+++ b/gui/app.py
@@ -4,7 +4,7 @@ import os
 import sys
 from logbook import Logger
 pyfalog = Logger(__name__)
-from service.settings import LocaleSettings
+from service.settings import LocaleSettings, ThemeSettings
 
 
 class PyfaApp(wx.App):
@@ -15,6 +15,9 @@ class PyfaApp(wx.App):
 
         # Name for my application.
         self.appName = "pyfa"
+
+        # Windows can only apply appearance before any windows exist.
+        self.ApplyAppearance()
 
         #------------
 
@@ -75,3 +78,24 @@ class PyfaApp(wx.App):
         else:
             pyfalog.debug("Cannot find langauge: " + lang)
             self.locale = wx.Locale(wx.Locale.FindLanguageInfo(LocaleSettings.defaults['locale']).Language)
+
+    def ApplyAppearance(self):
+        try:
+            appearance_map = {
+                ThemeSettings.SYSTEM: wx.App.Appearance.System,
+                ThemeSettings.LIGHT: wx.App.Appearance.Light,
+                ThemeSettings.DARK: wx.App.Appearance.Dark,
+            }
+        except AttributeError:
+            pyfalog.debug("wx.App.Appearance is not available; skipping theme setup")
+            return
+
+        mode = ThemeSettings.getInstance().get('appearance')
+        target = appearance_map.get(mode, wx.App.Appearance.System)
+        try:
+            result = self.SetAppearance(target)
+            pyfalog.info("Set appearance to {0} (result {1})", mode, result)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            pyfalog.warning("Failed to set application appearance: {0}", e)

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -40,7 +40,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.stSetUserPath, 0, wx.ALL, 5)
         self.inputUserPath = wx.TextCtrl(panel, wx.ID_ANY, config.savePath, wx.DefaultPosition, wx.DefaultSize, 0)
         self.inputUserPath.SetEditable(False)
-        self.inputUserPath.SetBackgroundColour((200, 200, 200))
+        self.inputUserPath.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
         mainSizer.Add(self.inputUserPath, 0, wx.ALL | wx.EXPAND, 5)
 
         # Save DB
@@ -50,7 +50,7 @@ class PFGeneralPref(PreferenceView):
 
         self.inputFitDB = wx.TextCtrl(panel, wx.ID_ANY, config.saveDB, wx.DefaultPosition, wx.DefaultSize, 0)
         self.inputFitDB.SetEditable(False)
-        self.inputFitDB.SetBackgroundColour((200, 200, 200))
+        self.inputFitDB.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
         mainSizer.Add(self.inputFitDB, 0, wx.ALL | wx.EXPAND, 5)
 
         # Game Data DB
@@ -60,7 +60,7 @@ class PFGeneralPref(PreferenceView):
 
         self.inputGameDB = wx.TextCtrl(panel, wx.ID_ANY, config.gameDB, wx.DefaultPosition, wx.DefaultSize, 0)
         self.inputGameDB.SetEditable(False)
-        self.inputGameDB.SetBackgroundColour((200, 200, 200))
+        self.inputGameDB.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
         mainSizer.Add(self.inputGameDB, 0, wx.ALL | wx.EXPAND, 5)
 
         self.cbsaveInRoot.SetValue(config.saveInRoot)

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -6,7 +6,7 @@ import gui.mainFrame
 from gui.bitmap_loader import BitmapLoader
 from gui.preferenceView import PreferenceView
 from service.fit import Fit
-from service.settings import SettingsProvider, LocaleSettings
+from service.settings import SettingsProvider, LocaleSettings, ThemeSettings
 import eos.config
 import wx.lib.agw.hyperlink as hl
 
@@ -23,6 +23,7 @@ class PFGeneralPref(PreferenceView):
         self.openFitsSettings = SettingsProvider.getInstance().getSettings("pyfaPrevOpenFits",
                                                                            {"enabled": False, "pyfaOpenFits": []})
         self.localeSettings = LocaleSettings.getInstance()
+        self.themeSettings = ThemeSettings.getInstance()
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
         self.stTitle = wx.StaticText(panel, wx.ID_ANY, self.title, wx.DefaultPosition, wx.DefaultSize, 0)
@@ -94,6 +95,17 @@ class PFGeneralPref(PreferenceView):
                                   _t("Auto will use the same language pyfa uses if available, otherwise English"),
                                   wx.DefaultPosition,
                                   wx.DefaultSize, 0), 0, wx.LEFT, 15)
+
+        self.appearanceChoices = [ThemeSettings.SYSTEM, ThemeSettings.LIGHT, ThemeSettings.DARK]
+        self.rbAppearance = wx.RadioBox(panel, -1, _t("Appearance (requires restart)"), wx.DefaultPosition, wx.DefaultSize,
+                                        [_t("System"), _t("Light"), _t("Dark")], 1, wx.RA_SPECIFY_COLS)
+        mainSizer.Add(self.rbAppearance, 0, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 10)
+        appearance = self.themeSettings.get('appearance')
+        try:
+            self.rbAppearance.SetSelection(self.appearanceChoices.index(appearance))
+        except ValueError:
+            self.rbAppearance.SetSelection(0)
+        self.rbAppearance.Bind(wx.EVT_RADIOBOX, self.OnAppearanceChange)
 
         self.cbGlobalChar = wx.CheckBox(panel, wx.ID_ANY, _t("Use global character"), wx.DefaultPosition, wx.DefaultSize,
                                         0)
@@ -280,6 +292,10 @@ class PFGeneralPref(PreferenceView):
         self.sFit.serviceFittingOptions["expandedMutantNames"] = self.cbExpMutants.GetValue()
         fitID = self.mainFrame.getActiveFit()
         wx.PostEvent(self.mainFrame, GE.FitChanged(fitIDs=(fitID,)))
+
+    def OnAppearanceChange(self, event):
+        self.themeSettings.set('appearance', self.appearanceChoices[event.GetInt()])
+        event.Skip()
 
     def OnAddLabelsChange(self, event):
         self.sFit.serviceFittingOptions["additionsLabels"] = event.GetInt()

--- a/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaLoggingPreferences.py
@@ -40,7 +40,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.stLogPath, 0, wx.ALL, 5)
         self.inputLogPath = wx.TextCtrl(panel, wx.ID_ANY, config.logPath, wx.DefaultPosition, wx.DefaultSize, 0)
         self.inputLogPath.SetEditable(False)
-        self.inputLogPath.SetBackgroundColour((200, 200, 200))
+        self.inputLogPath.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
         mainSizer.Add(self.inputLogPath, 0, wx.ALL | wx.EXPAND, 5)
 
         import requests
@@ -49,7 +49,7 @@ class PFGeneralPref(PreferenceView):
         mainSizer.Add(self.certPath, 0, wx.ALL, 5)
         self.certPathCtrl = wx.TextCtrl(panel, wx.ID_ANY, requests.certs.where(), wx.DefaultPosition, wx.DefaultSize, 0)
         self.certPathCtrl.SetEditable(False)
-        self.certPathCtrl.SetBackgroundColour((200, 200, 200))
+        self.certPathCtrl.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
         mainSizer.Add(self.certPathCtrl, 0, wx.ALL | wx.EXPAND, 5)
 
         # Debug Logging

--- a/gui/builtinShipBrowser/pfBitmapButton.py
+++ b/gui/builtinShipBrowser/pfBitmapButton.py
@@ -5,7 +5,7 @@ from wx.lib.buttons import GenBitmapButton
 class PFGenBitmapButton(GenBitmapButton):
     def __init__(self, parent, id, bitmap, pos, size, style):
         GenBitmapButton.__init__(self, parent, id, bitmap, pos, size, style)
-        self.bgcolor = wx.Brush(wx.WHITE)
+        self.bgcolor = wx.Brush(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
     def SetBackgroundColour(self, color):
         self.bgcolor = wx.Brush(color)

--- a/gui/utils/dark.py
+++ b/gui/utils/dark.py
@@ -2,8 +2,6 @@ import wx
 
 
 def isDark():
-    if 'wxMSW' in wx.PlatformInfo:
-        return False
     try:
         return wx.SystemSettings.GetAppearance().IsDark()
     except (KeyboardInterrupt, SystemExit):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wxPython==4.2.1
+wxPython==4.3.0
 logbook==1.7.0.post0
 numpy==1.26.2
 matplotlib==3.8.2

--- a/service/settings.py
+++ b/service/settings.py
@@ -600,3 +600,36 @@ class LocaleSettings:
         if key == 'locale' and value not in self.supported_languages():
             self.settings[key] = self.DEFAULT
         self.settings[key] = value
+
+
+class ThemeSettings:
+    _instance = None
+
+    SYSTEM = "system"
+    LIGHT = "light"
+    DARK = "dark"
+    VALUES = (SYSTEM, LIGHT, DARK)
+
+    defaults = {
+        'appearance': SYSTEM,
+    }
+
+    def __init__(self):
+        self.settings = SettingsProvider.getInstance().getSettings('pyfaTheme', self.defaults)
+
+    @classmethod
+    def getInstance(cls):
+        if cls._instance is None:
+            cls._instance = ThemeSettings()
+        return cls._instance
+
+    def get(self, key):
+        value = self.settings[key]
+        if key == 'appearance' and value not in self.VALUES:
+            return self.defaults['appearance']
+        return value
+
+    def set(self, key, value):
+        if key == 'appearance' and value not in self.VALUES:
+            value = self.defaults['appearance']
+        self.settings[key] = value


### PR DESCRIPTION
## Summary
- Add a Preferences appearance setting (System / Light / Dark) and apply it at startup via `wx.App.SetAppearance`.
- Replace hardcoded light-gray/white control backgrounds with system colors so preference fields and ship-browser buttons follow the active theme.
- Allow dark-mode detection on Windows (`gui.utils.dark.isDark` no longer short-circuits on `wxMSW`).
- Bump wxPython from 4.2.1 to 4.3.0 so appearance APIs are available.
- Ignore the local `run.ps1` launcher so it is not committed.

## Test plan
- [ ] Start Pyfa on Windows and confirm it launches with the default System appearance.
- [ ] Preferences -> General: switch Appearance to Dark, restart, confirm the UI uses a dark theme.
- [ ] Switch to Light, restart, confirm a light theme.
- [ ] Check Database and Logging preference path fields, plus ship-browser bitmap buttons, for readable backgrounds in both themes.
- [ ] Confirm existing fittings and graphs still open after the wxPython 4.3.0 bump.